### PR TITLE
fix(runtime): three errors that were recorded as the domain saying no

### DIFF
--- a/lib/hecksagain/runtime/errors.rb
+++ b/lib/hecksagain/runtime/errors.rb
@@ -23,6 +23,16 @@ module Hecksagain
     # loaded, and recording the undelivered reaction rather than raising is the
     # design — spec/policy_spec states it in so many words, "records a reaction
     # it cannot deliver rather than swallowing it".
-    DOMAIN_REFUSALS = [GivenNotMet, LifecycleRefused, NotFound, TypeMismatch, UnknownVerb].freeze
+    # InvariantViolation belongs here and was missing. A value object refusing
+    # its own rule is the domain saying no as plainly as a given is — but the
+    # class is declared over in value.rb and never made the list, so the policy
+    # and saga interpreters, which rescue exactly these, would let it propagate
+    # as though the RUNTIME had broken. A reaction whose target violates an
+    # invariant is declined, not crashed. Found by spec/domain_refusal_spec on
+    # its first run : every corpus refusal must be a class named here, and 23
+    # of banking's were InvariantViolation.
+    DOMAIN_REFUSALS = [
+      GivenNotMet, InvariantViolation, LifecycleRefused, NotFound, TypeMismatch, UnknownVerb
+    ].freeze
   end
 end

--- a/lib/hecksagain/runtime/value.rb
+++ b/lib/hecksagain/runtime/value.rb
@@ -42,6 +42,7 @@ module Hecksagain
           completed[attribute.name] = attribute.default unless completed.key?(attribute.name) || attribute.default.nil?
         end
         admit_member(value_object, fields)
+        check_numeric_fields(value_object, fields)
         value_object.invariants.each do |invariant|
           next if Bluebook::Expression::Evaluator.call(invariant.canonical, fields)
 
@@ -50,6 +51,30 @@ module Hecksagain
                 "(given #{canonical_fields(fields)})"
         end
         new(value_object, fields)
+      end
+
+      # A field declared Integer or Float must ARRIVE as one.
+      #
+      # Without this a String sails into a numeric field and the failure surfaces
+      # later, inside a predicate, as `positive? expects a number, got "three"` —
+      # an EvaluationError, which is NOT a domain refusal. So the runtime broke
+      # where the domain should have said no, and the run contract recorded the
+      # crash beside genuine refusals as though the domain had judged it.
+      #
+      # Checked BEFORE invariants, because an invariant reading a mistyped field
+      # is exactly the thing that used to explode.
+      NUMERIC = { "Integer" => Integer, "Float" => Numeric }.freeze
+      private_class_method def self.check_numeric_fields(value_object, fields)
+        value_object.attributes.each do |attribute|
+          expected = NUMERIC[attribute.type.to_s]
+          next unless expected
+
+          given = fields[attribute.name]
+          next if given.nil? || given.is_a?(expected)
+
+          raise TypeMismatch,
+                "#{value_object.name}.#{attribute.name} expects #{attribute.type}, got #{given.inspect}"
+        end
       end
 
       def self.hydrate(aggregate, state)

--- a/rust/src/runtime/dispatcher.rs
+++ b/rust/src/runtime/dispatcher.rs
@@ -572,6 +572,26 @@ impl Runtime {
             .and_then(|q| q.as_object().cloned())
             .ok_or_else(|| format!("{} has no query {:?}", aggregate_name, query_name))?;
 
+        // A query's arguments are coerced against their declared types exactly as
+        // a command's are — mirrors Ruby's QueryInterpreter#normalize_args. Without
+        // this a query took whatever it was handed : Ruby refused
+        // `cents: "lots"` for a Money and Rust answered with an empty result set,
+        // agreeing about nothing. Reads enter through the aggregate, so they meet
+        // the same gate writes do.
+        let mut args = args.clone();
+        for attribute in array(&declared, "attributes") {
+            let Some(name) = attribute.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(given) = args.get(name).cloned() else {
+                continue;
+            };
+            let attribute = attribute.as_object().cloned().unwrap_or_default();
+            let coerced = coerce_attribute(&aggregate, &attribute, &given)?;
+            args.insert(name.to_string(), coerced);
+        }
+        let args = &args;
+
         let mut matched: Vec<(String, State)> = Vec::new();
         for (key, state) in self.all_records(&domain, &aggregate_name, &aggregate) {
             let holds = array(&declared, "wheres").iter().all(|clause| {

--- a/rust/src/runtime/mutations.rs
+++ b/rust/src/runtime/mutations.rs
@@ -148,6 +148,7 @@ pub fn coerce_attribute(
             }
         }
         admit_member(&value_object, &completed)?;
+        check_numeric_fields(&value_object, &completed)?;
         enforce_invariants(&value_object, &completed)?;
         return Ok(Value::Object(completed));
     }
@@ -396,6 +397,64 @@ fn build_element(
     }
 
     Ok(Value::Object(fields))
+}
+
+/// Mirrors Ruby's `Value.check_numeric_fields` (`lib/hecksagain/runtime/value.rb`).
+///
+/// A field declared Integer or Float must ARRIVE as one. Without this a string
+/// sails into a numeric field and the failure surfaces later, inside a
+/// predicate, as `positive? expects a number, got "three"` — which is not the
+/// domain refusing, it is the runtime breaking, and the run contract recorded
+/// it beside genuine refusals.
+///
+/// Checked BEFORE invariants, because an invariant reading a mistyped field is
+/// exactly what used to explode. The message is byte-identical to Ruby's.
+fn check_numeric_fields(
+    value_object: &Map<String, Value>,
+    fields: &Map<String, Value>,
+) -> Result<(), String> {
+    let vo_name = value_object
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    for attribute in array(value_object, "attributes") {
+        let Some(name) = attribute.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(type_name) = attribute.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        let numeric = match type_name {
+            "Integer" => true,
+            "Float" => true,
+            _ => continue,
+        };
+        let Some(given) = fields.get(name) else { continue };
+        if given.is_null() {
+            continue;
+        }
+        let ok = if type_name == "Integer" {
+            given.is_i64() || given.is_u64()
+        } else {
+            given.is_number()
+        };
+        if numeric && !ok {
+            return Err(format!(
+                "{vo_name}.{name} expects {type_name}, got {}",
+                render_scalar(given)
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Ruby's `#inspect` for the values a bluebook field can hold — a string gets
+/// quotes, a number does not. Parity compares these messages byte-for-byte.
+fn render_scalar(value: &Value) -> String {
+    match value {
+        Value::String(text) => format!("{text:?}"),
+        other => other.to_string(),
+    }
 }
 
 /// Mirrors Ruby's `Value.scalar` (`lib/hecksagain/runtime/value.rb:87`) at the

--- a/spec/command_rules_spec.rb
+++ b/spec/command_rules_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe "the rules a command obeys" do
       expect do
         runtime.dispatch("Banking::Account.LedgerEntry.Amend",
                          id: "a1", sequence: { value: 1 }, adjustment: { cents: "a lot", currency: "USD" }, narrative: narrative)
-      end.to raise_error(Hecksagain::Bluebook::Expression::EvaluationError,
-                         'addition expects a number, got "a lot"')
+      end.to raise_error(Hecksagain::Runtime::TypeMismatch,
+                         'Money.cents expects Integer, got "a lot"')
     end
 
     it "moves an element by exactly what it was told" do

--- a/spec/domain_refusal_spec.rb
+++ b/spec/domain_refusal_spec.rb
@@ -1,0 +1,71 @@
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+
+# A refusal is the domain saying NO. Anything else is the runtime breaking.
+#
+# `Runtime::DOMAIN_REFUSALS` declares that boundary, and the policy and saga
+# interpreters honour it — they rescue only those classes, so a crash in a
+# reaction propagates instead of being logged as "declined". The RUNNERS did
+# not: `bin/run` and the Rust CLI both catch everything a dispatch throws and
+# write it into `refusals`, so a crash arrives in the run contract wearing a
+# refusal's clothes.
+#
+# That is not hypothetical. Every one of these was recorded as a refusal:
+#
+#   positive? expects a number, got {"value":3}     the append flatten bug
+#   no implicit conversion of Symbol into Integer   an argument/attribute collision
+#   addition expects a number, got "a lot"          a String reaching a numeric field
+#
+# The last is fixed at the source — `Value.check_numeric_fields` now refuses it
+# as a TypeMismatch, which IS a domain refusal. This spec is what stops the
+# class from coming back: every error the corpus provokes must be one the
+# domain is allowed to raise.
+RSpec.describe "every refusal the corpus provokes" do
+  CORPUS = {
+    "banking" => "examples/banking",
+    "pizzas"  => "examples/pizzas"
+  }.freeze
+
+  def domain_refusal?(error)
+    Hecksagain::Runtime::DOMAIN_REFUSALS.any? { |klass| error.is_a?(klass) }
+  end
+
+  CORPUS.each do |name, path|
+    it "#{name} raises only errors the domain is allowed to raise" do
+      script = JSON.parse(File.read(File.join(InMemoryDomain::ROOT, "spec/parity/#{name}.json")))
+      Dir.mktmpdir do |tmp|
+        domain = File.join(tmp, name)
+        FileUtils.cp_r(File.join(InMemoryDomain::ROOT, path), domain)
+        FileUtils.rm_rf(File.join(domain, "data"))
+        runtime = Hecks.boot(domain)
+
+        faults = []
+        script.fetch("steps").each do |step|
+          args = (step["args"] || {}).transform_keys(&:to_sym)
+          begin
+            if (question = step["query"])
+              runtime.query(question, **args)
+            else
+              runtime.dispatch(step["verb"], **args)
+            end
+          rescue StandardError => e
+            faults << "#{step['verb'] || step['query']} raised #{e.class}: #{e.message}" unless domain_refusal?(e)
+          end
+        end
+
+        expect(faults).to be_empty
+      end
+    end
+  end
+
+  it "catches an error the domain is NOT allowed to raise" do
+    # The guard has to be seen refusing something, or it is one more rule that
+    # cannot fire. EvaluationError is the class the three leaks above wore.
+    error = Hecksagain::Bluebook::Expression::EvaluationError.new("a predicate blew up")
+    expect(domain_refusal?(error)).to be(false)
+    expect(domain_refusal?(Hecksagain::Runtime::TypeMismatch.new("a value was wrong"))).to be(true)
+  end
+end

--- a/spec/mutation_spec.rb
+++ b/spec/mutation_spec.rb
@@ -50,9 +50,12 @@ RSpec.describe "then_set arithmetic" do
     runtime.dispatch("TillRoom::Till.OpenTill", id: "till-1")
     runtime.dispatch("TillRoom::Till.TakeIn", id: "till-1", amount: { cents: 10_000 })
 
+    # Refused at the payload gate as a DOMAIN refusal, not deep in a predicate
+    # as an EvaluationError — the latter is not in DOMAIN_REFUSALS, so it used
+    # to be recorded beside genuine refusals while actually being a crash.
     expect { runtime.dispatch("TillRoom::Till.TakeIn", id: "till-1", amount: { cents: "lots" }) }
-      .to raise_error(Hecksagain::Bluebook::Expression::EvaluationError,
-                      /comparison of String with 0 failed/)
+      .to raise_error(Hecksagain::Runtime::TypeMismatch,
+                      'Money.cents expects Integer, got "lots"')
 
     expect(TillRoom::Till.find("till-1").balance.to_h).to eq(cents: 10_000)
   end


### PR DESCRIPTION
A refusal is the domain judging. Anything else is the runtime breaking. Both are
written to the same list in the run contract, so a crash arrived looking exactly
like a rule doing its job — and one of these was already in the corpus, agreed on
by both runtimes, green.

## 1. A declared field was never type-checked

`Value.build` filled defaults, admitted members and evaluated invariants — and never
checked a field against the type it declares. So a `String` sailed into an `Integer`
field and detonated later, inside a predicate:

```
EvaluationError: addition expects a number, got "a lot"
```

`EvaluationError` is not in `DOMAIN_REFUSALS`. The domain never refused anything; the
evaluator hit a value the gate should have stopped. Now it is stopped where it enters:

```
TypeMismatch: Money.cents expects Integer, got "a lot"
```

`check_numeric_fields` runs **before** invariants in both runtimes, because an invariant
reading a mistyped field is precisely what used to explode. Messages are byte-identical;
`render_scalar` mirrors Ruby's `#inspect`.

## 2. Rust never coerced query arguments at all

Fixing (1) split banking immediately. Ruby refused `cents: "lots"` on
`Account.Overdrawn`; Rust answered with an empty result set. Rust had only ever
normalised **command** args — so for as long as queries have been in the contract, the
two runtimes have been agreeing about nothing on that step.

Rust's `query` now coerces through the same `coerce_attribute` the command path uses.
Reads enter through the aggregate, so they meet the gate writes do.

## 3. `InvariantViolation` was not a domain refusal

Found by the new spec on its first run: **23 of banking's refusals are
`InvariantViolation`**, and the class is declared in `value.rb` and never made the list
in `errors.rb`.

A value object refusing its own rule is the domain saying no as plainly as a `given` is.
But `policy_interpreter` and `saga_interpreter` rescue exactly `DOMAIN_REFUSALS`, so a
reaction whose target violated an invariant would have propagated as though the runtime
had broken, instead of being recorded as declined.

## What keeps it fixed

`spec/domain_refusal_spec` replays every corpus script in-process and fails if any error
raised is not a class the domain is allowed to raise. It carries an example proving it
distinguishes `EvaluationError` from `TypeMismatch`, so it cannot quietly become one more
rule that never fires.

Two specs were pinning the leak as correct — both asserted the `EvaluationError` wording.
They now assert the refusal that arrives earlier.

## Still open, deliberately

`bin/run` and the Rust CLI both blanket-catch into `refusals`. Splitting `faults` out
changes the run-contract shape, and Rust returns `Err(String)` with no error classes, so
it cannot classify without carrying a kind through dispatch. This PR closes the hole at
the source; making the **contract** distinguish them is a change to both runners and
wants deciding separately.

## Verification

```
rspec        365 examples, 0 failures
cargo test   177 passed, 0 warnings
bin/parity   AGREED — banking 100/192 · pizzas 5/17 · grammar 27/37
```
