### PR TITLE
refactor: every file requires what it references

### DIFF
--- a/lib/hecksagain/adapters/driven/heki.rb
+++ b/lib/hecksagain/adapters/driven/heki.rb
@@ -2,6 +2,9 @@ require "json"
 require "fileutils"
 require_relative "heki/snapshot"
 require_relative "heki/journal"
+require_relative "../../ports/persistence/append_only"
+require_relative "../../ports/query/in_memory"
+require_relative "../../runtime/instance"
 
 module Hecksagain
   module Adapters

--- a/lib/hecksagain/adapters/driven/heki/journal.rb
+++ b/lib/hecksagain/adapters/driven/heki/journal.rb
@@ -1,3 +1,5 @@
+require_relative "../../../ports/persistence/append_only"
+
 module Hecksagain
   module Adapters
     class Heki

--- a/lib/hecksagain/adapters/driven/memory.rb
+++ b/lib/hecksagain/adapters/driven/memory.rb
@@ -1,3 +1,7 @@
+require_relative "../../ports/persistence/append_only"
+require_relative "../../ports/query/in_memory"
+require_relative "../../runtime/instance"
+
 module Hecksagain
   module Adapters
     class Memory

--- a/lib/hecksagain/adapters/driven/postgres.rb
+++ b/lib/hecksagain/adapters/driven/postgres.rb
@@ -4,6 +4,10 @@ require "json"
 require_relative "sql_query_builder"
 require_relative "postgres/lineage"
 require_relative "postgres/lineage_manager"
+require_relative "../../ports/persistence/append_only"
+require_relative "../../runtime/event"
+require_relative "../../runtime/instance"
+require_relative "../../runtime/registry"
 
 module Hecksagain
   module Adapters

--- a/lib/hecksagain/adapters/driven/postgres/lineage.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage.rb
@@ -7,6 +7,7 @@ require_relative "lineage/mint_transaction"
 require_relative "lineage/tail_merge"
 require_relative "lineage/head_compiler"
 require_relative "lineage/transform_installer"
+require_relative "../../../naming"
 
 module Hecksagain
   module Adapters

--- a/lib/hecksagain/adapters/driven/postgres/lineage/era_store.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage/era_store.rb
@@ -1,3 +1,7 @@
+require_relative "../../../../ports/persistence/era_tamper"
+require_relative "../../../../runtime/registry"
+require_relative "../../../../runtime/storage_shape"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/postgres/lineage/head_compiler.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage/head_compiler.rb
@@ -1,3 +1,5 @@
+require_relative "../../../../naming"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/postgres/lineage/mint_transaction.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage/mint_transaction.rb
@@ -1,3 +1,6 @@
+require_relative "../../../../runtime/registry"
+require_relative "../../../../runtime/storage_shape"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/postgres/lineage/tail_merge.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage/tail_merge.rb
@@ -1,3 +1,5 @@
+require_relative "../../../../runtime/registry"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/postgres/lineage_manager.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage_manager.rb
@@ -4,6 +4,8 @@ require_relative "lineage_manager/era_resolver"
 require_relative "lineage_manager/minter"
 require_relative "lineage_manager/merge_coordinator"
 require_relative "lineage_manager/coverage_check"
+require_relative "../../../runtime/era_guard"
+require_relative "../../../runtime/registry"
 
 module Hecksagain
   module Adapters

--- a/lib/hecksagain/adapters/driven/postgres/lineage_manager/coverage_check.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage_manager/coverage_check.rb
@@ -1,3 +1,9 @@
+require_relative "../../../../ports/persistence/lineage"
+require_relative "../../../../runtime/era_guard"
+require_relative "../../../../runtime/identity"
+require_relative "../../../../runtime/registry"
+require_relative "../../../../translation/audit"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/postgres/lineage_manager/era_resolver.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage_manager/era_resolver.rb
@@ -1,3 +1,6 @@
+require_relative "../lineage"
+require_relative "../../../../runtime/storage_shape"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/postgres/lineage_manager/merge_coordinator.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage_manager/merge_coordinator.rb
@@ -1,3 +1,7 @@
+require_relative "../lineage"
+require_relative "../../../../runtime/registry"
+require_relative "../../../../translation/audit"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/postgres/lineage_manager/minter.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage_manager/minter.rb
@@ -1,3 +1,8 @@
+require_relative "../../../../runtime/registry"
+require_relative "../../../../runtime/storage_shape"
+require_relative "../../../../translation/audit"
+require_relative "../../../../translation/scaffold"
+
 module Hecksagain
   module Adapters
     class Postgres

--- a/lib/hecksagain/adapters/driven/prism.rb
+++ b/lib/hecksagain/adapters/driven/prism.rb
@@ -1,4 +1,5 @@
 require "prism"
+require_relative "../../bluebook/expression/canonical_form"
 
 module Hecksagain
   module Adapters

--- a/lib/hecksagain/adapters/driven/sql_query_builder.rb
+++ b/lib/hecksagain/adapters/driven/sql_query_builder.rb
@@ -1,3 +1,7 @@
+require_relative "../../query_specification/common/null_policy"
+require_relative "../../runtime/errors"
+require_relative "../../runtime/value"
+
 module Hecksagain
   module Adapters
     # The one SQL query compilation, shared by the SQLite and Postgres

--- a/lib/hecksagain/adapters/driven/sqlite.rb
+++ b/lib/hecksagain/adapters/driven/sqlite.rb
@@ -5,6 +5,10 @@ require "fileutils"
 require_relative "sql_query_builder"
 require_relative "sqlite/schema_builder"
 require_relative "sqlite/codec"
+require_relative "../../ports/persistence/append_only"
+require_relative "../../query_specification/common/null_policy"
+require_relative "../../runtime/event"
+require_relative "../../runtime/instance"
 
 module Hecksagain
   module Adapters

--- a/lib/hecksagain/adapters/driven/sqlite/codec.rb
+++ b/lib/hecksagain/adapters/driven/sqlite/codec.rb
@@ -1,3 +1,5 @@
+require_relative "../../../runtime/value"
+
 module Hecksagain
   module Adapters
     class Sqlite

--- a/lib/hecksagain/adapters/driven/sqlite/projection.rb
+++ b/lib/hecksagain/adapters/driven/sqlite/projection.rb
@@ -1,3 +1,11 @@
+require_relative "../../../runtime/instance"
+require_relative "../../../runtime/value"
+
+# The subclass needs its parent — and sqlite.rb requires this file at
+# its BOTTOM, after class Sqlite is defined, so the require cycle this
+# creates resolves correctly from either entry point.
+require_relative "../sqlite"
+
 module Hecksagain
   module Adapters
     # Rebuilds a read store from the authoritative journal, entry by entry.

--- a/lib/hecksagain/bluebook.rb
+++ b/lib/hecksagain/bluebook.rb
@@ -16,6 +16,12 @@ module Hecksagain
   end
 end
 
+# What the chapter's own files lean on at class-body level (`extend
+# Construct`, the assembly's QuerySpecification marks) — required here
+# because those files' contents are frozen and cannot say so themselves.
+require_relative "construct"
+require_relative "query_specification"
+
 require_relative "bluebook/expression"
 require_relative "bluebook/ir"
 

--- a/lib/hecksagain/bluebook/dsl.rb
+++ b/lib/hecksagain/bluebook/dsl.rb
@@ -9,6 +9,13 @@ module Hecksagain
   end
 end
 
+# The query/read-model builders reach QuerySpecification at class-body
+# level and cannot say so themselves (contents frozen) — the namespace
+# file says it for them. The builders also build IR, at build time.
+require_relative "../construct"
+require_relative "../query_specification"
+require_relative "ir"
+
 require_relative "dsl/malformed"
 require_relative "dsl/const_shim"
 require_relative "dsl/attribute_collector"

--- a/lib/hecksagain/bluebook/ir.rb
+++ b/lib/hecksagain/bluebook/ir.rb
@@ -9,6 +9,12 @@ module Hecksagain
   end
 end
 
+# Every declaration file extends Construct at class body — and Query
+# subclasses QuerySpecification's Options there too. They cannot say so
+# themselves (contents frozen) — the namespace file says it for them.
+require_relative "../construct"
+require_relative "../query_specification"
+
 require_relative "ir/reference"
 require_relative "ir/attribute"
 require_relative "ir/value_object"

--- a/lib/hecksagain/facade/handle.rb
+++ b/lib/hecksagain/facade/handle.rb
@@ -1,3 +1,5 @@
+require_relative "../naming"
+
 module Hecksagain
   module Facade
     # ONE record in hand — the object `Pizza.create_pizza(...)` and

--- a/lib/hecksagain/facade/surface/aggregate_door.rb
+++ b/lib/hecksagain/facade/surface/aggregate_door.rb
@@ -1,3 +1,8 @@
+require_relative "../../bluebook/dsl/hecksagon_builder"
+require_relative "../../bluebook/ir/hexagon"
+require_relative "../handle"
+require_relative "../../naming"
+
 module Hecksagain
   module Facade
     module Surface

--- a/lib/hecksagain/facade/surface/chapter.rb
+++ b/lib/hecksagain/facade/surface/chapter.rb
@@ -1,3 +1,6 @@
+require_relative "../../bluebook/dsl/binding_proxy"
+require_relative "../../bluebook/dsl/hecksagon_builder"
+
 module Hecksagain
   module Facade
     module Surface

--- a/lib/hecksagain/fuzzing/sequence_generator/outcome_tracker.rb
+++ b/lib/hecksagain/fuzzing/sequence_generator/outcome_tracker.rb
@@ -1,3 +1,5 @@
+require_relative "../value_generator"
+
 module Hecksagain
   module Fuzzing
     class SequenceGenerator

--- a/lib/hecksagain/fuzzing/sequence_generator/step_builder.rb
+++ b/lib/hecksagain/fuzzing/sequence_generator/step_builder.rb
@@ -1,3 +1,8 @@
+require_relative "../../bluebook/expression/resolver"
+require_relative "../invalid_value_generator"
+require_relative "../value_generator"
+require_relative "../../runtime/errors"
+
 module Hecksagain
   module Fuzzing
     class SequenceGenerator

--- a/lib/hecksagain/ports/extraction.rb
+++ b/lib/hecksagain/ports/extraction.rb
@@ -1,3 +1,5 @@
+require_relative "../runtime/registry"
+
 module Hecksagain
   module Ports
     module Extraction

--- a/lib/hecksagain/ports/loading.rb
+++ b/lib/hecksagain/ports/loading.rb
@@ -1,3 +1,5 @@
+require_relative "../adapters/driven/folder"
+
 module Hecksagain
   module Ports
     module Loading

--- a/lib/hecksagain/ports/persistence/append_only.rb
+++ b/lib/hecksagain/ports/persistence/append_only.rb
@@ -1,3 +1,5 @@
+require_relative "../../runtime/registry"
+
 module Hecksagain
   module Ports
     module Persistence

--- a/lib/hecksagain/ports/persistence/binding_policy.rb
+++ b/lib/hecksagain/ports/persistence/binding_policy.rb
@@ -1,3 +1,6 @@
+require_relative "../../bluebook/ir/hexagon"
+require_relative "../../runtime/registry"
+
 module Hecksagain
   module Ports
     module Persistence

--- a/lib/hecksagain/ports/persistence/era_tamper.rb
+++ b/lib/hecksagain/ports/persistence/era_tamper.rb
@@ -1,5 +1,7 @@
 require "json"
 require "tempfile"
+require_relative "../../runtime/era_guard"
+require_relative "../../runtime/storage_shape"
 
 module Hecksagain
   module Ports

--- a/lib/hecksagain/ports/persistence/lineage.rb
+++ b/lib/hecksagain/ports/persistence/lineage.rb
@@ -1,3 +1,7 @@
+require_relative "../../naming"
+require_relative "append_only"
+require_relative "../../runtime/registry"
+
 module Hecksagain
   module Ports
     module Persistence

--- a/lib/hecksagain/ports/persistence/repository_factory.rb
+++ b/lib/hecksagain/ports/persistence/repository_factory.rb
@@ -1,3 +1,5 @@
+require_relative "append_only"
+
 module Hecksagain
   module Ports
     module Persistence

--- a/lib/hecksagain/ports/projection.rb
+++ b/lib/hecksagain/ports/projection.rb
@@ -1,3 +1,7 @@
+require_relative "persistence"
+require_relative "persistence/repository_factory"
+require_relative "../runtime/registry"
+
 module Hecksagain
   module Ports
     # Projection is a read-side port. Its stores are rebuildable consumers of

--- a/lib/hecksagain/ports/query/in_memory.rb
+++ b/lib/hecksagain/ports/query/in_memory.rb
@@ -1,3 +1,6 @@
+require_relative "ordering"
+require_relative "../../runtime/value"
+
 module Hecksagain
   module Ports
     module Query

--- a/lib/hecksagain/ports/query/ordering.rb
+++ b/lib/hecksagain/ports/query/ordering.rb
@@ -1,3 +1,5 @@
+require_relative "../../query_specification/common/null_policy"
+
 module Hecksagain
   module Ports
     module Query

--- a/lib/hecksagain/query_specification/common/dsl.rb
+++ b/lib/hecksagain/query_specification/common/dsl.rb
@@ -1,3 +1,16 @@
+require_relative "authorization_spec"
+require_relative "comparators"
+require_relative "consistency_spec"
+require_relative "cursor_spec"
+require_relative "freshness_spec"
+require_relative "index_hint"
+require_relative "inspection_spec"
+require_relative "limit_spec"
+require_relative "null_semantics"
+require_relative "offset_spec"
+require_relative "order_by"
+require_relative "where_clause"
+
 module Hecksagain
   module QuerySpecification
     module Common

--- a/lib/hecksagain/query_specification/common/options.rb
+++ b/lib/hecksagain/query_specification/common/options.rb
@@ -1,3 +1,5 @@
+require_relative "null_semantics"
+
 module Hecksagain
   module QuerySpecification
     module Common

--- a/lib/hecksagain/query_specification/read_model/specification.rb
+++ b/lib/hecksagain/query_specification/read_model/specification.rb
@@ -1,3 +1,5 @@
+require_relative "../common/options"
+
 module Hecksagain
   module QuerySpecification
     module ReadModel

--- a/lib/hecksagain/router/namespace_installer.rb
+++ b/lib/hecksagain/router/namespace_installer.rb
@@ -1,3 +1,5 @@
+require_relative "../fqn"
+
 module Hecksagain
   class Router
     # Installs optional Ruby syntax over an already-loaded router. FQN

--- a/lib/hecksagain/runtime/command_interpreter.rb
+++ b/lib/hecksagain/runtime/command_interpreter.rb
@@ -1,6 +1,10 @@
 require_relative "interpreting"
 require_relative "command_interpreter/argument_gate"
 require_relative "command_interpreter/mutation_applier"
+require_relative "../rendering"
+require_relative "errors"
+require_relative "identity"
+require_relative "instance"
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/command_interpreter/argument_gate.rb
+++ b/lib/hecksagain/runtime/command_interpreter/argument_gate.rb
@@ -1,3 +1,6 @@
+require_relative "../../naming"
+require_relative "../errors"
+
 module Hecksagain
   module Runtime
     class CommandInterpreter

--- a/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
+++ b/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
@@ -1,3 +1,5 @@
+require_relative "../value"
+
 module Hecksagain
   module Runtime
     class CommandInterpreter

--- a/lib/hecksagain/runtime/command_rules/admissibility.rb
+++ b/lib/hecksagain/runtime/command_rules/admissibility.rb
@@ -1,3 +1,7 @@
+require_relative "../../bluebook/expression/evaluator"
+require_relative "../../rendering"
+require_relative "../errors"
+
 module Hecksagain
   module Runtime
     class CommandRules

--- a/lib/hecksagain/runtime/command_rules/arithmetic.rb
+++ b/lib/hecksagain/runtime/command_rules/arithmetic.rb
@@ -1,3 +1,7 @@
+require_relative "../../rendering"
+require_relative "../errors"
+require_relative "../value"
+
 module Hecksagain
   module Runtime
     class CommandRules

--- a/lib/hecksagain/runtime/command_rules/emission.rb
+++ b/lib/hecksagain/runtime/command_rules/emission.rb
@@ -1,3 +1,5 @@
+require_relative "../event"
+
 module Hecksagain
   module Runtime
     class CommandRules

--- a/lib/hecksagain/runtime/command_rules/references.rb
+++ b/lib/hecksagain/runtime/command_rules/references.rb
@@ -1,3 +1,5 @@
+require_relative "../errors"
+
 module Hecksagain
   module Runtime
     class CommandRules

--- a/lib/hecksagain/runtime/dispatcher.rb
+++ b/lib/hecksagain/runtime/dispatcher.rb
@@ -6,6 +6,7 @@ require_relative "query_interpreter"
 require_relative "read_model_interpreter"
 require_relative "policy_interpreter"
 require_relative "saga_interpreter"
+require_relative "../naming"
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/entity_interpreter.rb
+++ b/lib/hecksagain/runtime/entity_interpreter.rb
@@ -1,4 +1,9 @@
 require_relative "interpreting"
+require_relative "../naming"
+require_relative "errors"
+require_relative "identity"
+require_relative "instance"
+require_relative "value"
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/era_check.rb
+++ b/lib/hecksagain/runtime/era_check.rb
@@ -1,3 +1,8 @@
+require_relative "../ports/persistence"
+require_relative "../ports/persistence/binding_policy"
+require_relative "../ports/persistence/lineage"
+require_relative "registry"
+
 module Hecksagain
   module Runtime
     # The boot-time era gate, run for the adapters that HAVE eras — the

--- a/lib/hecksagain/runtime/era_guard.rb
+++ b/lib/hecksagain/runtime/era_guard.rb
@@ -1,5 +1,9 @@
 require "fileutils"
 require_relative "era_guard/shape_diff"
+require_relative "../naming"
+require_relative "../ports/loading"
+require_relative "../ports/persistence/lineage"
+require_relative "registry"
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/errors.rb
+++ b/lib/hecksagain/runtime/errors.rb
@@ -1,3 +1,5 @@
+require_relative "value/invariant_violation"
+
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/identity.rb
+++ b/lib/hecksagain/runtime/identity.rb
@@ -1,3 +1,6 @@
+require_relative "../naming"
+require_relative "value"
+
 module Hecksagain
   module Runtime
     # THE SCALAR AN IDENTITY PATH NAMES.

--- a/lib/hecksagain/runtime/instance.rb
+++ b/lib/hecksagain/runtime/instance.rb
@@ -1,3 +1,5 @@
+require_relative "value"
+
 module Hecksagain
   module Runtime
     class Instance

--- a/lib/hecksagain/runtime/interpreting.rb
+++ b/lib/hecksagain/runtime/interpreting.rb
@@ -1,3 +1,5 @@
+require_relative "value"
+
 module Hecksagain
   module Runtime
     # What every stepwise interpreter shares: the traced step, and the

--- a/lib/hecksagain/runtime/loader.rb
+++ b/lib/hecksagain/runtime/loader.rb
@@ -1,3 +1,9 @@
+require_relative "../facade/surface"
+require_relative "../ports/loading"
+require_relative "dispatcher"
+require_relative "era_check"
+require_relative "registry"
+
 module Hecksagain
   module Runtime
     class Loader

--- a/lib/hecksagain/runtime/policy_interpreter.rb
+++ b/lib/hecksagain/runtime/policy_interpreter.rb
@@ -1,3 +1,6 @@
+require_relative "../naming"
+require_relative "errors"
+
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/query_interpreter.rb
+++ b/lib/hecksagain/runtime/query_interpreter.rb
@@ -1,3 +1,9 @@
+require_relative "../naming"
+require_relative "../ports/query"
+require_relative "../ports/query/ordering"
+require_relative "errors"
+require_relative "value"
+
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/read_model_interpreter.rb
+++ b/lib/hecksagain/runtime/read_model_interpreter.rb
@@ -1,3 +1,7 @@
+require_relative "../rendering"
+require_relative "errors"
+require_relative "value"
+
 module Hecksagain
   module Runtime
     class ReadModelInterpreter

--- a/lib/hecksagain/runtime/registry/verification.rb
+++ b/lib/hecksagain/runtime/registry/verification.rb
@@ -1,3 +1,5 @@
+require_relative "../../bluebook/ir/hexagon"
+
 module Hecksagain
   module Runtime
     class Registry

--- a/lib/hecksagain/runtime/saga_interpreter.rb
+++ b/lib/hecksagain/runtime/saga_interpreter.rb
@@ -1,4 +1,7 @@
 require_relative "saga_interpreter/correlation"
+require_relative "../bluebook/ir/process_manager"
+require_relative "errors"
+require_relative "value"
 
 module Hecksagain
   module Runtime

--- a/lib/hecksagain/runtime/saga_interpreter/correlation.rb
+++ b/lib/hecksagain/runtime/saga_interpreter/correlation.rb
@@ -1,3 +1,6 @@
+require_relative "../../naming"
+require_relative "../value"
+
 module Hecksagain
   module Runtime
     class SagaInterpreter

--- a/lib/hecksagain/runtime/value/admission.rb
+++ b/lib/hecksagain/runtime/value/admission.rb
@@ -1,3 +1,5 @@
+require_relative "invariant_violation"
+
 module Hecksagain
   module Runtime
     class Value

--- a/lib/hecksagain/runtime/value/coercion.rb
+++ b/lib/hecksagain/runtime/value/coercion.rb
@@ -1,3 +1,8 @@
+require_relative "../../bluebook/expression/evaluator"
+require_relative "../../rendering"
+require_relative "../errors"
+require_relative "invariant_violation"
+
 module Hecksagain
   module Runtime
     class Value

--- a/lib/hecksagain/translation/audit/approval_digest.rb
+++ b/lib/hecksagain/translation/audit/approval_digest.rb
@@ -1,4 +1,5 @@
 require "digest"
+require_relative "../../projector/exporter"
 
 module Hecksagain
   module Translation

--- a/lib/hecksagain/translation/audit/layer_one.rb
+++ b/lib/hecksagain/translation/audit/layer_one.rb
@@ -1,3 +1,7 @@
+require_relative "../../runtime/errors"
+require_relative "../../runtime/instance"
+require_relative "../../runtime/value/invariant_violation"
+
 module Hecksagain
   module Translation
     module Audit

--- a/lib/hecksagain/translation/audit/layer_two.rb
+++ b/lib/hecksagain/translation/audit/layer_two.rb
@@ -1,3 +1,6 @@
+require_relative "../../ports/persistence/append_only"
+require_relative "../../ports/persistence/lineage"
+
 module Hecksagain
   module Translation
     module Audit

--- a/lib/hecksagain/translation/reattest.rb
+++ b/lib/hecksagain/translation/reattest.rb
@@ -1,4 +1,7 @@
 require "tempfile"
+require_relative "../runtime/era_guard"
+require_relative "../runtime/registry"
+require_relative "../runtime/storage_shape"
 
 module Hecksagain
   module Translation

--- a/lib/hecksagain/translation/scaffold/differ.rb
+++ b/lib/hecksagain/translation/scaffold/differ.rb
@@ -1,3 +1,5 @@
+require_relative "../../runtime/storage_shape"
+
 module Hecksagain
   module Translation
     module Scaffold

--- a/spec/load_hygiene_spec.rb
+++ b/spec/load_hygiene_spec.rb
@@ -1,0 +1,74 @@
+require "open3"
+
+# The loading contract, made executable. Two facts hold across lib/:
+#
+#   1. Every file is SELF-SUFFICIENT — it requires what it references,
+#      so it loads standalone, first, in an empty process. Nothing may
+#      lean on some other file having loaded a dependency earlier.
+#   2. The subsystem wrappers' require order is CONVENIENCE, not load
+#      order — the whole framework loads with the wrappers reversed.
+#
+# Both used to be true only by accident of history: the flat require
+# list in lib/hecksagain.rb encoded the order files were added in, and
+# nothing would have named the moment a class-body constant reference
+# quietly made that order load-bearing again. Now this spec names it,
+# and the file it names is the one that grew the dependency.
+RSpec.describe "load hygiene" do
+  ROOT_DIR = File.expand_path("..", __dir__)
+  LIB = File.join(ROOT_DIR, "lib")
+
+  def load_in_subprocess(feature)
+    Open3.capture3("ruby", "-I", LIB, "-e", "require #{feature.inspect}")
+  end
+
+  # bluebook/** file contents are frozen by standing constraint, so a
+  # bluebook INTERNAL cannot grow the requires standalone loading needs
+  # (`extend Construct` at class body, contract.rb before contracts.rb).
+  # Their namespace files carry those requires instead — so the wrappers
+  # ARE held to the standard, and the internals are exempt.
+  BLUEBOOK_WRAPPERS = %w[
+    hecksagain/bluebook hecksagain/bluebook/ir hecksagain/bluebook/dsl
+    hecksagain/bluebook/expression
+  ].freeze
+
+  it "loads every lib file standalone, in a fresh process" do
+    features = Dir[File.join(LIB, "hecksagain", "**", "*.rb")]
+               .map { |file| file.sub("#{LIB}/", "").sub(/\.rb\z/, "") }
+               .reject { |f| f.start_with?("hecksagain/bluebook/") && !BLUEBOOK_WRAPPERS.include?(f) }
+               .sort
+
+    failures = Queue.new
+    work = Queue.new
+    features.each { |feature| work << feature }
+    8.times.map do
+      Thread.new do
+        until work.empty?
+          feature = begin
+            work.pop(true)
+          rescue ThreadError
+            break
+          end
+          _out, err, status = load_in_subprocess(feature)
+          failures << "#{feature}:\n#{err.lines.first(3).join}" unless status.success?
+        end
+      end
+    end.each(&:join)
+
+    broken = [].tap { |list| list << failures.pop until failures.empty? }
+    expect(broken).to be_empty,
+                      "these files no longer load standalone — each needs to require what it references:\n\n" \
+                      "#{broken.sort.join("\n")}"
+  end
+
+  it "loads the whole framework with the subsystem wrappers in reverse order" do
+    wrappers = File.read(File.join(LIB, "hecksagain.rb"))
+               .scan(%r{^require_relative "(hecksagain/[^"]+)"}).flatten
+
+    script = wrappers.reverse.map { |wrapper| "require #{wrapper.inspect}" }.join("; ")
+    _out, err, status = Open3.capture3("ruby", "-I", LIB, "-e", script)
+
+    expect(status.success?).to be(true),
+                               "reversing the wrapper order broke the load — an order-dependence " \
+                               "crept back in:\n#{err.lines.first(5).join}"
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #3. The flat require list encoded history, not dependency — files leaned on whatever happened to load before them. Now every file names its own dependencies, and a new spec makes the loading contract executable.

- **213 `require_relative` additions across 68 files**, derived mechanically: every constant reference resolved through its lexical nesting with Prism, mapped to its defining file (with the outside-file convention resolving "reopened in collaborators" ambiguity), then filtered so no file back-requires one whose existing require chain already reaches it — the parent-`extend`s-collaborator shape, one level removed, is a load-time NameError waiting for a reordering.
- **Two judgment calls**: `sqlite/projection.rb` takes the benign bottom-require cycle to reach its superclass from either entry point; the bluebook namespace files (`bluebook.rb`, `bluebook/ir.rb`, `bluebook/dsl.rb`) carry the requires their frozen children lean on at class-body level (`extend Construct`, the `QuerySpecification::Common::Options` superclass). **No bluebook internal changed content.**
- **`spec/load_hygiene_spec.rb`** enforces both facts forever: every non-frozen lib file loads standalone in a fresh subprocess (~3.5s, parallelized), and the whole framework loads with the subsystem wrappers in *reverse* order. The spec found real issues while being written — the sqlite projection gap and the bluebook `Construct`/`Options` leans were its first catches.

## Test plan
- [x] `bundle exec rspec` — 776 examples, 0 failures (774 + 2 new)
- [x] `bin/parity` — AGREED across all runtimes, era dance included
- [x] Pre-push hook re-ran parity on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cJcet8Ng4SdCSYhMkUnJL