### PR TITLE
fix(runtime): a reference must point at something that exists

### DIFF
--- a/lib/hecksagain/runtime/command_interpreter.rb
+++ b/lib/hecksagain/runtime/command_interpreter.rb
@@ -12,6 +12,7 @@ module Hecksagain
 
       def call(domain, aggregate, command, args)
         args       = normalize_args(aggregate, command, args)
+        resolve_references(domain, aggregate, command, args)
         repository = @registry.repository(domain, aggregate)
         instance   = hydrate(repository, aggregate, command, args)
 
@@ -38,6 +39,55 @@ module Hecksagain
                raise(NotFound, "#{command.name} acts on an existing #{aggregate.name} — pass #{aggregate.identified_by}:")
           repository.find(id) || raise(NotFound, "no #{aggregate.name} with #{aggregate.identified_by} #{id.inspect}")
         end
+      end
+
+      # A reference must point at something that EXISTS.
+      #
+      # `reference_to Customer` is the one guarantee an aggregate reference is
+      # for, and it was declared 14 times across banking and enforced nowhere :
+      # an Account could belong to a customer who was never registered, in both
+      # runtimes, and parity stayed green because both were equally permissive
+      # and no corpus step ever passed a dangling reference.
+      #
+      # Resolved here rather than in coercion because coercion is pure — it
+      # holds no repository. A reference INTO ANOTHER DOMAIN is left alone : a
+      # cross-domain target may legitimately not be loaded, which is the same
+      # reading `across` policies already get.
+      def resolve_references(domain, aggregate, command, args)
+        command.attributes.each do |attribute|
+          next unless attribute.reference?
+          next unless args.key?(attribute.name)
+
+          held = args[attribute.name]
+          next if held.nil?
+
+          target = referenced_aggregate(domain, attribute)
+          next unless target
+
+          key = reference_identity(held)
+          next if key.to_s.empty?
+          next if @registry.repository(domain, target).find(key)
+
+          raise NotFound,
+                "no #{target.name} with #{target.identified_by || :id} #{key.inspect}"
+        end
+      end
+
+      def referenced_aggregate(domain, attribute)
+        name = attribute.type.to_s[/\AReference<(.+)>\z/, 1]
+        return nil unless name
+
+        @registry.bluebook(domain)&.aggregates&.find { |candidate| candidate.name == name }
+      end
+
+      def reference_identity(held)
+        case held
+        when Value then Value.scalar(held).to_s
+        when Hash  then held.values.first.to_s
+        else held.to_s
+        end
+      rescue TypeMismatch
+        nil
       end
 
       def reference_key(command)

--- a/rust/src/runtime/dispatcher.rs
+++ b/rust/src/runtime/dispatcher.rs
@@ -401,6 +401,7 @@ impl Runtime {
             .and_then(|c| c.as_object().cloned())
             .ok_or_else(|| format!("{} has no command {:?}", entity_name, command_name))?;
         let normalized_args = normalize_command_args(&aggregate, &command, args)?;
+        self.resolve_references(domain, &command, &normalized_args)?;
         let args = &normalized_args;
 
         let identity = aggregate
@@ -797,6 +798,70 @@ impl Runtime {
             .collect()
     }
 
+    /// A reference must point at something that EXISTS.
+    ///
+    /// Mirrors Ruby's `CommandInterpreter#resolve_references`. `reference_to
+    /// Customer` is the one guarantee an aggregate reference is for, and it was
+    /// declared 14 times across banking and enforced in neither runtime — an
+    /// Account could belong to a customer who was never registered, and parity
+    /// stayed green because both sides were equally permissive.
+    ///
+    /// Checked here, not in coercion, because coercion holds no store. A
+    /// reference INTO ANOTHER DOMAIN is left alone : the target may legitimately
+    /// not be loaded, the same reading `across` policies already get.
+    fn resolve_references(
+        &mut self,
+        domain: &str,
+        command: &Map<String, Value>,
+        args: &State,
+    ) -> Result<(), String> {
+        for attribute in array(command, "attributes") {
+            let Some(name) = attribute.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(type_name) = attribute.get("type").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(target_name) = type_name
+                .strip_prefix("Reference<")
+                .and_then(|rest| rest.strip_suffix('>'))
+            else {
+                continue;
+            };
+            let Some(held) = args.get(name) else { continue };
+            if held.is_null() {
+                continue;
+            }
+            let Ok(target) = self.find_aggregate(domain, target_name, name) else {
+                continue;
+            };
+            let key = match held {
+                Value::Object(fields) if fields.len() == 1 => fields
+                    .values()
+                    .next()
+                    .map(query_text)
+                    .unwrap_or_default(),
+                other => query_text(other),
+            };
+            if key.is_empty() {
+                continue;
+            }
+            let identity = target
+                .get("identified_by")
+                .and_then(Value::as_str)
+                .unwrap_or("id")
+                .to_string();
+            let found = self
+                .all_records(domain, target_name, &target)
+                .into_iter()
+                .any(|(id, _)| id == key);
+            if !found {
+                return Err(format!("no {target_name} with {identity} {key:?}"));
+            }
+        }
+        Ok(())
+    }
+
     pub fn dispatch(&mut self, verb: &str, args: &State) -> Result<State, String> {
         let (domain, aggregate_name, command_name) = parse_verb(verb)?;
         if command_name.contains('.') {
@@ -806,6 +871,7 @@ impl Runtime {
         let command = find_command(&aggregate, &command_name)
             .ok_or_else(|| format!("{} has no command {:?}", aggregate_name, command_name))?;
         let normalized_args = normalize_command_args(&aggregate, &command, args)?;
+        self.resolve_references(&domain, &command, &normalized_args)?;
         let args = &normalized_args;
 
         let identity = aggregate

--- a/spec/banking_state_machine_spec.rb
+++ b/spec/banking_state_machine_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe "Banking's generated account machine" do
   it "preserves the account balance invariant across deterministic command traces" do
     20.times do |seed|
       runtime = boot_banking
+      runtime.dispatch("Banking::Customer.Register", reference: { value: "c" },
+                       name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
       runtime.dispatch("Banking::Account.Open", id: "a#{seed}", customer_id: { value: "c" }, number: { value: "ACC-#{seed}" },
                                                 kind: { name: "current" }, daily_limit: { cents: 1_000 })
       model = 0

--- a/spec/command_rules_spec.rb
+++ b/spec/command_rules_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "the rules a command obeys" do
   def boot_till    = boot(RULES_TILL)
 
   def funded_account(runtime)
+    runtime.dispatch("Banking::Customer.Register", reference: { value: "c" },
+                     name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
     runtime.dispatch("Banking::Account.Open", id: "a1", customer_id: { value: "c" }, number: { value: "ACC-1" },
                                               kind: { name: "current" }, daily_limit: { cents: 50_000 })
     runtime.dispatch("Banking::Account.Credit", id: "a1", amount: { cents: 10_000, currency: "USD" }, narrative: { text: "Opening" })
@@ -111,8 +113,16 @@ RSpec.describe "the rules a command obeys" do
 
     it "does not settle a transfer until its destination credit is recorded" do
       runtime = boot_banking
+      runtime.dispatch("Banking::Customer.Register", reference: { value: "c-src" },
+                       name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
+      runtime.dispatch("Banking::Account.Open", id: "src", customer_id: { value: "c-src" },
+                       number: { value: "ACC-src" }, kind: { name: "current" }, daily_limit: { cents: 50_000 })
+      runtime.dispatch("Banking::Customer.Register", reference: { value: "c-dst" },
+                       name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
+      runtime.dispatch("Banking::Account.Open", id: "dst", customer_id: { value: "c-dst" },
+                       number: { value: "ACC-dst" }, kind: { name: "current" }, daily_limit: { cents: 50_000 })
       runtime.dispatch("Banking::Transfer.Request",
-                       id: "x1", source: { value: "missing-source" }, destination: { value: "missing-destination" },
+                       id: "x1", source: { value: "src" }, destination: { value: "dst" },
                        amount: { cents: 100 }, narrative: { text: "A transfer waiting for credit" })
       runtime.dispatch("Banking::Transfer.Debited", transfer: "x1")
 
@@ -124,8 +134,16 @@ RSpec.describe "the rules a command obeys" do
 
     it "refuses duplicate and out-of-order transfer legs without changing their state" do
       runtime = boot_banking
+      runtime.dispatch("Banking::Customer.Register", reference: { value: "c-src" },
+                       name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
+      runtime.dispatch("Banking::Account.Open", id: "src", customer_id: { value: "c-src" },
+                       number: { value: "ACC-src" }, kind: { name: "current" }, daily_limit: { cents: 50_000 })
+      runtime.dispatch("Banking::Customer.Register", reference: { value: "c-dst" },
+                       name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
+      runtime.dispatch("Banking::Account.Open", id: "dst", customer_id: { value: "c-dst" },
+                       number: { value: "ACC-dst" }, kind: { name: "current" }, daily_limit: { cents: 50_000 })
       runtime.dispatch("Banking::Transfer.Request",
-                       id: "x1", source: { value: "missing-source" }, destination: { value: "missing-destination" },
+                       id: "x1", source: { value: "src" }, destination: { value: "dst" },
                        amount: { cents: 100 }, narrative: { text: "An ordered transfer" })
 
       expect { runtime.dispatch("Banking::Transfer.Settle", transfer: "x1") }

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "an entity" do
   end
 
   def funded_account(runtime)
+    runtime.dispatch("Banking::Customer.Register", reference: { value: "c" },
+                     name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
     runtime.dispatch("Banking::Account.Open", id: "a1", customer_id: { value: "c" }, number: { value: "ACC-1" },
                                               kind: { name: "current" }, daily_limit: { cents: 50_000 })
     runtime.dispatch("Banking::Account.Credit", id: "a1", amount: { cents: 10_000, currency: "USD" }, narrative: { text: "Opening" })
@@ -37,6 +39,8 @@ RSpec.describe "an entity" do
 
   it "validates a nested value object before appending an entity" do
     runtime = boot_banking
+    runtime.dispatch("Banking::Customer.Register", reference: { value: "c" },
+                     name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
     runtime.dispatch("Banking::Account.Open", id: "a1", customer_id: { value: "c" }, number: { value: "ACC-1" },
                                               kind: { name: "current" }, daily_limit: { cents: 50_000 })
 

--- a/spec/one_of_spec.rb
+++ b/spec/one_of_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe "one_of" do
     runtime = boot_banking
 
     expect do
+      runtime.dispatch("Banking::Customer.Register", reference: { value: "c" },
+                       name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
       runtime.dispatch("Banking::Account.Open", id: "a1", customer_id: { value: "c" }, number: { value: "ACC-1" },
                                                 kind: { name: "savings" }, daily_limit: { cents: 10_000 })
     end.not_to raise_error
@@ -32,6 +34,8 @@ RSpec.describe "one_of" do
     runtime = boot_banking
 
     expect do
+      runtime.dispatch("Banking::Customer.Register", reference: { value: "c" },
+                       name: { given: "A", family: "Customer" }, email: { address: "a@example.com" })
       runtime.dispatch("Banking::Account.Open", id: "a1", customer_id: { value: "c" }, number: { value: "ACC-1" },
                                                 kind: { name: "gold" }, daily_limit: { cents: 10_000 })
     end.to raise_error(Hecksagain::Runtime::InvariantViolation,

--- a/spec/parity/banking.json
+++ b/spec/parity/banking.json
@@ -394,8 +394,7 @@
     },
     {
       "query": "Banking::Transfer.InFlight",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::Transfer.Reverse",
@@ -464,8 +463,7 @@
     },
     {
       "query": "Banking::Customer.Suspended",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::Customer.Reinstate",
@@ -633,8 +631,7 @@
     },
     {
       "query": "Banking::Account.Open",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::Account.Overdrawn",
@@ -647,23 +644,19 @@
     },
     {
       "query": "Banking::Customer.InGoodStanding",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::Customer.Suspended",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::Transfer.InFlight",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::Account.LedgerEntry.Reversed",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::Customer.Close",
@@ -903,18 +896,15 @@
     },
     {
       "query": "Banking::ATMCard.Active",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::ATMCard.ByFee",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::ATMCard.Withdrawal.Recent",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::ATMCard.Retire",
@@ -926,8 +916,7 @@
     },
     {
       "query": "Banking::ATMCard.Active",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::Customer.Register",
@@ -1484,8 +1473,7 @@
     },
     {
       "query": "Banking::Transfer.InFlight",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::Transfer.Reject",
@@ -1513,15 +1501,14 @@
     },
     {
       "query": "Banking::Transfer.InFlight",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::Transfer.Request",
       "args": {
         "id": "xfer-5",
         "source": {
-          "value": "acct-ghost"
+          "value": "acct-8"
         },
         "destination": {
           "value": "acct-7"
@@ -1530,7 +1517,7 @@
           "cents": 100
         },
         "narrative": {
-          "text": "Out of an account that never existed"
+          "text": "A transfer between two accounts that exist"
         }
       }
     },
@@ -1544,6 +1531,24 @@
       "verb": "Banking::Transfer.Reject",
       "args": {
         "id": "xfer-5"
+      }
+    },
+    {
+      "verb": "Banking::Transfer.Request",
+      "args": {
+        "id": "xfer-ghost",
+        "source": {
+          "value": "acct-8"
+        },
+        "destination": {
+          "value": "acct-nowhere"
+        },
+        "amount": {
+          "cents": 100
+        },
+        "narrative": {
+          "text": "A transfer to an account that was never opened"
+        }
       }
     },
     {
@@ -1699,33 +1704,27 @@
     },
     {
       "query": "Banking::Account.Overdrawn",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::Account.Open",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::Customer.InGoodStanding",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::ATMCard.Active",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::ATMCard.ByFee",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::Transfer.InFlight",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::Account.ApplyFee",
@@ -1952,13 +1951,11 @@
     },
     {
       "query": "Banking::CardPayment.Pending",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking::CardPayment.Disputed",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::ExternalTransfer.Request",
@@ -2043,8 +2040,7 @@
     },
     {
       "query": "Banking::ExternalTransfer.Sent",
-      "args": {
-      }
+      "args": {}
     },
     {
       "verb": "Banking::ScheduledPayment.Schedule",
@@ -2126,8 +2122,7 @@
     },
     {
       "query": "Banking::ScheduledPayment.Due",
-      "args": {
-      }
+      "args": {}
     },
     {
       "query": "Banking.customer_portfolio",

--- a/spec/saga_spec.rb
+++ b/spec/saga_spec.rb
@@ -131,6 +131,10 @@ RSpec.describe "a lifecycle" do
 
   it "addresses a record by its reference key, like every saga leg must" do
     runtime = boot_wire
+    # the drawers have to exist — a wire between accounts that were never
+    # opened is not a wire, and the runtime now says so
+    runtime.dispatch("Wire::Drawer.Open", id: "a")
+    runtime.dispatch("Wire::Drawer.Open", id: "b")
     runtime.dispatch("Wire::Wire.Ask", id: "w", amount: { cents: 1 }, source: { value: "a" }, destination: { value: "b" })
 
     expect { runtime.dispatch("Wire::Wire.Returned", wire: "missing") }


### PR DESCRIPTION
`reference_to Customer` is the one guarantee an aggregate reference is for. It was
declared **fourteen times** across banking and enforced in **neither runtime**:

```
Banking::Account.Open  customer_id: "NOBODY-AT-ALL"
  ruby → ACCEPTED, stored
  rust → ACCEPTED, AccountOpened emitted
```

An account could belong to a customer who was never registered. Parity stayed green
because both sides were equally permissive, and no corpus step had ever passed a
dangling reference — **the gate cannot see what never enters it.**

Now both refuse, in the same words:

```
no Customer with reference "NOBODY-AT-ALL"
```

## Where it lives

Resolved at dispatch, after argument normalisation, in both runtimes — not in coercion,
which is pure and holds no store. A reference **into another domain** is left alone: the
target may legitimately not be loaded, the same reading `across` policies already get.

## What it exposed in the specs

**Seventeen examples were relying on the missing enforcement** — opening accounts with
`customer_id: { value: "c" }` and never registering customer `"c"`. Fixtures taking the
shortcut the rule now forbids; each registers its customer.

Two in `command_rules_spec` used literal `"missing-source"` placeholders to exercise
transfer state transitions. A transfer between accounts that were never opened is not a
transfer, so those examples now open the accounts they move money between.

## What it exposed in the corpus — the part worth reading

Step 125 requested `xfer-5` from `"acct-ghost"`, an account nothing opens. **It
succeeded**, so the corpus held a transfer out of an account that never existed. Worse,
steps 126–127 exercise `Transfer.Reverse` and `Transfer.Reject` on `xfer-5` — against a
transfer whose source was a ghost. Enforcement made those two refuse outright, which is
how the hole surfaced.

Pointing the transfer at `acct-8` restores what 126–127 were always written to test.
(`acct-5` and `acct-6` are themselves deliberate refusal steps — which is exactly what
made the ghost easy to miss.)

**Banking now runs 103 events where it ran 100.** The corpus gained three, because a
transfer that had been silently discarded now completes and its saga runs.

A new step pins the rule: `xfer-ghost`, a transfer to `"acct-nowhere"`, refused
byte-identically on both sides.

## Verification

```
rspec        365 examples, 0 failures
cargo test   177 passed, 0 warnings
bin/parity   AGREED — banking 103/193 · pizzas 5/17 · grammar 27/37
```
