### PR TITLE
feat(lang): the language evolution arc — LOP M1–M5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,23 @@
 # hecksagain
 
-Hecks, rewritten — with **Ruby as the source of truth**.
+A `.bluebook` file declares a business domain — aggregates, value objects,
+commands, invariants — and the runtime boots it. Nothing in a domain is
+scripted: `given` guards, `then_set` mutates, `emits` announces, and no
+handler body exists anywhere. That is the load-bearing choice everything else
+follows from: a domain that is entirely **data** can be diffed, stored,
+translated across versions, and projected into another language.
 
-## The thesis
-
-In Hecks the parser is authored twice: once as a Ruby DSL, once as a Rust
-parser, kept in step by a parity suite. Every drift retired over the last
-months was a disagreement between those two authors — never a routing
-disagreement, because routing was already data.
-
-hecksagain does not fix that by generating one runtime from the other. **Both
-runtimes are hand-written, and that is the design.** What changed is where
-authority lives: **Ruby holds the semantics**, and Rust is a second
-implementation held to Ruby's answers.
-
-So parity here is a claim about OUTPUT, not about origin — two authors reading
-the same source file must produce the same IR, the same behaviour, and the same
-stored records. `bin/parity` is what makes the claim real.
+Two runtimes read the same file. **Ruby holds the semantics.** Rust runs the
+same domains from a projection minted out of the language's own
+self-description — how far that projection reaches today, and what stays
+hand-written on purpose, is [its own section below](#the-rust-projection).
+`bin/parity` is what makes every claim in this file real:
 
 ```
   a .bluebook  →  Ruby runtime  ┐
                                 ├─→  must agree, or it is a SPLIT
   the same file →  Rust runtime ┘
 ```
-
-Neither runtime is handed the other's output. The IR is *extracted* from Ruby
-for inspection and diffing ; Ruby is never generated from it, and neither is
-Rust.
-
-> **A note on the word "projection."** An earlier framing called Rust a
-> projection of Ruby, with the interpreter as the one exception. It is not one:
-> nothing here generates the Rust parser, and no step in any build produces it.
-> It is written by hand, like the Ruby, and the two are kept together by
-> `bin/parity` comparing what they DO.
->
-> The word mattered because it described the wrong kind of safety. "Projection"
-> promises agreement BY CONSTRUCTION — one author, so nothing to drift. What
-> actually holds here is agreement BY CHECKING, which is a weaker promise and a
-> real one, and which is only as wide as the corpus. Every divergence this
-> project has found — `dims.length_cm`, the acronym snake rule, an aggregate
-> named `Order` — hid in exactly the gap between those two claims.
->
-> A related thing to know when reading this tree: parts of the Rust side were
-> cherry-picked from Hecks ahead of the Ruby here, so it can carry vocabulary
-> the Ruby has not yet grown. `has_many` / `has_one` / `belongs_to` were the
-> longest-standing example of this — the Rust parser read them, Hecks's Ruby
-> DSL had them, and hecksagain's Ruby did not, so a bluebook using one parsed
-> on one side only. Ruby has them now, as sugar over `reference_to`. Porting
-> them was also how two zero-tested Rust bugs surfaced: `has_one`/`belongs_to`
-> built two attributes where Ruby builds one, and every aggregate's attributes
-> were silently reordered relative to the source the moment a plain field was
-> declared before a reference — invisible because the whole corpus happens to
-> write references first. See `RESTART.md` for the rest. `subscribe`
-> (`.hecksagon`'s word, not a bluebook one) remains unported, by scope rather
-> than oversight.
 
 ## Try it
 
@@ -82,38 +46,60 @@ chain. Dispatch is plumbing; nobody writing a domain should ever type it. (No
 domain classes exist behind this: the door is a per-boot facade of modules
 closing over the dispatcher, and the IR is the only graph the runtime runs.)
 
-## Two runtimes, one answer
+For scripted runs, `bin/run <domain> <script.json>` executes a step list —
+commands and queries — and reports events, refusals, and rows. It is the same
+entry `bin/parity` drives.
 
-```sh
-bin/parity
-#   AGREED — ruby and rust returned the same answer for every step
+## Writing a bluebook
+
+```ruby
+Hecks.bluebook "TillRoom" do
+  vision "A till takes money in and gives money out, and the drawer count is arithmetic — never a guess."
+
+  aggregate "Till" do
+    identified_by { number.value }
+
+    attribute :number,  TillNumber
+    attribute :balance, Money, default: { cents: 0 }
+    attribute :marks,   list_of(Mark)
+
+    value_object "Money" do
+      attribute :cents, Integer
+      invariant("a cash amount is never negative") { cents >= 0 }
+    end
+
+    command "TakeIn" do
+      role "Clerk"
+      goal "Add cents to the drawer"
+
+      reference_to Till
+      attribute :amount, Money
+
+      then_set :balance, increment: :amount
+      then_set :marks,   append: { amount: :amount, direction: "in" }
+
+      emits "TakenIn"
+    end
+  end
+end
 ```
 
-Ruby parses the bluebook and exports an IR ; Rust currently reads that IR.
+Everything a command may do is one of a closed set of declared effects, and
+everything it may refuse is a named `given` or `invariant`. Refusals are not
+exceptions; they are half the language, and the parity harness runs every one
+of them — a runtime that ACCEPTS what the other refuses is the failure most
+worth catching.
 
-**That is a scaffold, not the destination.** Both runtimes should parse the
-native `.bluebook` format — and since a `.bluebook` file is already Ruby, the
-parseable subset and the evaluable subset turn out to be the same question. The
-JSON handover exists because it made semantic parity provable early, and it
-retires when the Rust parser lands.
-
-Two parsers is not the mistake. Two parsers whose agreement nobody CHECKS is.
-Both parsers here are authored by hand, so the whole burden falls on the
-harness — and the harness answers it by comparing what the runtimes DO, at
-three stages: the IR they read, the behaviour they run, and the records they
-write.
-
-The harness runs successes and every refusal path, because a runtime that
-ACCEPTS what the other refuses is the failure most worth catching. Only JSON
-key order is normalised before diffing (key order is not semantics); final
-state, event order, and refusal wording all have to match on their own.
+A required attribute missing from a payload is refused at the gate, before any
+effect resolves. Events are emitted last, after the state is persisted: an
+event is a promise that the state behind it survived.
 
 ## The expression sublanguage
 
 Everything in a command was already data except the predicate — and a `Proc`
-crosses no language boundary. So predicates are **extracted**, not closed over.
-Ruby 3.3 ships Prism, so the developer's actual source is parsed by Ruby's own
-parser and lowered to canonical text:
+crosses no language boundary. So predicates are **extracted**, not closed
+over. The developer's actual source is parsed by Prism, Ruby's own parser, and
+lowered to canonical text:
 
 ```ruby
 given("at most 10 toppings") { toppings.size < 10 }
@@ -122,8 +108,8 @@ given("at most 10 toppings") { toppings.size < 10 }
 ```
 
 The Ruby stays exactly as written. What changed is that it is now *read* as
-well as run — and **both runtimes evaluate the text**, because a Ruby running a
-closure while Rust runs text agrees only by luck.
+well as run — and **both runtimes evaluate the text**, because a Ruby running
+a closure while Rust runs text agrees only by luck.
 
 The admissible subset is conceived in
 [`lib/hecksagain/grammar/expression.bluebook`](lib/hecksagain/grammar/expression.bluebook)
@@ -138,27 +124,9 @@ Leaves are literals, dotted value-object paths, `.size`/`.length`,
 only once it reads in EVERY target — one with no Rust rendering is not a slow
 operator, it is not an operator. That sentence is checked, not aspired to:
 every operator the evaluator runs passes through the grammar chapter's own
-Admit gate on each suite run (`lib/hecksagain/grammar/expression_operators.json`,
-held by `spec/operator_conformance_spec.rb`).
-
-## Porting to a new language
-
-Adding a third implementation — or just maintaining these two — needs more than reading Ruby and
-Rust side by side and guessing at intent. `docs/porting/` collects what's otherwise scattered:
-
-- [`grammar.md`](docs/porting/grammar.md) — the expression sublanguage above, written out as a
-  formal precedence-ordered grammar instead of two pieces of regex to reverse-engineer.
-- [`conformance-kit.md`](docs/porting/conformance-kit.md) — precisely what `spec/golden/ir/*.json`
-  and `spec/parity/*.json` are, and what `bin/parity` actually checks (there is no per-step expected
-  value anywhere — it's a full-output diff, byte-exact past JSON key order).
-- [`behavior-notes.md`](docs/porting/behavior-notes.md) — the non-obvious behavioral rules this
-  project only learned by breaking, consolidated from comments scattered across both runtimes.
-- [`build-order.md`](docs/porting/build-order.md) — a staged path (parser → expressions → dispatch →
-  query → full corpus) with a checkpoint at each stage, since `bin/parity` alone gives no signal
-  until a new implementation is substantially complete.
-
-Persistence adapters are deliberately not covered — that's its own concern, separate from whether a
-bluebook runs correctly.
+Admit gate on each suite run
+(`lib/hecksagain/grammar/expression_operators.json`, held by
+`spec/operator_conformance_spec.rb`).
 
 ## The folder convention
 
@@ -177,13 +145,11 @@ Ports and adapters are **not** in there. They are the two halves of the
 inverted arrow, and each ships with the library beside its implementation:
 
 ```
-lib/hecksagain/ports/
-  persistence.port         the PORT — the how-verb and the signal
-lib/hecksagain/adapters/
-  sqlite.adapter           the DECLARATION — its port, and the config it needs
-  sqlite.rb                the IMPLEMENTATION — the same thing said in Ruby
-  memory.adapter
-  memory.rb
+lib/hecksagain/ports/            the PORT — the how-verb and the signal
+lib/hecksagain/adapters/driven/
+  sqlite.adapter                 the DECLARATION — its port, and the config it needs
+  sqlite.rb                      the IMPLEMENTATION — the same thing said in Ruby
+  memory.* heki.* postgres.* folder.* prism.*
 ```
 
 A declaration and its implementation are one thing described two ways, so they
@@ -193,53 +159,120 @@ library's load first, so a project's can only add, never silently replace.
 
 Fields belong to the **adapter**, not the port. Adapters implementing one port
 genuinely differ — Sqlite needs a `database`, Memory nothing at all — and the
-`.world` block is checked against what that adapter declares, so a value it does
-not know is refused at boot rather than ignored.
+`.world` block is checked against what that adapter declares, so a value it
+does not know is refused at boot rather than ignored. Persisted schemas are
+projected from the IR — one column per attribute, lists as JSON, never
+hand-written.
 
-Load order is dependency order, not alphabetical: ports declare the verb, an
-adapter declares a port, the hecksagon names both, the world supplies values.
+## Domain versions
+
+A domain's shape changes; its stored history doesn't get to. On Postgres a
+booted domain carries an **era**: the source text it was born from is held,
+drift between held text and booting text is refused, and a deliberate change
+ships with a translation — `rename`, `convert`, `drop`, `retype`, `retired`,
+and `compute` rules in a `translations/*.bluebook` file — that carries the old
+era's records into the new shape. `compute` is a raw SQL expression on
+purpose: evaluated inside Postgres, it never needs byte-identical logic in
+Ruby and Rust, which is this project's single most recurring bug class.
+
+Eras are a Postgres concern only. Memory, Sqlite, and Heki carry no era
+concept at all — a domain there boots the text it is handed.
 
 ## The library
 
 ```
 lib/hecksagain/
-  bluebook/     dsl → ir → expression.  WHAT A BLUEBOOK IS.
+  language/     the language, declared in its own bluebooks.  WHAT A BLUEBOOK IS.
+  grammar/      the expression and translation sublanguages, and the Admit gate.
+  bluebook/     dsl → ir → expression.  READING ONE.
   runtime/      dispatch, instances, the registry.  RUNNING IT.
-  adapters/     sqlite, memory.
-  projector/    the IR exporter, and whatever targets follow.  SENDING IT ELSEWHERE.
+  adapters/     driven: memory, sqlite, heki, postgres, folder, prism.
+  translation/  domain-version translation — eras and lineage.
+  projector/    IR export and the Rust projection.  SENDING IT ELSEWHERE.
 ```
 
 The split follows the dependency direction rather than the topic. The
-expression evaluator is in `bluebook/` and not `projector/` because the Ruby
-runtime evaluates every given and every invariant through it — it is the
-semantic core, and Rust is merely the first thing to read it.
+expression evaluator is in the semantic core and not `projector/` because the
+Ruby runtime evaluates every given and every invariant through it — Rust is
+merely the first other thing to read it.
 
-## The shape
+## The Rust projection
 
-- **An aggregate IS the port**, and the hexagon wires it by name —
-  `Pizzas::Pizza.persisted_by("Sqlite")` reads as a method call and records a
-  bind, whether it lands on the installed door or on the load-time proxy.
-- **A family names a how-verb**, a signal, and config field *names*. It never
-  names its adapters — the adapter declares the family, so a new backend is
-  purely additive.
-- **A bind resolves only if the adapter's family carries the verb**, checked for
-  every bind at boot.
-- **Commands are declared, never scripted.** `given` guards, `then_set`
-  mutates, `emits` announces. No handler body exists anywhere — which is what
-  makes the same declaration projectable.
-- **Events are emitted last**, after the state is persisted. An event is a
-  promise that the state behind it survived.
-- **The SQLite schema is projected from the IR** — one column per attribute,
-  lists as JSON, never hand-written.
+The language describes itself:
+[`lib/hecksagain/language/bluebook/`](lib/hecksagain/language/bluebook)
+declares what an aggregate, a command, a transition ARE, in bluebooks. The
+Rust IR is generated from that self-description — `bin/ir_structs` and
+`bin/ir_vocabulary` emit the typed structs and the closed sets they sit in,
+and specs hold the checked-in Rust byte-equal to its generators.
+`crate::ir::Aggregate` is not a port of a Ruby class; it is the language's own
+declaration, rendered in Rust.
+
+`bin/ir_rust` takes the next rung: a whole domain, projected as Rust
+**values** of those structs and compiled into the binary. `Runtime::boot`
+prefers a projection to a parse, and a projected chapter boots with no file at
+all. Every projection is sealed to its source by SHA — a projection that no
+longer matches its source refuses to stand in for it, because name-only lookup
+once booted stale after an edit.
+
+The distinction this project cares about is agreement **by construction** (one
+author, nothing to drift) versus agreement **by checking** (two authors, a
+harness, and a corpus exactly as wide as its coverage). The generated structs
+and projected domains are by-construction; everything else is still
+by-checking — and `bin/parity` stays the gate either way, diffing what the two
+runtimes DO at three stages: the IR they read, the behaviour they run, and the
+records they write. Successes and every refusal path, byte-exact past JSON key
+order.
+
+What is not projected, and why:
+
+- **The dispatcher still reads the flattened JSON IR in most places.** The
+  typed domain is in the runtime now and readers move over one at a time —
+  moving them blind would leave two sources of truth mid-flight. The
+  flattening is where the recurring bug class lives (a typed `Vec<String>`
+  read back with `as_str` returns None on an array, silently, and compiles),
+  which is the whole reason the projection exists.
+- **The expression evaluator is hand-written in both runtimes.** The language
+  can declare what an expression is; it cannot declare how to evaluate one.
+- **Era minting stays Ruby-only, and the reference transform stays
+  hand-written in both runtimes, by policy** — independence of authorship is
+  the point. Generating one from the other would put correlated error exactly
+  where identity is created.
+
+The path to a third target is a ratchet, not a port: hand-write a runtime in
+the new language **from the `.bluebook` files** — never from the Ruby or Rust,
+since an implementation ported from reading Ruby inherits Ruby's misreadings —
+drive it parity-complete, and only then specialize it, diffing the projected
+output against the hand-written, parity-complete artifact: a golden file at
+the scale of a whole runtime.
+
+`docs/porting/` is the kit for that first step:
+
+- [`grammar.md`](docs/porting/grammar.md) — the expression sublanguage as a
+  formal precedence-ordered grammar.
+- [`conformance-kit.md`](docs/porting/conformance-kit.md) — what
+  `spec/golden/ir/*.json` and `spec/parity/*.json` are, and what `bin/parity`
+  actually checks (no per-step expected values anywhere — a full-output diff).
+- [`behavior-notes.md`](docs/porting/behavior-notes.md) — the non-obvious
+  behavioral rules this project only learned by breaking.
+- [`build-order.md`](docs/porting/build-order.md) — a staged path (parser →
+  expressions → dispatch → query → full corpus) with a checkpoint at each
+  stage, since `bin/parity` alone gives no signal until an implementation is
+  substantially complete.
 
 ## Verify
 
 ```sh
-rspec                  # 41 examples — the Ruby side
-(cd rust && cargo test)  # the Rust half of the sublanguage contract
-bin/parity             # the two runtimes agree
+rspec                    # the Ruby side
+(cd rust && cargo test)  # the Rust side
+bin/parity               # the two runtimes agree
 ```
 
-Every Rust interpreter test has a named Ruby twin. The sublanguage is specified
-once and implemented twice, so each implementation needs its own tests or the
-second is only believed rather than known.
+`bin/parity` always rebuilds the Rust workspace first — a compiled artifact is
+never trusted to match the source tree. It expects a local Postgres for the
+era gates (`postgres://localhost/hecks_parity` by convention;
+`HECKS_PARITY_POSTGRES` overrides the URL, and an unset variable does not skip
+the gate — skipping-on-unset once let a broken era dance exit 0 twice).
+
+Every Rust interpreter test has a named Ruby twin. The sublanguage is
+specified once and implemented twice, so each implementation needs its own
+tests or the second is only believed rather than known.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ and bounded by what the interpreter floor can evaluate:
 Leaves are literals, dotted value-object paths, `.size`/`.length`,
 `.positive?`/`.negative?`/`.zero?`, and `.modulo(n)`. An operator is admitted
 only once it reads in EVERY target — one with no Rust rendering is not a slow
-operator, it is not an operator.
+operator, it is not an operator. That sentence is checked, not aspired to:
+every operator the evaluator runs passes through the grammar chapter's own
+Admit gate on each suite run (`lib/hecksagain/grammar/expression_operators.json`,
+held by `spec/operator_conformance_spec.rb`).
 
 ## Porting to a new language
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ Ruby and Rust, which is this project's single most recurring bug class.
 Eras are a Postgres concern only. Memory, Sqlite, and Heki carry no era
 concept at all — a domain there boots the text it is handed.
 
+## Language versions
+
+The language applies the same discipline to itself. Every word of the
+bluebook surface carries a lifecycle in `syntax.bluebook` — proposed,
+admitted, deprecated, retired — and a proposed or retired word reaches no
+projected parser table: to a projected reader it does not exist. A renamed
+word keeps its old spelling in `was:`, and the old spelling parses forever
+in both runtimes (`sets` is the word; `then_set` is the era the whole
+corpus was written under, and the corpus still boots). The chapter declares
+its own version, and `bin/evolve` walks a change through the stations —
+snapshot, rewrite, regenerate, gate, restore-on-red.
+
 ## The library
 
 ```

--- a/bin/evolve
+++ b/bin/evolve
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+
+# The language-change convention, made executable. Adding a word to the
+# bluebook surface has always been a many-file walk — syntax row, Ruby
+# builder, Rust parser arm, regenerated projections, moved golden — held
+# together by memory and review. This tool walks it, in the lifecycle
+# the syntax table now carries:
+#
+#   bin/evolve status                             where every word stands
+#   bin/evolve propose <word> --context Aggregate  a row enters, proposed
+#   bin/evolve admit   <word> --context Aggregate  proposed -> admitted
+#   bin/evolve deprecate <word> --context X        admitted -> deprecated
+#   bin/evolve retire  <word> --context X          deprecated/admitted -> retired
+#
+# Every mutating command does the same dance: snapshot the touched
+# files, rewrite the row, regenerate what the row feeds (the three
+# syntax projections and the golden Bluebook.json), then run the gates —
+# syntax conformance, the lifecycle spec, the export freshness specs.
+# Green: the change stands, and the tool prints what remains by hand
+# (a proposed word still needs its builder and its Rust arm before
+# admission will hold). Red: every file is restored byte-for-byte and
+# the failures print as the checklist they are. The tool never leaves a
+# tree the suite has not accepted.
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "hecksagain/grammar/evolve"
+
+ROOT = File.expand_path("..", __dir__)
+
+SNAPSHOT_PATHS = [
+  "lib/hecksagain/language/bluebook/syntax.bluebook",
+  "spec/golden/ir/Bluebook.json",
+  "rust/src/bluebook/ir_syntax.rs",
+  "rust/src/bluebook/ir_syntax_flags.rs",
+  "rust/src/bluebook/ir_dispatch_words.rs"
+].map { |rel| File.join(ROOT, rel) }.freeze
+
+GATES = %w[
+  spec/syntax_conformance_spec.rb
+  spec/syntax_lifecycle_spec.rb
+  spec/ir_syntax_export_spec.rb
+  spec/ir_syntax_flags_export_spec.rb
+  spec/ir_dispatch_words_export_spec.rb
+  spec/ir_golden_spec.rb
+].freeze
+
+Evolve = Hecksagain::Grammar::Evolve
+
+def option(name, default = nil)
+  index = ARGV.index("--#{name}")
+  index ? ARGV[index + 1] : default
+end
+
+def regenerate!
+  { "bin/ir_syntax"         => "rust/src/bluebook/ir_syntax.rs",
+    "bin/ir_syntax_flags"   => "rust/src/bluebook/ir_syntax_flags.rs",
+    "bin/ir_dispatch_words" => "rust/src/bluebook/ir_dispatch_words.rs" }.each do |script, target|
+    output = `#{File.join(ROOT, script)}`
+    abort "#{script} refused — nothing was written" unless $?.success?
+    File.write(File.join(ROOT, target), output)
+  end
+  system({ "GOLDEN" => "rewrite" },
+         "bundle", "exec", "rspec", "spec/ir_golden_spec.rb",
+         chdir: ROOT, out: File::NULL, err: File::NULL)
+end
+
+def gates_pass?
+  system("bundle", "exec", "rspec", *GATES, chdir: ROOT)
+end
+
+def guarded(word, context)
+  snapshots = SNAPSHOT_PATHS.to_h { |path| [path, File.read(path)] }
+  yield
+  regenerate!
+  if gates_pass?
+    puts "\n#{context}.#{word} — the gates hold. Regenerated projections and the golden are in the tree."
+    true
+  else
+    snapshots.each { |path, content| File.write(path, content) }
+    puts "\nRESTORED — the gates refused, and the failures above are the checklist. " \
+         "Nothing was changed."
+    false
+  end
+end
+
+command = ARGV.shift
+
+case command
+when "status"
+  rows = Evolve.keyword_rows
+  moving = rows.reject { |row| row[:status] == "admitted" }
+  puts "#{rows.size} keyword rows; #{moving.size} not simply admitted"
+  moving.each { |row| puts "  #{row[:status].ljust(10)} #{row[:context]}.#{row[:word]}" }
+when "propose"
+  word = ARGV.shift or abort "propose what word?"
+  context = option("context") or abort "--context is required — a word is a word somewhere"
+  ok = guarded(word, context) do
+    Evolve.propose(word: word, context: context,
+                   body: option("body", "none"), inner: option("inner", ""),
+                   opens: option("opens", ""), fills: option("fills", ""))
+  end
+  if ok
+    puts "Proposed. It reaches no projection until admitted. Before `bin/evolve admit`:"
+    puts "  1. teach the #{context} builder the word (and its spec/dsl_spec example)"
+    puts "  2. teach rust/src/bluebook/parser.rs the same word"
+    puts "  3. run bin/parity"
+  end
+when "admit", "deprecate", "retire"
+  to = { "admit" => "admitted", "deprecate" => "deprecated", "retire" => "retired" }.fetch(command)
+  word = ARGV.shift or abort "#{command} what word?"
+  context = option("context") or abort "--context is required"
+  guarded(word, context) { Evolve.set_status(word: word, context: context, to: to) }
+else
+  abort "usage: bin/evolve status|propose|admit|deprecate|retire <word> --context <Context> " \
+        "[--body none|keywords|source|rows] [--inner X] [--opens X] [--fills x]"
+end

--- a/bin/evolve
+++ b/bin/evolve
@@ -89,8 +89,10 @@ case command
 when "status"
   rows = Evolve.keyword_rows
   moving = rows.reject { |row| row[:status] == "admitted" }
-  puts "#{rows.size} keyword rows; #{moving.size} not simply admitted"
+  renamed = rows.reject { |row| row[:was].to_s.empty? }
+  puts "#{rows.size} keyword rows; #{moving.size} not simply admitted; #{renamed.size} renamed"
   moving.each { |row| puts "  #{row[:status].ljust(10)} #{row[:context]}.#{row[:word]}" }
+  renamed.each { |row| puts "  renamed    #{row[:context]}.#{row[:word]} (was #{row[:was]})" }
 when "propose"
   word = ARGV.shift or abort "propose what word?"
   context = option("context") or abort "--context is required — a word is a word somewhere"
@@ -110,6 +112,17 @@ when "admit", "deprecate", "retire"
   word = ARGV.shift or abort "#{command} what word?"
   context = option("context") or abort "--context is required"
   guarded(word, context) { Evolve.set_status(word: word, context: context, to: to) }
+when "rename"
+  word = ARGV.shift or abort "rename what word?"
+  context = option("context") or abort "--context is required"
+  to = option("to") or abort "--to is required — a rename goes somewhere"
+  ok = guarded(word, context) { Evolve.rename(word: word, context: context, to: to) }
+  if ok
+    puts "Renamed. The old spelling keeps parsing — that is the point. Before this holds:"
+    puts "  1. alias the new word to the old in the #{context} builder (alias_method :#{to}, :#{word})"
+    puts "  2. teach rust/src/bluebook the new spelling beside the old"
+    puts "  3. add the identical-IR example to spec/dsl_spec.rb, then run bin/parity"
+  end
 else
   abort "usage: bin/evolve status|propose|admit|deprecate|retire <word> --context <Context> " \
         "[--body none|keywords|source|rows] [--inner X] [--opens X] [--fills x]"

--- a/bin/expression_projection
+++ b/bin/expression_projection
@@ -16,13 +16,16 @@
 # the checked-in table, derives the fresh one from the DOMAIN (never
 # from what it just read), and replaces the file atomically.
 #
-# IF THE CHECKED-IN FILE IS EVER BROKEN, `git restore` it — this script
-# cannot rebuild from a projection that no longer parses the chapter's
-# own guards. Which is a fact about the LANGUAGE, found the hard way:
-# the chapter's `status != "retired"` givens evaluate through the very
-# operator table being projected, so a projection missing `!=` cannot
-# even boot the chapter to fix itself. A word the language's own
-# self-description uses is load-bearing and cannot simply be retired.
+# TWO GUARDS STAND WHERE THE WEDGE WAS FOUND. The chapter's own
+# `status != "retired"` givens evaluate through the very operator table
+# being projected — a projection missing a SELF-BEARING operator cannot
+# even boot the chapter to fix itself. So: (1) this script refuses to
+# WRITE a projection whose admitted set drops an operator the language's
+# own predicates evaluate through (Grammar.self_bearing_operators names
+# each one with a usage site); and (2) `--bootstrap` rebuilds the
+# projection from the LEDGER alone, before the framework loads — so a
+# projection that is already broken is repaired by the tool, not by git
+# archaeology.
 #
 # Operators carry the vocabulary's comparison algebra through the same
 # join bin/operators makes (the domain owns WHICH and IN WHAT ORDER;
@@ -34,6 +37,56 @@
 
 require "json"
 require "tempfile"
+
+TARGET = File.expand_path("../lib/hecksagain/bluebook/expression/projection.json", __dir__)
+
+def write_atomically(content)
+  Tempfile.create("projection", File.dirname(TARGET)) do |tmp|
+    tmp.write(content)
+    tmp.flush
+    File.rename(tmp.path, TARGET)
+  end
+end
+
+# STAGE ZERO, BEFORE THE FRAMEWORK — the framework cannot load while the
+# projection is broken, so this path must not load it. The ledger holds
+# which operators exist and in what order; the algebra comes from the
+# OTHER runtime's checked-in stage zero (rust operators.json), the two
+# being held equal whenever the suite runs. Rebuild, then run this
+# script again WITHOUT --bootstrap so the domain-derived fixpoint
+# confirms the repair.
+if ARGV.include?("--bootstrap")
+  root   = File.expand_path("..", __dir__)
+  ledger = JSON.parse(File.read(File.join(root, "lib/hecksagain/grammar/expression_operators.json")))
+  algebra = JSON.parse(File.read(File.join(root, "rust/src/bluebook/expression/operators.json")))
+                .to_h { |row| [row.fetch("symbol"), row] }
+
+  operators = []
+  normalisations = []
+  ledger.fetch("steps").each do |step|
+    args = step.fetch("args")
+    case step.fetch("verb")
+    when "Expression::Operator.Propose"
+      row = { symbol: args.dig("symbol", "value"), category: args.dig("category", "value"),
+              precedence: args.dig("precedence", "value"), arity: args.dig("arity", "value") }
+      if row[:category] == "comparison"
+        declared = algebra.fetch(row[:symbol])
+        row.merge!(compares_less_than: declared.fetch("compares_less_than"),
+                   compares_equal: declared.fetch("compares_equal"), negated: declared.fetch("negated"))
+      end
+      operators << row
+    when "Expression::Normalisation.Propose"
+      normalisations << { strategy: args.dig("strategy", "value"), source_token: args.dig("source_token", "value"),
+                          replacement: args.dig("replacement", "value"), boundary: args.dig("boundary", "value"),
+                          position: args.dig("position", "value") }
+    end
+  end
+
+  write_atomically(JSON.pretty_generate(operators: operators, normalisations: normalisations) + "\n")
+  puts "bootstrapped #{TARGET} from the ledger — now run bin/expression_projection to confirm the fixpoint"
+  exit
+end
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "hecksagain"
 require "hecksagain/grammar"
@@ -57,6 +110,19 @@ operators = Hecksagain::Grammar.admitted_operators(dispatcher).map do |op|
             compares_equal: declared[:compares_equal], negated: declared[:negated])
 end
 
+# THE SELF-BEARING REFUSAL — see the header. A projection that drops an
+# operator the language's own predicates evaluate through would wedge
+# every future boot; refuse to write it, naming each operator and where
+# the language stands on it.
+admitted = operators.map { |row| row[:symbol] }
+stranded = Hecksagain::Grammar.self_bearing_operators.reject { |symbol, _| admitted.include?(symbol) }
+unless stranded.empty?
+  abort stranded.map { |symbol, sites|
+    "#{symbol} is self-bearing — the language's own predicates evaluate through it " \
+    "(#{sites.first(3).join('; ')}) — rewrite those guards before retiring it"
+  }.join("\n")
+end
+
 content = JSON.pretty_generate(
   operators: operators,
   normalisations: Hecksagain::Grammar.admitted_normalisations(dispatcher)
@@ -65,11 +131,6 @@ content = JSON.pretty_generate(
 if ARGV.include?("--stdout")
   print content
 else
-  target = File.expand_path("../lib/hecksagain/bluebook/expression/projection.json", __dir__)
-  Tempfile.create("projection", File.dirname(target)) do |tmp|
-    tmp.write(content)
-    tmp.flush
-    File.rename(tmp.path, target)
-  end
-  puts "wrote #{target}"
+  write_atomically(content)
+  puts "wrote #{TARGET}"
 end

--- a/bin/expression_projection
+++ b/bin/expression_projection
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+
+# The Ruby side of what bin/operators is for Rust: the expression
+# machinery's tables, projected from the grammar chapter's admitted set
+# and checked in, so the evaluator and the canonical form READ the
+# domain rather than restating it. Regenerate with:
+#
+#   bin/expression_projection            # rewrites the file in place
+#   bin/expression_projection --stdout   # prints instead (the spec's diff mode)
+#
+# WRITES ITS OWN FILE, NEVER `>` — this generator's output IS the file
+# the framework reads at require time, and a shell redirection truncates
+# that file before Ruby ever boots: the empty file kills the require and
+# the run dies with nothing written. Measured, not assumed — the first
+# regeneration attempt did exactly that. So the default mode boots off
+# the checked-in table, derives the fresh one from the DOMAIN (never
+# from what it just read), and replaces the file atomically.
+#
+# IF THE CHECKED-IN FILE IS EVER BROKEN, `git restore` it — this script
+# cannot rebuild from a projection that no longer parses the chapter's
+# own guards. Which is a fact about the LANGUAGE, found the hard way:
+# the chapter's `status != "retired"` givens evaluate through the very
+# operator table being projected, so a projection missing `!=` cannot
+# even boot the chapter to fix itself. A word the language's own
+# self-description uses is load-bearing and cannot simply be retired.
+#
+# Operators carry the vocabulary's comparison algebra through the same
+# join bin/operators makes (the domain owns WHICH and IN WHAT ORDER;
+# Vocabulary::Comparison owns WHAT IT COMPUTES); normalisations are the
+# admitted rules in position order. spec/operators_export_spec.rb holds
+# the checked-in file equal to this script's --stdout output; the
+# machinery refuses to load without the file, which is the point — a
+# table nobody regenerates is a table the Admit gates never saw.
+
+require "json"
+require "tempfile"
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "hecksagain"
+require "hecksagain/grammar"
+
+dispatcher = Hecksagain::Grammar.expression
+
+judged     = Hecksagain::Bluebook::MetaValidator.grammar_registry.bluebook("Bluebook")
+vocabulary = judged.aggregates.find { |a| a.name == "Vocabulary" }
+algebra    = vocabulary.value_objects.find { |vo| vo.hecks_name == "Comparison" }
+                       .members.to_h { |row| [row.to_h.values.first, row.to_h] }
+
+operators = Hecksagain::Grammar.admitted_operators(dispatcher).map do |op|
+  row = { symbol: op[:symbol], category: op[:category],
+          precedence: op[:precedence], arity: op[:arity] }
+  next row unless op[:category] == "comparison"
+
+  declared = algebra.fetch(op[:symbol]) do
+    abort "#{op[:symbol]} is admitted but Vocabulary::Comparison declares no algebra for it"
+  end
+  row.merge(compares_less_than: declared[:compares_less_than],
+            compares_equal: declared[:compares_equal], negated: declared[:negated])
+end
+
+content = JSON.pretty_generate(
+  operators: operators,
+  normalisations: Hecksagain::Grammar.admitted_normalisations(dispatcher)
+) + "\n"
+
+if ARGV.include?("--stdout")
+  print content
+else
+  target = File.expand_path("../lib/hecksagain/bluebook/expression/projection.json", __dir__)
+  Tempfile.create("projection", File.dirname(target)) do |tmp|
+    tmp.write(content)
+    tmp.flush
+    File.rename(tmp.path, target)
+  end
+  puts "wrote #{target}"
+end

--- a/bin/ir_dispatch_words
+++ b/bin/ir_dispatch_words
@@ -66,6 +66,9 @@ def table_name(context) = "#{Hecksagain::Naming.snake(context).upcase}_WORDS"
 def words_for(keyword, context)
   rows = keyword.members
                 .map(&:to_h)
+                # A proposed or retired word reaches no projected table — to a
+                # projected reader it does not exist. Deprecated still reads.
+                .reject { |row| %w[proposed retired].include?(row[:status].to_s) }
                 .select { |row| row.fetch(:context) == context && !row.fetch(:opens).to_s.empty? }
                 .uniq { |row| row.fetch(:word) }
                 .sort_by { |row| row.fetch(:word) }

--- a/bin/ir_dispatch_words
+++ b/bin/ir_dispatch_words
@@ -70,6 +70,9 @@ def words_for(keyword, context)
                 # projected reader it does not exist. Deprecated still reads.
                 .reject { |row| %w[proposed retired].include?(row[:status].to_s) }
                 .select { |row| row.fetch(:context) == context && !row.fetch(:opens).to_s.empty? }
+                # A renamed word's OLD spelling stays recognized — the row
+                # carries it as `was:`, and both eras project.
+                .flat_map { |row| [row, row[:was].to_s.empty? ? nil : row.merge(word: row[:was])].compact }
                 .uniq { |row| row.fetch(:word) }
                 .sort_by { |row| row.fetch(:word) }
 

--- a/bin/ir_syntax
+++ b/bin/ir_syntax
@@ -58,7 +58,8 @@ words = keyword.members
                # projected reader it does not exist. Deprecated still reads.
                .reject { |row| %w[proposed retired].include?(row[:status].to_s) }
                .select { |row| row.fetch(:context) == "Aggregate" }
-               .map { |row| row.fetch(:word) }
+               # A renamed word's OLD spelling stays recognized — see `was:`.
+               .flat_map { |row| [row.fetch(:word), row[:was].to_s.empty? ? nil : row[:was]].compact }
                .uniq
                .sort
 

--- a/bin/ir_syntax
+++ b/bin/ir_syntax
@@ -54,6 +54,9 @@ keyword = syntax.value_object("Keyword") or raise "the language declares no Synt
 # this list from being consulted there.
 words = keyword.members
                .map(&:to_h)
+               # A proposed or retired word reaches no projected table — to a
+               # projected reader it does not exist. Deprecated still reads.
+               .reject { |row| %w[proposed retired].include?(row[:status].to_s) }
                .select { |row| row.fetch(:context) == "Aggregate" }
                .map { |row| row.fetch(:word) }
                .uniq

--- a/bin/ir_syntax_flags
+++ b/bin/ir_syntax_flags
@@ -44,6 +44,9 @@ argument = syntax.value_object("Argument") or raise "the language declares no Sy
 def flag_argument_names(argument)
   rows = argument.members
                  .map(&:to_h)
+                 # A proposed or retired argument reaches no projected table —
+                 # to a projected reader it does not exist. Deprecated reads.
+                 .reject { |row| %w[proposed retired].include?(row[:status].to_s) }
                  .select { |row| row.fetch(:kind) == "flag" }
                  .reject { |row| row.fetch(:named).to_s.empty? }
                  .uniq { |row| row.fetch(:named) }

--- a/bin/operators
+++ b/bin/operators
@@ -1,25 +1,46 @@
 #!/usr/bin/env ruby
 
 # Dumps the comparison-operator table both runtimes' `compare` reads instead
-# of hardcoding a six-way case statement. Ruby reads Evaluator::OPERATORS
-# directly ; Rust cannot run this file, so its copy is this script's output,
-# checked in at rust/src/bluebook/expression/operators.json and embedded at
-# compile time. Regenerate with:
+# of hardcoding a six-way case statement. Rust cannot run this file, so its
+# copy is this script's output, checked in at
+# rust/src/bluebook/expression/operators.json and embedded at compile time;
+# Ruby's copy is bin/expression_projection's output, read at require time.
+# Regenerate with:
 #
 #   bin/operators > rust/src/bluebook/expression/operators.json
 #
-# spec/vocabulary_conformance_spec.rb holds Evaluator::OPERATORS equal to
-# what the language declares (Vocabulary::Comparison) ; spec/operators_export_spec.rb
-# holds the checked-in JSON equal to this script's own output, so regenerate
-# it any time OPERATORS changes.
+# THE DOMAIN IS THE SOURCE. Which operators exist, and in what check order,
+# comes from the grammar chapter's own admitted set — the ledger replayed
+# through its Admit gates (Hecksagain::Grammar.admitted_operators). What each
+# operator COMPUTES — the less_than/equal/negated algebra — stays declared in
+# Vocabulary::Comparison, and this script is the join: the two declarations
+# own different halves of one operator, and the seam between them is held by
+# spec/operator_conformance_spec.rb's triangle. An admitted comparison the
+# vocabulary does not declare refuses here rather than emitting a row with
+# invented algebra.
+#
+# spec/operators_export_spec.rb holds the checked-in JSON equal to this
+# script's own output, so regenerate it any time the ledger or the
+# vocabulary changes.
 
 require "json"
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "hecksagain"
+require "hecksagain/grammar"
 
-rows = Hecksagain::Bluebook::Expression::Evaluator::OPERATORS.map do |op|
-  { symbol: op.symbol, compares_less_than: op.compares_less_than,
-    compares_equal: op.compares_equal, negated: op.negated }
+judged     = Hecksagain::Bluebook::MetaValidator.grammar_registry.bluebook("Bluebook")
+vocabulary = judged.aggregates.find { |a| a.name == "Vocabulary" }
+algebra    = vocabulary.value_objects.find { |vo| vo.hecks_name == "Comparison" }
+                       .members.to_h { |row| [row.to_h.values.first, row.to_h] }
+
+rows = Hecksagain::Grammar.admitted_operators
+                          .select { |op| op[:category] == "comparison" }
+                          .map do |op|
+  declared = algebra.fetch(op[:symbol]) do
+    abort "#{op[:symbol]} is admitted but Vocabulary::Comparison declares no algebra for it"
+  end
+  { symbol: op[:symbol], compares_less_than: declared[:compares_less_than],
+    compares_equal: declared[:compares_equal], negated: declared[:negated] }
 end
 
 puts JSON.pretty_generate(rows)

--- a/docs/porting/grammar.md
+++ b/docs/porting/grammar.md
@@ -19,8 +19,17 @@ to be a content-management domain about operators that nothing read; it is now *
 by checking**: `lib/hecksagain/grammar/expression_operators.json` replays every operator through the
 chapter's own Propose → Render (ruby, rust) → Admit commands, and `spec/operator_conformance_spec.rb`
 holds the evaluator's tables equal to the admitted set, both directions — an operator the ledger
-never admitted does not exist to the evaluator. This document remains the parser's spec; the
-chapter is the ledger the parser is audited against.
+never admitted does not exist to the evaluator. And since then, **read by projection**: the
+evaluator's and canonical form's tables are `lib/hecksagain/bluebook/expression/projection.json`,
+regenerated from the admitted set by `bin/expression_projection` (the same relationship Rust's
+`operators.json` has to `bin/operators` — the domain owns which operators exist and in what check
+order; `Vocabulary::Comparison` owns the algebra each computes; the generators are the join). This
+document remains the parser's spec; the chapter is the source its tables are projected from.
+
+One boundary found by measurement: an operator the chapter's OWN guards evaluate through — `!=`
+appears in `status != "retired"` — is load-bearing for the self-description and cannot simply be
+retired; a projection without it cannot even boot the chapter. Retiring such a word would first
+mean rewriting the chapter's guards without it.
 
 ## Outer grammar (boolean / comparison)
 

--- a/docs/porting/grammar.md
+++ b/docs/porting/grammar.md
@@ -14,8 +14,13 @@ encoded as check order — the first pattern that matches wins, so order *is* th
 
 A related but different artifact: `lib/hecksagain/grammar/expression.bluebook` is the language's own
 self-description of admitted operators as *data* (an `Operator` aggregate with a `proposed →
-admitted → retired` lifecycle, tracking precedence/category/arity/renderings per operator). That's a
-content-management domain about operators, not the parser itself — this document is the parser.
+admitted → retired` lifecycle, tracking precedence/category/arity/renderings per operator). It used
+to be a content-management domain about operators that nothing read; it is now **held to the parser
+by checking**: `lib/hecksagain/grammar/expression_operators.json` replays every operator through the
+chapter's own Propose → Render (ruby, rust) → Admit commands, and `spec/operator_conformance_spec.rb`
+holds the evaluator's tables equal to the admitted set, both directions — an operator the ledger
+never admitted does not exist to the evaluator. This document remains the parser's spec; the
+chapter is the ledger the parser is audited against.
 
 ## Outer grammar (boolean / comparison)
 

--- a/lib/hecksagain/bluebook/dsl/command_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/command_builder.rb
@@ -71,6 +71,10 @@ module Hecksagain
           )
         end
 
+        # `sets` is the word; `then_set` is the spelling every existing
+        # bluebook was written under (Syntax::Keyword carries the rename as
+        # `was:`), and it stays answered here forever — a renamed word's old
+        # era keeps booting, which is the whole point of the rename column.
         def then_set(target, to: nil, append: nil, increment: nil, decrement: nil)
           # moved to the language: given "a mutation names a target", on Verb.Change
 
@@ -92,6 +96,7 @@ module Hecksagain
           op, source = named.first
           @mutations << IR::Mutation.new(target: target.to_sym, op: op, source: source)
         end
+        alias_method :sets, :then_set
 
         # No raise here. "an event is named" is declared in the language itself —
         # language/bluebook/behavior.bluebook, on Command.Announce — and MetaValidator is what

--- a/lib/hecksagain/bluebook/expression/canonical_form.rb
+++ b/lib/hecksagain/bluebook/expression/canonical_form.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module Hecksagain
   module Bluebook
     module Expression
@@ -6,10 +8,13 @@ module Hecksagain
 
         STRATEGIES = %w[collapse_whitespace replace].freeze
 
-        RULES = [
-          Rule.new(strategy: "collapse_whitespace", source_token: "", replacement: "", boundary: "none", position: 1),
-          Rule.new(strategy: "replace", source_token: ".length", replacement: ".size", boundary: "word", position: 2)
-        ].freeze
+        # READ, NOT RESTATED — the admitted normalisation rules, projected
+        # from the grammar chapter by bin/expression_projection exactly as
+        # the evaluator's operator table is. See Evaluator::PROJECTION for
+        # why a projection rather than a boot.
+        RULES = JSON.parse(
+          File.read(File.join(__dir__, "projection.json")), symbolize_names: true
+        ).fetch(:normalisations).map { |row| Rule.new(**row) }.freeze
 
         module_function
 

--- a/lib/hecksagain/bluebook/expression/evaluator.rb
+++ b/lib/hecksagain/bluebook/expression/evaluator.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module Hecksagain
   module Bluebook
     module Expression
@@ -6,19 +8,25 @@ module Hecksagain
 
         # Six operators, reduced to two primitives (less_than, equal) combined
         # with a small boolean algebra: compares_less_than/compares_equal choose
-        # which primitive(s) OR together, negated inverts the result. Declared
-        # the same way in Vocabulary::Comparison (language/bluebook/vocabulary.bluebook) —
-        # spec/vocabulary_conformance_spec holds the two tables equal, field for
-        # field, so a runtime cannot drift from what the language says an
-        # operator computes.
-        OPERATORS = [
-          Operator.new(symbol: ">=", compares_less_than: true,  compares_equal: false, negated: true),
-          Operator.new(symbol: "<=", compares_less_than: true,  compares_equal: true,  negated: false),
-          Operator.new(symbol: "<",  compares_less_than: true,  compares_equal: false, negated: false),
-          Operator.new(symbol: ">",  compares_less_than: true,  compares_equal: true,  negated: true),
-          Operator.new(symbol: "==", compares_less_than: false, compares_equal: true,  negated: false),
-          Operator.new(symbol: "!=", compares_less_than: false, compares_equal: true,  negated: true)
-        ].freeze
+        # which primitive(s) OR together, negated inverts the result.
+        #
+        # READ, NOT RESTATED. This table is the checked-in projection of the
+        # grammar chapter's admitted set (bin/expression_projection — the same
+        # relationship Rust's operators.json has to bin/operators), joined with
+        # the algebra Vocabulary::Comparison declares. The evaluator cannot
+        # boot the chapter that configures it — the Prism adapter normalises
+        # every predicate through CanonicalForm while a bluebook loads — so
+        # the projection is how the domain reaches here: regenerated when the
+        # ledger changes, held fresh by spec/operators_export_spec.rb, and
+        # held to the live machinery by spec/operator_conformance_spec.rb.
+        PROJECTION = JSON.parse(
+          File.read(File.join(__dir__, "projection.json")), symbolize_names: true
+        ).freeze
+
+        OPERATORS = PROJECTION.fetch(:operators)
+                              .select { |row| row[:category] == "comparison" }
+                              .map { |row| Operator.new(**row.slice(:symbol, :compares_less_than, :compares_equal, :negated)) }
+                              .freeze
 
         COMPARISONS = OPERATORS.map(&:symbol).freeze
 

--- a/lib/hecksagain/bluebook/expression/projection.json
+++ b/lib/hecksagain/bluebook/expression/projection.json
@@ -1,0 +1,110 @@
+{
+  "operators": [
+    {
+      "symbol": "||",
+      "category": "logical",
+      "precedence": 1,
+      "arity": 2
+    },
+    {
+      "symbol": "&&",
+      "category": "logical",
+      "precedence": 2,
+      "arity": 2
+    },
+    {
+      "symbol": ".include?",
+      "category": "membership",
+      "precedence": 3,
+      "arity": 2
+    },
+    {
+      "symbol": ">=",
+      "category": "comparison",
+      "precedence": 4,
+      "arity": 2,
+      "compares_less_than": true,
+      "compares_equal": false,
+      "negated": true
+    },
+    {
+      "symbol": "<=",
+      "category": "comparison",
+      "precedence": 4,
+      "arity": 2,
+      "compares_less_than": true,
+      "compares_equal": true,
+      "negated": false
+    },
+    {
+      "symbol": "<",
+      "category": "comparison",
+      "precedence": 4,
+      "arity": 2,
+      "compares_less_than": true,
+      "compares_equal": false,
+      "negated": false
+    },
+    {
+      "symbol": ">",
+      "category": "comparison",
+      "precedence": 4,
+      "arity": 2,
+      "compares_less_than": true,
+      "compares_equal": true,
+      "negated": true
+    },
+    {
+      "symbol": "==",
+      "category": "comparison",
+      "precedence": 4,
+      "arity": 2,
+      "compares_less_than": false,
+      "compares_equal": true,
+      "negated": false
+    },
+    {
+      "symbol": "!=",
+      "category": "comparison",
+      "precedence": 4,
+      "arity": 2,
+      "compares_less_than": false,
+      "compares_equal": true,
+      "negated": true
+    },
+    {
+      "symbol": "!",
+      "category": "logical",
+      "precedence": 5,
+      "arity": 1
+    },
+    {
+      "symbol": "+",
+      "category": "arithmetic",
+      "precedence": 6,
+      "arity": 2
+    },
+    {
+      "symbol": ".modulo",
+      "category": "arithmetic",
+      "precedence": 6,
+      "arity": 2
+    }
+  ],
+  "normalisations": [
+    {
+      "strategy": "collapse_whitespace",
+      "source_token": "",
+      "replacement": "",
+      "boundary": "none",
+      "position": 1
+    },
+    {
+      "strategy": "replace",
+      "source_token": ".length",
+      "replacement": ".size",
+      "boundary": "word",
+      "position": 2
+    }
+  ]
+}

--- a/lib/hecksagain/grammar.rb
+++ b/lib/hecksagain/grammar.rb
@@ -77,6 +77,95 @@ module Hecksagain
       registry.repository("Expression", aggregate).all
     end
 
+    # THE OPERATORS THE LANGUAGE STANDS ON. Every guard and invariant in
+    # the language's own chapters — the meta-domain (Bluebook, World) and
+    # the grammar chapters beside this file — evaluates through the very
+    # operator table the ledger admits. An operator one of those
+    # predicates uses is SELF-BEARING: retire it and the language can no
+    # longer read its own rules — found the hard way, as a projection
+    # missing `!=` that could not boot the chapter to fix itself. This
+    # derives the set, with a usage site per operator, so the generator
+    # and the conformance spec can refuse the retirement BY NAME instead
+    # of wedging.
+    def self_bearing_operators
+      sites = Hash.new { |h, k| h[k] = [] }
+
+      chapters = Bluebook::MetaValidator.grammar_registry
+                                        .then { |reg| %w[Bluebook World].map { |name| reg.bluebook(name) } }
+      chapters += grammar_chapters
+
+      chapters.compact.each do |chapter|
+        chapter.aggregates.each do |aggregate|
+          aggregate.commands.each do |command|
+            command.givens.each do |given|
+              operators_in(given.canonical).each do |symbol|
+                sites[symbol] << "#{chapter.name} #{aggregate.name}.#{command.hecks_name}"
+              end
+            end
+          end
+          aggregate.value_objects.each do |value_object|
+            value_object.invariants.each do |invariant|
+              operators_in(invariant.canonical).each do |symbol|
+                sites[symbol] << "#{chapter.name} #{aggregate.name}::#{value_object.hecks_name}"
+              end
+            end
+          end
+        end
+      end
+
+      sites.transform_values(&:uniq)
+    end
+
+    # Every grammar/*.bluebook chapter, booted the same way the corpus
+    # boots them — each alone, in a scratch registry.
+    def grammar_chapters
+      Dir[File.join(DIR, "*.bluebook")].sort.map do |chapter|
+        registry = Runtime::Registry.new
+        root = File.expand_path("../..", __dir__)
+        Hecksagain.with_registry(registry) do
+          Kernel.load(File.join(root, "lib/hecksagain/ports/persistence.port"))
+          Kernel.load(File.join(root, "lib/hecksagain/ports/extraction.port"))
+          Kernel.load(File.join(root, "lib/hecksagain/adapters/driven/memory.adapter"))
+          Kernel.load(File.join(root, "lib/hecksagain/adapters/driven/prism.adapter"))
+          Kernel.load(chapter)
+        end
+        registry.bluebooks.values.first
+      end
+    end
+
+    # Which admitted operators one canonical text evaluates through —
+    # the evaluator's own parse, walked for its operator nodes, leaves
+    # walked for the resolver's arithmetic.
+    def operators_in(canonical)
+      evaluator = Bluebook::Expression::Evaluator
+      node = begin
+        evaluator.parse(canonical)
+      rescue StandardError
+        return []
+      end
+      walk_operators(node, evaluator).uniq
+    end
+
+    def walk_operators(node, evaluator)
+      resolver = Bluebook::Expression::Resolver
+      case node
+      when evaluator::Or  then ["||"] + walk_operators(node.left, evaluator) + walk_operators(node.right, evaluator)
+      when evaluator::And then ["&&"] + walk_operators(node.left, evaluator) + walk_operators(node.right, evaluator)
+      when evaluator::Not then ["!"] + walk_operators(node.node, evaluator)
+      when evaluator::Compare
+        [node.operator.symbol] + walk_operators(node.left, evaluator) + walk_operators(node.right, evaluator)
+      when evaluator::Include
+        [".include?"] + walk_operators(node.haystack, evaluator) + walk_operators(node.needle, evaluator)
+      when evaluator::Resolve then walk_operators(node.expr, evaluator)
+      when resolver::Addition then ["+"] + walk_operators(node.left, evaluator) + walk_operators(node.right, evaluator)
+      when resolver::Modulo   then [".modulo"] + walk_operators(node.receiver, evaluator) + walk_operators(node.divisor, evaluator)
+      when Struct
+        node.members.flat_map { |member| walk_operators(node[member], evaluator) }
+      else
+        []
+      end
+    end
+
     def symbolize(value)
       case value
       when Hash  then value.to_h { |k, v| [k.to_sym, symbolize(v)] }

--- a/lib/hecksagain/grammar.rb
+++ b/lib/hecksagain/grammar.rb
@@ -1,0 +1,88 @@
+require "json"
+
+# The whole framework, deliberately: booting a grammar chapter exercises
+# the DSL, the meta-validator, and the runtime — and nothing the entry
+# point loads ever requires this file back, so the require is acyclic.
+require_relative "../hecksagain"
+
+module Hecksagain
+  # The sublanguage grammar domains (grammar/*.bluebook) and the one boot
+  # path for reading them as DATA — the expression chapter replayed
+  # through its own admission ledger, so anything derived from it (the
+  # operator projections, the conformance specs) reads the set that
+  # actually survived the Admit gates, never a hand-copied list.
+  #
+  # Booted on CALL, never at require: the Prism adapter normalises every
+  # predicate through CanonicalForm while a bluebook loads, so the
+  # expression machinery cannot boot the chapter that configures it —
+  # this module exists precisely so generators and specs boot it in a
+  # scratch registry instead.
+  module Grammar
+    DIR    = File.expand_path("grammar", __dir__)
+    LEDGER = File.join(DIR, "expression_operators.json")
+
+    module_function
+
+    # Boot the expression chapter and replay the admission ledger through
+    # its real commands. A refused step raises — a generator running off
+    # a half-admitted ledger would project a table the gates never
+    # accepted.
+    def expression
+      registry = Runtime::Registry.new
+      root = File.expand_path("../..", __dir__)
+      Hecksagain.with_registry(registry) do
+        Kernel.load(File.join(root, "lib/hecksagain/ports/persistence.port"))
+        Kernel.load(File.join(root, "lib/hecksagain/ports/extraction.port"))
+        Kernel.load(File.join(root, "lib/hecksagain/adapters/driven/memory.adapter"))
+        Kernel.load(File.join(root, "lib/hecksagain/adapters/driven/prism.adapter"))
+        Kernel.load(File.join(DIR, "expression.bluebook"))
+      end
+      dispatcher = Runtime::Dispatcher.new(registry)
+
+      JSON.parse(File.read(LEDGER)).fetch("steps").each do |step|
+        args = symbolize(step.fetch("args"))
+        begin
+          dispatcher.dispatch(step.fetch("verb"), **args)
+        rescue *Runtime::DOMAIN_REFUSALS => refusal
+          raise Runtime::WiringError,
+                "the admission ledger refused at #{step['verb']} #{step['args']} — #{refusal.message}"
+        end
+      end
+
+      dispatcher
+    end
+
+    def admitted_operators(dispatcher = expression)
+      records(dispatcher, "Operator").select { |op| op[:status] == "admitted" }.map do |op|
+        { symbol: op[:symbol].value, category: op[:category].value,
+          precedence: op[:precedence].value, arity: op[:arity].value,
+          renderings: Array(op[:renderings]).map { |r| { target: r[:target], form: r[:form] } } }
+      end
+    end
+
+    def admitted_normalisations(dispatcher = expression)
+      records(dispatcher, "Normalisation")
+        .select { |rule| rule[:status] == "admitted" }
+        .sort_by { |rule| rule[:position].value }
+        .map do |rule|
+          { strategy: rule[:strategy].value, source_token: rule[:source_token].value,
+            replacement: rule[:replacement].value, boundary: rule[:boundary].value,
+            position: rule[:position].value }
+        end
+    end
+
+    def records(dispatcher, aggregate_name)
+      registry  = dispatcher.registry
+      aggregate = registry.bluebook("Expression").aggregate(aggregate_name)
+      registry.repository("Expression", aggregate).all
+    end
+
+    def symbolize(value)
+      case value
+      when Hash  then value.to_h { |k, v| [k.to_sym, symbolize(v)] }
+      when Array then value.map { |v| symbolize(v) }
+      else value
+      end
+    end
+  end
+end

--- a/lib/hecksagain/grammar/evolve.rb
+++ b/lib/hecksagain/grammar/evolve.rb
@@ -1,0 +1,93 @@
+module Hecksagain
+  module Grammar
+    # The file surgery under bin/evolve: reading and rewriting the
+    # Keyword rows of language/bluebook/syntax.bluebook as TEXT, so a
+    # proposed word enters the table exactly as a hand would write it
+    # and an admitted one loses its ceremony (an absent status reads as
+    # admitted — the grown-column convention).
+    #
+    # Text, not IR, on purpose: the syntax table is source, its comments
+    # and grouping are part of the declaration, and a rewrite that
+    # round-tripped it through the IR would flatten both. Everything
+    # here touches only `member ` lines inside Keyword's one_of block
+    # and leaves every other byte alone.
+    module Evolve
+      class Refusal < StandardError; end
+
+      module_function
+
+      def syntax_path
+        File.expand_path("../language/bluebook/syntax.bluebook", __dir__)
+      end
+
+      # The Keyword one_of's member rows, parsed leniently off the text —
+      # enough to know each row's (word, context, status), which is all
+      # the tool ever asks.
+      def keyword_rows(path = syntax_path)
+        block = keyword_block(File.read(path))
+        block.scan(/^\s*member (.+)$/).map do |(cells)|
+          row = cells.scan(/(\w+): "((?:[^"\\]|\\.)*)"/).to_h
+          { word: row["word"], context: row["context"],
+            status: row.fetch("status", "admitted") }
+        end
+      end
+
+      def propose(word:, context:, body: "none", inner: "", opens: "", fills: "", path: syntax_path)
+        if keyword_rows(path).any? { |row| row[:word] == word && row[:context] == context }
+          raise Refusal, "#{context}.#{word} is already declared — one row per (word, context, form)"
+        end
+
+        source = File.read(path)
+        block  = keyword_block(source)
+        indent = block[/^(\s*)member /, 1] || "        "
+        row = %(#{indent}member word: "#{word}", context: "#{context}", body: "#{body}", ) +
+              %(inner: "#{inner}", opens: "#{opens}", fills: "#{fills}", status: "proposed"\n)
+
+        # At the END of the one_of — grouping by context is a courtesy of
+        # the hand; a proposed row sits at the bottom until admission,
+        # when whoever admits it may move it home.
+        closing = block.rindex(/^\s*end\s*$/)
+        updated = block[0...closing] + row + block[closing..]
+        File.write(path, source.sub(block, updated))
+      end
+
+      def set_status(word:, context:, to:, path: syntax_path)
+        unless %w[proposed admitted deprecated retired].include?(to)
+          raise Refusal, "#{to.inspect} is not a station a word's life admits"
+        end
+
+        source = File.read(path)
+        block  = keyword_block(source)
+        rows   = block.lines.select { |line| member_row?(line, word, context) }
+        raise Refusal, "#{context}.#{word} is not declared" if rows.empty?
+
+        updated = block.lines.map do |line|
+          next line unless member_row?(line, word, context)
+
+          stripped = line.sub(/,\s*status: "[^"]*"/, "")
+          # Admitted is the default and stays UNSPELLED — only a word
+          # entering or leaving the language carries its status.
+          to == "admitted" ? stripped : stripped.sub(/\n\z/, %(, status: "#{to}"\n))
+        end.join
+
+        File.write(path, source.sub(block, updated))
+      end
+
+      def member_row?(line, word, context)
+        line =~ /^\s*member / && line.include?(%(word: "#{word}")) && line.include?(%(context: "#{context}"))
+      end
+
+      # From `value_object "Keyword"` to the end of its one_of block —
+      # the only region this module may touch.
+      def keyword_block(source)
+        start = source.index(/^\s*value_object "Keyword" do$/)
+        raise Refusal, "syntax.bluebook declares no Keyword value object" unless start
+
+        one_of = source.index(/^\s*one_of do$/, start)
+        closing = source.index(/^\s*end\s*$/, one_of)
+        closing = source.index(/\n/, closing) + 1
+        source[start...closing]
+      end
+    end
+  end
+end

--- a/lib/hecksagain/grammar/evolve.rb
+++ b/lib/hecksagain/grammar/evolve.rb
@@ -28,7 +28,7 @@ module Hecksagain
         block.scan(/^\s*member (.+)$/).map do |(cells)|
           row = cells.scan(/(\w+): "((?:[^"\\]|\\.)*)"/).to_h
           { word: row["word"], context: row["context"],
-            status: row.fetch("status", "admitted") }
+            status: row.fetch("status", "admitted"), was: row["was"] }
         end
       end
 
@@ -71,6 +71,33 @@ module Hecksagain
         end.join
 
         File.write(path, source.sub(block, updated))
+      end
+
+      # A rename respells the row's word and holds the old spelling in
+      # `was:` — one hop only. Renaming an already-renamed word refuses
+      # until the language grows real eras for its own words; renaming
+      # onto a spelling the context already declares refuses too. The
+      # word's Argument rows follow it — arguments belong to the word,
+      # not to its spelling.
+      def rename(word:, context:, to:, path: syntax_path)
+        row = keyword_rows(path).find { |r| r[:word] == word && r[:context] == context }
+        raise Refusal, "#{context}.#{word} is not declared" unless row
+        raise Refusal, "#{context}.#{word} was already #{row[:was]} — one rename hop, then eras" if row[:was]
+        if keyword_rows(path).any? { |r| r[:word] == to && r[:context] == context }
+          raise Refusal, "#{context}.#{to} is already declared — a rename cannot land on a living word"
+        end
+
+        source = File.read(path)
+        block  = keyword_block(source)
+        updated = block.lines.map do |line|
+          next line unless member_row?(line, word, context)
+
+          line.sub(%(word: "#{word}"), %(word: "#{to}"))
+              .sub(/\n\z/, %(, was: "#{word}"\n))
+        end.join
+        source = source.sub(block, updated)
+        source = source.gsub(%(keyword: "#{word}",), %(keyword: "#{to}",))
+        File.write(path, source)
       end
 
       def member_row?(line, word, context)

--- a/lib/hecksagain/grammar/expression_operators.json
+++ b/lib/hecksagain/grammar/expression_operators.json
@@ -1,0 +1,760 @@
+{
+  "name": "expression-operators",
+  "note": "The admission ledger \u2014 every operator and normalisation rule the expression machinery runs, driven through the grammar chapter's own lifecycle. Propose, then a rendering per target, then Admit, so the 'reads in every target' guard gates each admission for real. spec/operator_conformance_spec.rb replays this and holds the evaluator's tables equal to what survives \u2014 an operator absent here is not a slow operator, it is not an operator.",
+  "steps": [
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "||"
+        },
+        "category": {
+          "value": "logical"
+        },
+        "precedence": {
+          "value": 1
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "||"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a || b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "||"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a || b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "||"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "&&"
+        },
+        "category": {
+          "value": "logical"
+        },
+        "precedence": {
+          "value": 2
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "&&"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a && b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "&&"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a && b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "&&"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".include?"
+        },
+        "category": {
+          "value": "membership"
+        },
+        "precedence": {
+          "value": 3
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".include?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "haystack.include?(needle)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".include?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "haystack.include?(needle)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".include?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ">="
+        },
+        "category": {
+          "value": "comparison"
+        },
+        "precedence": {
+          "value": 4
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ">="
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a >= b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ">="
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a >= b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ">="
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "<="
+        },
+        "category": {
+          "value": "comparison"
+        },
+        "precedence": {
+          "value": 4
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "<="
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a <= b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "<="
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a <= b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "<="
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "<"
+        },
+        "category": {
+          "value": "comparison"
+        },
+        "precedence": {
+          "value": 4
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "<"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a < b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "<"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a < b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "<"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ">"
+        },
+        "category": {
+          "value": "comparison"
+        },
+        "precedence": {
+          "value": 4
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ">"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a > b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ">"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a > b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ">"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "=="
+        },
+        "category": {
+          "value": "comparison"
+        },
+        "precedence": {
+          "value": 4
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "=="
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a == b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "=="
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a == b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "=="
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "!="
+        },
+        "category": {
+          "value": "comparison"
+        },
+        "precedence": {
+          "value": 4
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "!="
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a != b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "!="
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a != b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "!="
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "!"
+        },
+        "category": {
+          "value": "logical"
+        },
+        "precedence": {
+          "value": 5
+        },
+        "arity": {
+          "value": 1
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "!"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "!a"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "!"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "!a"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "!"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": "+"
+        },
+        "category": {
+          "value": "arithmetic"
+        },
+        "precedence": {
+          "value": 6
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "+"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a + b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": "+"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a + b"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": "+"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".modulo"
+        },
+        "category": {
+          "value": "arithmetic"
+        },
+        "precedence": {
+          "value": 6
+        },
+        "arity": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".modulo"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.modulo(b)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".modulo"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.modulo(b)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".modulo"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Propose",
+      "args": {
+        "name": {
+          "value": "collapse_whitespace"
+        },
+        "strategy": {
+          "value": "collapse_whitespace"
+        },
+        "source_token": {
+          "value": ""
+        },
+        "replacement": {
+          "value": ""
+        },
+        "boundary": {
+          "value": "none"
+        },
+        "position": {
+          "value": 1
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Read",
+      "args": {
+        "name": {
+          "value": "collapse_whitespace"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "text.gsub(/\\s+/, \" \")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Read",
+      "args": {
+        "name": {
+          "value": "collapse_whitespace"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "WHITESPACE.replace_all(text, \" \")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Admit",
+      "args": {
+        "name": {
+          "value": "collapse_whitespace"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Propose",
+      "args": {
+        "name": {
+          "value": "length_to_size"
+        },
+        "strategy": {
+          "value": "replace"
+        },
+        "source_token": {
+          "value": ".length"
+        },
+        "replacement": {
+          "value": ".size"
+        },
+        "boundary": {
+          "value": "word"
+        },
+        "position": {
+          "value": 2
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Read",
+      "args": {
+        "name": {
+          "value": "length_to_size"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "text.gsub(/\\.length(?![[:alnum:]_])/, \".size\")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Read",
+      "args": {
+        "name": {
+          "value": "length_to_size"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "replace_word_bounded(text, \".length\", \".size\")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Normalisation.Admit",
+      "args": {
+        "name": {
+          "value": "length_to_size"
+        }
+      }
+    }
+  ]
+}

--- a/lib/hecksagain/language/bluebook/bluebook.bluebook
+++ b/lib/hecksagain/language/bluebook/bluebook.bluebook
@@ -1,4 +1,4 @@
-Hecks.bluebook "Bluebook" do
+Hecks.bluebook "Bluebook", version: "1" do
   vision "The bluebook language, declared in itself. Loading a domain becomes dispatching commands into this meta-domain ; the IR it stores must equal the IR the DSL builder produces. The floor that stays hand-written is the interpreter — evaluating a predicate held as data — and IO."
   core
 

--- a/lib/hecksagain/language/bluebook/syntax.bluebook
+++ b/lib/hecksagain/language/bluebook/syntax.bluebook
@@ -105,6 +105,26 @@ Hecks.bluebook "Bluebook" do
       end
     end
 
+    # WHERE A WORD STANDS IN ITS OWN LIFE. The same shape the expression
+    # grammar's Operator carries (proposed → admitted → retired), plus
+    # `deprecated` — a word still read but on its way out, which an operator
+    # never needed because nothing outside this repo writes expressions yet.
+    # A row DEFAULTS to admitted, so the table below stays a table of words
+    # rather than a table of words-with-ceremony; only a word entering or
+    # leaving the language spells its status. The projections read this:
+    # a proposed or retired word reaches no generated parser table, so to
+    # every projected reader it simply does not exist — the operator rule,
+    # at the syntax layer.
+    value_object "Status" do
+      attribute :name, String
+      one_of do
+        member name: "proposed"
+        member name: "admitted"
+        member name: "deprecated"
+        member name: "retired"
+      end
+    end
+
     # WHAT AN ARGUMENT LOOKS LIKE WHEN IT IS TYPED. Lexical, not semantic — two
     # arguments of the same kind are read the same way and mean whatever the
     # field they fill means.
@@ -162,6 +182,7 @@ Hecks.bluebook "Bluebook" do
       attribute :inner,   String
       attribute :opens,   String
       attribute :fills,   String
+      attribute :status,  String, default: "admitted", admits: "Syntax::Status"
 
       one_of do
         # The outside of every body. `Hecks.bluebook` is reached through the
@@ -347,6 +368,7 @@ Hecks.bluebook "Bluebook" do
       attribute :kind,     String, admits: "Syntax::ArgumentKind"
       attribute :required, String
       attribute :fills,    String
+      attribute :status,   String, default: "admitted", admits: "Syntax::Status"
 
       one_of do
         member keyword: "bluebook",        context: "File",     at: "1", named: "",        kind: "text",     required: "true",  fills: "name"

--- a/lib/hecksagain/language/bluebook/syntax.bluebook
+++ b/lib/hecksagain/language/bluebook/syntax.bluebook
@@ -183,6 +183,14 @@ Hecks.bluebook "Bluebook" do
       attribute :opens,   String
       attribute :fills,   String
       attribute :status,  String, default: "admitted", admits: "Syntax::Status"
+      # THE RENAME COLUMN — the language's own `was:`, one level up from the
+      # data translations that taught it the shape. A row whose word was
+      # respelled keeps the old spelling here; the old spelling stays
+      # answered by the builder and emitted into every projection, so a
+      # bluebook written under it keeps booting — in both runtimes —
+      # forever. One hop only: renaming an already-renamed word refuses
+      # until the language grows real eras for its own words.
+      attribute :was,     String
 
       one_of do
         # The outside of every body. `Hecks.bluebook` is reached through the
@@ -242,7 +250,11 @@ Hecks.bluebook "Bluebook" do
         member word: "goal",            context: "Command", body: "none",   inner: "", opens: "", fills: "goal"
         member word: "reference_to",    context: "Command", body: "none",   inner: "", opens: "", fills: "references"
         member word: "given",           context: "Command", body: "source", inner: "", opens: "", fills: "givens"
-        member word: "then_set",        context: "Command", body: "none",   inner: "", opens: "", fills: "mutations"
+        # RENAMED, NOT REPLACED. `sets :balance, increment: :amount` is the
+        # spelling; `then_set` is the era every existing bluebook was written
+        # under, and every one of them still boots — the corpus itself is the
+        # proof the rename machinery is safe.
+        member word: "sets",            context: "Command", body: "none",   inner: "", opens: "", fills: "mutations", was: "then_set"
         member word: "emits",           context: "Command", body: "none",   inner: "", opens: "", fills: "emits"
         member word: "attribute",       context: "Command", body: "none",   inner: "", opens: "", fills: "attributes"
 
@@ -436,11 +448,11 @@ Hecks.bluebook "Bluebook" do
         member keyword: "reference_to",    context: "Command", at: "",  named: "as",        kind: "symbol",   required: "false", fills: "name"
         member keyword: "reference_to",    context: "Command", at: "",  named: "optional",  kind: "flag",     required: "false", fills: "optional"
         member keyword: "given",           context: "Command", at: "1", named: "",          kind: "text",     required: "true",  fills: "description"
-        member keyword: "then_set",        context: "Command", at: "1", named: "",          kind: "symbol",   required: "true",  fills: "target"
-        member keyword: "then_set",        context: "Command", at: "",  named: "to",        kind: "symbol",   required: "false", fills: "source"
-        member keyword: "then_set",        context: "Command", at: "",  named: "append",    kind: "pairs",    required: "false", fills: ""
-        member keyword: "then_set",        context: "Command", at: "",  named: "increment", kind: "symbol",   required: "false", fills: "source"
-        member keyword: "then_set",        context: "Command", at: "",  named: "decrement", kind: "symbol",   required: "false", fills: "source"
+        member keyword: "sets",            context: "Command", at: "1", named: "",          kind: "symbol",   required: "true",  fills: "target"
+        member keyword: "sets",            context: "Command", at: "",  named: "to",        kind: "symbol",   required: "false", fills: "source"
+        member keyword: "sets",            context: "Command", at: "",  named: "append",    kind: "pairs",    required: "false", fills: ""
+        member keyword: "sets",            context: "Command", at: "",  named: "increment", kind: "symbol",   required: "false", fills: "source"
+        member keyword: "sets",            context: "Command", at: "",  named: "decrement", kind: "symbol",   required: "false", fills: "source"
         member keyword: "emits",           context: "Command", at: "1", named: "",          kind: "text",     required: "true",  fills: "emits"
         member keyword: "attribute",       context: "Command", at: "1", named: "",          kind: "symbol",   required: "true",  fills: "name"
         member keyword: "attribute",       context: "Command", at: "2", named: "",          kind: "constant", required: "false", fills: "type"

--- a/rust/src/bluebook/parse_blocks.rs
+++ b/rust/src/bluebook/parse_blocks.rs
@@ -197,7 +197,10 @@ pub fn parse_command(lines: &[&str], owner: &str) -> (Command, usize) {
                     canonical: expr,
                     description: msg,
                 });
-            } else if line.starts_with("then_set") {
+            } else if line.starts_with("then_set") || line.starts_with("sets ") || line.starts_with("sets(") {
+                // `sets` is the word, `then_set` the spelling every existing
+                // bluebook was written under — Syntax::Keyword carries the
+                // rename as `was:`, and both eras parse here forever.
                 if let Some(m) = parse_mutation(line) {
                     cmd.mutations.push(m);
                 }

--- a/rust/tests/sets_rename_test.rs
+++ b/rust/tests/sets_rename_test.rs
@@ -1,0 +1,51 @@
+//! `sets` is the word; `then_set` is the spelling every existing bluebook
+//! was written under — Syntax::Keyword carries the rename as `was:`, and
+//! the contract of that column is that BOTH spellings parse, forever, to
+//! byte-identical IR. The Ruby twin of this test lives in spec/dsl_spec.rb
+//! ("builds the same mutation under sets and then_set — a rename, not a
+//! fork"); this is the same claim made against this parser.
+
+use storehouse::parser;
+
+fn bluebook_with(mutation_line: &str) -> String {
+    format!(
+        r#"Hecks.bluebook "Spelled" do
+  aggregate "Thing" do
+    identified_by {{ name.value }}
+    attribute :name, Name
+    attribute :count, Tally
+
+    value_object "Name" do
+      attribute :value, String
+    end
+
+    value_object "Tally" do
+      attribute :value, Integer
+    end
+
+    command "Bump" do
+      attribute :amount, Tally
+      {mutation_line}
+      emits "Bumped"
+    end
+  end
+end
+"#
+    )
+}
+
+#[test]
+fn sets_and_then_set_build_identical_mutations() {
+    let renamed = parser::parse(&bluebook_with("sets :count, increment: :amount"));
+    let original = parser::parse(&bluebook_with("then_set :count, increment: :amount"));
+
+    let renamed_cmd = &renamed.aggregates[0].commands[0];
+    let original_cmd = &original.aggregates[0].commands[0];
+
+    assert_eq!(renamed_cmd.mutations.len(), 1, "sets parsed no mutation");
+    assert_eq!(
+        format!("{:?}", renamed_cmd.mutations),
+        format!("{:?}", original_cmd.mutations),
+        "the two spellings built different IR — the rename column is lying"
+    );
+}

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "the DSL surface is fully covered" do
     ],
     "CommandBuilder" => [
       Hecksagain::Bluebook::DSL::CommandBuilder,
-      %i[role goal reference_to given then_set emits attribute list_of attributes]
+      %i[role goal reference_to given then_set sets emits attribute list_of attributes]
     ],
     "PortBuilder" => [
       Hecksagain::Bluebook::DSL::PortBuilder,

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -286,6 +286,16 @@ RSpec.describe "the DSL surface" do
         .to raise_error(Malformed, /names no operation/)
     end
 
+    it "builds the same mutation under sets and then_set — a rename, not a fork" do
+      # `sets` is the word; `then_set` is the era every existing bluebook was
+      # written under (Syntax::Keyword carries the rename as `was:`). The two
+      # spellings must build byte-identical IR, or the rename column is a lie.
+      renamed = build_command("Spelled") { sets :balance, increment: :amount }
+      original = build_command("Spelled2") { then_set :balance, increment: :amount }
+
+      expect(renamed.mutations.map(&:to_h)).to eq(original.mutations.map(&:to_h))
+    end
+
     it "refuses a mutation that names two operations" do
       expect { build_command("Torn") { then_set :balance, to: 5, increment: :amount } }
         .to raise_error(Malformed, /one mutation, one meaning/)

--- a/spec/evolve_spec.rb
+++ b/spec/evolve_spec.rb
@@ -1,0 +1,103 @@
+
+require "spec_helper"
+require "tmpdir"
+require "hecksagain/grammar/evolve"
+
+# The file surgery under bin/evolve, exercised against throwaway COPIES
+# of the real syntax table — never the tree's own. The tool's gates
+# (regenerate, run the conformance specs, restore on red) are proven by
+# driving bin/evolve itself; what this file pins is the surgery: a
+# proposal lands as a hand would write it, admission removes the
+# ceremony (absent status reads as admitted), and the region outside
+# Keyword's one_of block is never touched.
+RSpec.describe "the evolve surgery" do
+  EVOLVE_SOURCE = File.read(Hecksagain::Grammar::Evolve.syntax_path)
+
+  def with_copy
+    Dir.mktmpdir("evolve") do |dir|
+      path = File.join(dir, "syntax.bluebook")
+      File.write(path, EVOLVE_SOURCE)
+      yield path
+    end
+  end
+
+  it "reads every keyword row, absent status as admitted" do
+    with_copy do |path|
+      rows = Hecksagain::Grammar::Evolve.keyword_rows(path)
+      expect(rows.size).to be > 70
+      expect(rows.map { |row| row[:status] }.uniq).to eq(["admitted"])
+    end
+  end
+
+  it "proposes a word as one row, proposed, at the table's foot" do
+    with_copy do |path|
+      Hecksagain::Grammar::Evolve.propose(word: "annotate", context: "Aggregate",
+                                          fills: "description", path: path)
+      rows = Hecksagain::Grammar::Evolve.keyword_rows(path)
+      row = rows.find { |candidate| candidate[:word] == "annotate" }
+
+      expect(row).to eq(word: "annotate", context: "Aggregate", status: "proposed")
+      expect(rows.last).to eq(row)
+    end
+  end
+
+  it "refuses a second row for the same word and context" do
+    with_copy do |path|
+      Hecksagain::Grammar::Evolve.propose(word: "annotate", context: "Aggregate", path: path)
+
+      expect do
+        Hecksagain::Grammar::Evolve.propose(word: "annotate", context: "Aggregate", path: path)
+      end.to raise_error(Hecksagain::Grammar::Evolve::Refusal, /one row per/)
+    end
+  end
+
+  it "admits by removing the ceremony — an admitted row spells no status" do
+    with_copy do |path|
+      Hecksagain::Grammar::Evolve.propose(word: "annotate", context: "Aggregate", path: path)
+      Hecksagain::Grammar::Evolve.set_status(word: "annotate", context: "Aggregate",
+                                             to: "admitted", path: path)
+
+      line = File.read(path).lines.find { |l| l.include?('word: "annotate"') }
+      expect(line).not_to include("status:")
+      expect(Hecksagain::Grammar::Evolve.keyword_rows(path)
+               .find { |row| row[:word] == "annotate" }[:status]).to eq("admitted")
+    end
+  end
+
+  it "deprecates and retires by spelling the station" do
+    with_copy do |path|
+      Hecksagain::Grammar::Evolve.set_status(word: "then_set", context: "Command",
+                                             to: "deprecated", path: path)
+      row = Hecksagain::Grammar::Evolve.keyword_rows(path)
+                                       .find { |r| r[:word] == "then_set" && r[:context] == "Command" }
+      expect(row[:status]).to eq("deprecated")
+    end
+  end
+
+  it "refuses a station the language does not admit, and a word it does not hold" do
+    with_copy do |path|
+      expect do
+        Hecksagain::Grammar::Evolve.set_status(word: "then_set", context: "Command",
+                                               to: "banished", path: path)
+      end.to raise_error(Hecksagain::Grammar::Evolve::Refusal, /not a station/)
+
+      expect do
+        Hecksagain::Grammar::Evolve.set_status(word: "imagined", context: "Command",
+                                               to: "retired", path: path)
+      end.to raise_error(Hecksagain::Grammar::Evolve::Refusal, /not declared/)
+    end
+  end
+
+  it "touches nothing outside the Keyword one_of block" do
+    with_copy do |path|
+      Hecksagain::Grammar::Evolve.propose(word: "annotate", context: "Aggregate", path: path)
+      Hecksagain::Grammar::Evolve.set_status(word: "annotate", context: "Aggregate",
+                                             to: "retired", path: path)
+
+      before_block = EVOLVE_SOURCE[0...EVOLVE_SOURCE.index(/^\s*value_object "Keyword" do$/)]
+      after = File.read(path)
+      expect(after[0...before_block.size]).to eq(before_block)
+      expect(after).to include('value_object "Argument"')
+    end
+  end
+end

--- a/spec/evolve_spec.rb
+++ b/spec/evolve_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "the evolve surgery" do
       rows = Hecksagain::Grammar::Evolve.keyword_rows(path)
       row = rows.find { |candidate| candidate[:word] == "annotate" }
 
-      expect(row).to eq(word: "annotate", context: "Aggregate", status: "proposed")
+      expect(row).to eq(word: "annotate", context: "Aggregate", status: "proposed", was: nil)
       expect(rows.last).to eq(row)
     end
   end
@@ -66,18 +66,42 @@ RSpec.describe "the evolve surgery" do
 
   it "deprecates and retires by spelling the station" do
     with_copy do |path|
-      Hecksagain::Grammar::Evolve.set_status(word: "then_set", context: "Command",
+      Hecksagain::Grammar::Evolve.set_status(word: "given", context: "Command",
                                              to: "deprecated", path: path)
       row = Hecksagain::Grammar::Evolve.keyword_rows(path)
-                                       .find { |r| r[:word] == "then_set" && r[:context] == "Command" }
+                                       .find { |r| r[:word] == "given" && r[:context] == "Command" }
       expect(row[:status]).to eq("deprecated")
+    end
+  end
+
+  it "renames by respelling the row and holding the old spelling in was" do
+    with_copy do |path|
+      Hecksagain::Grammar::Evolve.rename(word: "emits", context: "Command", to: "announces", path: path)
+      rows = Hecksagain::Grammar::Evolve.keyword_rows(path)
+
+      expect(rows.find { |r| r[:word] == "announces" && r[:context] == "Command" }[:was]).to eq("emits")
+      expect(rows.none? { |r| r[:word] == "emits" && r[:context] == "Command" }).to be(true)
+    end
+  end
+
+  it "refuses a second rename hop, and a rename onto a living word" do
+    with_copy do |path|
+      Hecksagain::Grammar::Evolve.rename(word: "emits", context: "Command", to: "announces", path: path)
+
+      expect do
+        Hecksagain::Grammar::Evolve.rename(word: "announces", context: "Command", to: "declares", path: path)
+      end.to raise_error(Hecksagain::Grammar::Evolve::Refusal, /one rename hop/)
+
+      expect do
+        Hecksagain::Grammar::Evolve.rename(word: "given", context: "Command", to: "role", path: path)
+      end.to raise_error(Hecksagain::Grammar::Evolve::Refusal, /living word/)
     end
   end
 
   it "refuses a station the language does not admit, and a word it does not hold" do
     with_copy do |path|
       expect do
-        Hecksagain::Grammar::Evolve.set_status(word: "then_set", context: "Command",
+        Hecksagain::Grammar::Evolve.set_status(word: "given", context: "Command",
                                                to: "banished", path: path)
       end.to raise_error(Hecksagain::Grammar::Evolve::Refusal, /not a station/)
 

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -6675,6 +6675,50 @@
             [
               [
                 "name",
+                "proposed"
+              ]
+            ],
+            [
+              [
+                "name",
+                "admitted"
+              ]
+            ],
+            [
+              [
+                "name",
+                "deprecated"
+              ]
+            ],
+            [
+              [
+                "name",
+                "retired"
+              ]
+            ]
+          ],
+          "name": "Status"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "name",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": true,
+          "invariants": [
+
+          ],
+          "members": [
+            [
+              [
+                "name",
                 "text"
               ]
             ],
@@ -6775,6 +6819,15 @@
               "default": null,
               "list": false,
               "name": "fills",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            },
+            {
+              "admits": "Syntax::Status",
+              "default": "admitted",
+              "list": false,
+              "name": "status",
               "optional": false,
               "pattern": null,
               "type": "String"
@@ -8877,6 +8930,15 @@
               "default": null,
               "list": false,
               "name": "fills",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            },
+            {
+              "admits": "Syntax::Status",
+              "default": "admitted",
+              "list": false,
+              "name": "status",
               "optional": false,
               "pattern": null,
               "type": "String"
@@ -13213,6 +13275,6 @@
       "reference_target": "Bluebook"
     }
   ],
-  "version": null,
+  "version": "1",
   "vision": "The bluebook language, declared in itself. Loading a domain becomes dispatching commands into this meta-domain ; the IR it stores must equal the IR the DSL builder produces. The floor that stays hand-written is the interpreter — evaluating a predicate held as data — and IO."
 }

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -6831,6 +6831,15 @@
               "optional": false,
               "pattern": null,
               "type": "String"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "was",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
             }
           ],
           "closed_set": true,
@@ -7673,7 +7682,7 @@
             [
               [
                 "word",
-                "then_set"
+                "sets"
               ],
               [
                 "context",
@@ -7694,6 +7703,10 @@
               [
                 "fills",
                 "mutations"
+              ],
+              [
+                "was",
+                "then_set"
               ]
             ],
             [
@@ -10332,7 +10345,7 @@
             [
               [
                 "keyword",
-                "then_set"
+                "sets"
               ],
               [
                 "context",
@@ -10362,7 +10375,7 @@
             [
               [
                 "keyword",
-                "then_set"
+                "sets"
               ],
               [
                 "context",
@@ -10392,7 +10405,7 @@
             [
               [
                 "keyword",
-                "then_set"
+                "sets"
               ],
               [
                 "context",
@@ -10422,7 +10435,7 @@
             [
               [
                 "keyword",
-                "then_set"
+                "sets"
               ],
               [
                 "context",
@@ -10452,7 +10465,7 @@
             [
               [
                 "keyword",
-                "then_set"
+                "sets"
               ],
               [
                 "context",

--- a/spec/load_hygiene_spec.rb
+++ b/spec/load_hygiene_spec.rb
@@ -60,6 +60,30 @@ RSpec.describe "load hygiene" do
                       "#{broken.sort.join("\n")}"
   end
 
+  it "lets no two spec files disagree about a top-level constant" do
+    # A constant assigned inside an RSpec.describe block lands at TOP
+    # LEVEL — the block captures its file's lexical scope — so two spec
+    # files using the same constant name silently share one, last-loaded
+    # wins, and the loser fails somewhere else entirely (measured: a raw
+    # KEYWORDS here replaced a stringified KEYWORDS there and surfaced
+    # as an order-dependent NoMethodError two files away). Same name,
+    # same value is harmless and allowed; same name, different
+    # definition site with different content is the bug class.
+    definitions = Hash.new { |h, k| h[k] = [] }
+    Dir[File.join(ROOT_DIR, "spec", "**", "*_spec.rb")].sort.each do |file|
+      File.read(file).scan(/^  ([A-Z][A-Z_0-9]*) *=/) do |(name)|
+        definitions[name] << File.basename(file)
+      end
+    end
+
+    shared_values = %w[BANKING_BLUEBOOK ROOT_DIR]
+    colliding = definitions.select { |name, files| files.uniq.size > 1 && !shared_values.include?(name) }
+
+    expect(colliding).to be_empty,
+                         "spec files sharing a top-level constant name:\n" +
+                         colliding.map { |name, files| "  #{name}: #{files.uniq.join(', ')}" }.join("\n")
+  end
+
   it "loads the whole framework with the subsystem wrappers in reverse order" do
     wrappers = File.read(File.join(LIB, "hecksagain.rb"))
                .scan(%r{^require_relative "(hecksagain/[^"]+)"}).flatten

--- a/spec/operator_conformance_spec.rb
+++ b/spec/operator_conformance_spec.rb
@@ -1,0 +1,232 @@
+
+require "spec_helper"
+require "json"
+
+# The grammar chapter's Operator domain, made load-bearing — BY CHECKING.
+#
+# lib/hecksagain/grammar/expression.bluebook has always declared what an
+# operator IS: proposed until it reads in every target, admitted after,
+# retired when withdrawn. Nothing read it — docs/porting/grammar.md
+# called it "a content-management domain about operators, not the parser
+# itself", and the evaluator's tables were free to drift from it
+# (they did once, into DISJOINT sets — see vocabulary_conformance_spec's
+# header for that story).
+#
+# This spec closes the gap at this project's honest claim level,
+# agreement by checking: the admission ledger
+# (lib/hecksagain/grammar/expression_operators.json) is replayed through
+# the chapter's REAL commands — so every operator the evaluator runs
+# passed a live Admit, through the "reads in every target" guard, on
+# this very suite run — and the surviving admitted set is held equal to
+# the hardcoded tables, both directions. An operator added to the
+# evaluator without a ledger admission fails here; an admitted operator
+# the evaluator does not implement fails here; a proposed or retired
+# operator anywhere in a live table fails here, and that last line is
+# the milestone's whole claim.
+#
+# By-CONSTRUCTION (the evaluator building its table from the chapter) is
+# deliberately not attempted: the Prism adapter normalises every
+# predicate through CanonicalForm while a bluebook loads, so the
+# expression machinery cannot boot the chapter that would configure it —
+# that becomes a checked-in projection in a later milestone, the same
+# shape Rust already consumes.
+RSpec.describe "the operator domain" do
+  ROOT_DIR = InMemoryDomain::ROOT
+  LEDGER   = JSON.parse(File.read(File.join(ROOT_DIR, "lib/hecksagain/grammar/expression_operators.json"))).freeze
+  CHAPTER  = File.join(ROOT_DIR, "lib/hecksagain/grammar/expression.bluebook")
+
+  Evaluator     = Hecksagain::Bluebook::Expression::Evaluator
+  Resolver      = Hecksagain::Bluebook::Expression::Resolver
+  CanonicalForm = Hecksagain::Bluebook::Expression::CanonicalForm
+
+  # The same boot corpus_spec proves and bin/parity stages — fresh
+  # registry, ports and adapters loaded as data, the chapter itself,
+  # then a dispatcher over it. No facade: the ledger dispatches by FQN,
+  # the same path MetaValidator judges through.
+  def self.boot_expression
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.load(CHAPTER)
+    end
+    Hecksagain::Runtime::Dispatcher.new(registry)
+  end
+
+  def self.symbolize(value)
+    case value
+    when Hash  then value.to_h { |k, v| [k.to_sym, symbolize(v)] }
+    when Array then value.map { |v| symbolize(v) }
+    else value
+    end
+  end
+
+  # Replayed ONCE for the whole file, refusals collected rather than
+  # raised — a silently-refused Admit would shrink the admitted set and
+  # surface as a confusing direction-B failure two examples later.
+  DISPATCHER = boot_expression
+  REFUSALS = LEDGER["steps"].filter_map do |step|
+    begin
+      DISPATCHER.dispatch(step["verb"], **symbolize(step["args"]))
+      nil
+    rescue *Hecksagain::Runtime::DOMAIN_REFUSALS => refusal
+      "#{step['verb']} #{step['args']} — #{refusal.message}"
+    end
+  end.freeze
+
+  def self.records(aggregate_name)
+    registry  = DISPATCHER.registry
+    aggregate = registry.bluebook("Expression").aggregate(aggregate_name)
+    registry.repository("Expression", aggregate).all
+  end
+
+  OPERATORS = records("Operator").freeze
+  ADMITTED  = OPERATORS.select { |op| op[:status] == "admitted" }.freeze
+  RULES     = records("Normalisation").freeze
+
+  def admitted(category) = ADMITTED.select { |op| op[:category].value == category }
+  def symbols(ops)       = ops.map { |op| op[:symbol].value }
+
+  it "replays the admission ledger without a single refusal" do
+    expect(REFUSALS).to be_empty,
+                        "the ledger refused — an operator was admitted without reading in every " \
+                        "target, or a step no longer matches the chapter:\n  #{REFUSALS.join("\n  ")}"
+  end
+
+  it "admits exactly the comparison operators the evaluator runs, in check order" do
+    # ORDER included on purpose: grammar.md says declared order IS the
+    # grammar (the first pattern that matches wins), and Memory#all
+    # answers in insertion order, which is the ledger's Propose order.
+    expect(symbols(admitted("comparison"))).to eq(Evaluator::COMPARISONS)
+  end
+
+  it "closes the triangle — the admitted comparisons are Vocabulary::Comparison's" do
+    judged     = Hecksagain::Bluebook::MetaValidator.grammar_registry.bluebook("Bluebook")
+    vocabulary = judged.aggregates.find { |a| a.name == "Vocabulary" }
+    declared   = vocabulary.value_objects.find { |vo| vo.hecks_name == "Comparison" }
+                           .members.map { |row| row.to_h.values.first }
+
+    expect(symbols(admitted("comparison"))).to eq(declared)
+  end
+
+  it "lets no proposed or retired operator into any live table" do
+    # THE MILESTONE'S CLAIM. A proposed operator is not slower or gated —
+    # it does not exist to the evaluator until the ledger admits it, and
+    # a retired one stops existing the same way.
+    unadmitted = symbols(OPERATORS.reject { |op| op[:status] == "admitted" })
+    live       = Evaluator::COMPARISONS + PROBES.keys
+
+    expect(live & unadmitted).to be_empty,
+                                 "#{(live & unadmitted).inspect} run in a live table while the " \
+                                 "chapter holds them proposed or retired — admit them in the " \
+                                 "ledger or take them out of the machinery"
+  end
+
+  # The structural operators have no live constant — they ARE parse's
+  # cases — so each is held by a behavioral probe, and direction B is
+  # the probe table's keys equalling the admitted set.
+  PROBES = {
+    "||"        => -> { Evaluator.parse("a || b").is_a?(Evaluator::Or) },
+    "&&"        => -> { Evaluator.parse("a && b").is_a?(Evaluator::And) },
+    "!"         => -> { Evaluator.parse("!a").is_a?(Evaluator::Not) },
+    ".include?" => -> { Evaluator.parse("list.include?(x)").is_a?(Evaluator::Include) },
+    "+"         => -> { Resolver.parse("a + b").is_a?(Resolver::Addition) },
+    ".modulo"   => -> { Resolver.parse("a.modulo(b)").is_a?(Resolver::Modulo) }
+  }.freeze
+
+  it "implements every admitted structural operator, and no other" do
+    structural = symbols(ADMITTED) - symbols(admitted("comparison"))
+
+    expect(PROBES.keys.sort).to eq(structural.sort)
+    PROBES.each do |symbol, probe|
+      expect(probe.call).to be(true), "#{symbol} is admitted but the machinery no longer parses it"
+    end
+  end
+
+  it "orders precedence the way the grammar checks" do
+    # grammar.md: || binds loosest, then &&, then membership, then the
+    # comparison tier, then !. Precedence rises with binding tightness.
+    tiers = ["||", "&&", ".include?", ">=", "!"].map do |symbol|
+      ADMITTED.find { |op| op[:symbol].value == symbol }[:precedence].value
+    end
+    expect(tiers).to eq(tiers.sort)
+    expect(tiers.uniq).to eq(tiers)
+
+    expect(Evaluator.parse("a || b && c")).to be_a(Evaluator::Or)
+  end
+
+  it "renders every admitted operator in ruby AND rust — the guard's claim, strengthened" do
+    ADMITTED.each do |op|
+      targets = Array(op[:renderings]).map { |rendering| rendering[:target] }
+      expect(targets).to include("ruby", "rust"),
+                         "#{op[:symbol].value} was admitted reading in #{targets.inspect} — " \
+                         "every target means ruby and rust both"
+    end
+  end
+
+  it "appears, comparison for comparison, in the table Rust embeds" do
+    rust_table = JSON.parse(File.read(File.join(ROOT_DIR, "rust/src/bluebook/expression/operators.json")))
+    rust_symbols = rust_table.map { |row| row.fetch("symbol") }
+
+    expect(rust_symbols).to eq(symbols(admitted("comparison")))
+  end
+
+  it "admits exactly the normalisation rules canonical form applies, field for field" do
+    admitted_rules = RULES.select { |rule| rule[:status] == "admitted" }.sort_by { |rule| rule[:position].value }
+    read_back = admitted_rules.map do |rule|
+      { strategy: rule[:strategy].value, source_token: rule[:source_token].value,
+        replacement: rule[:replacement].value, boundary: rule[:boundary].value,
+        position: rule[:position].value.to_s }
+    end
+
+    expect(read_back).to eq(CanonicalForm.table)
+  end
+
+  it "keeps the chapter's own Rule set equal to the live rules — no third copy" do
+    declared = DISPATCHER.registry.bluebook("Expression").aggregate("Normalisation")
+                         .value_object("Rule").members.map(&:to_h)
+
+    expect(declared).to eq(CanonicalForm::RULES.map { |rule| rule.to_h })
+  end
+
+  describe "the gates, seen refusing" do
+    it "refuses to admit an operator that does not read in every target" do
+      throwaway = self.class.boot_expression
+      throwaway.dispatch("Expression::Operator.Propose",
+                         symbol: { value: "**" }, category: { value: "arithmetic" },
+                         precedence: { value: 6 }, arity: { value: 2 })
+
+      expect { throwaway.dispatch("Expression::Operator.Admit", symbol: { value: "**" }) }
+        .to raise_error(Hecksagain::Runtime::GivenNotMet,
+                        /an operator must read in every target before it is admitted/)
+    end
+
+    it "refuses a rendering on a retired operator" do
+      throwaway = self.class.boot_expression
+      throwaway.dispatch("Expression::Operator.Propose",
+                         symbol: { value: "**" }, category: { value: "arithmetic" },
+                         precedence: { value: 6 }, arity: { value: 2 })
+      throwaway.dispatch("Expression::Operator.Render",
+                         symbol: { value: "**" }, target: { value: "ruby" }, form: { value: "a ** b" })
+      throwaway.dispatch("Expression::Operator.Render",
+                         symbol: { value: "**" }, target: { value: "rust" }, form: { value: "a ** b" })
+      throwaway.dispatch("Expression::Operator.Admit",  symbol: { value: "**" })
+      throwaway.dispatch("Expression::Operator.Retire", symbol: { value: "**" })
+
+      expect do
+        throwaway.dispatch("Expression::Operator.Render",
+                           symbol: { value: "**" }, target: { value: "go" }, form: { value: "a ** b" })
+      end.to raise_error(Hecksagain::Runtime::GivenNotMet, /a retired operator takes no new renderings/)
+    end
+
+    it "gives a spelling the ledger never admitted the ordinary unknown refusal" do
+      # Not a slow operator, not a gated operator — NOT AN OPERATOR. The
+      # refusal is the same one any unresolvable spelling gets; nothing
+      # about the lifecycle invents a third wording for parity to hold.
+      expect { Evaluator.call("a ** b", {}) }
+        .to raise_error(Hecksagain::Bluebook::Expression::EvaluationError, /cannot resolve/)
+    end
+  end
+end

--- a/spec/operator_conformance_spec.rb
+++ b/spec/operator_conformance_spec.rb
@@ -191,6 +191,25 @@ RSpec.describe "the operator domain" do
     expect(declared).to eq(CanonicalForm::RULES.map { |rule| rule.to_h })
   end
 
+  it "admits every operator the language itself stands on" do
+    # THE SELF-BEARING SET, derived rather than remembered: every guard
+    # and invariant in the language's own chapters evaluates through the
+    # operator table this ledger admits, so retiring one of THOSE
+    # operators would leave the language unable to read its own rules —
+    # found the hard way, as a projection missing != that could not boot
+    # the chapter to fix itself. bin/expression_projection refuses to
+    # write such a projection; this is the same refusal, in-suite, ahead
+    # of any regeneration.
+    require "hecksagain/grammar"
+    stranded = Hecksagain::Grammar.self_bearing_operators
+                                  .reject { |symbol, _| symbols(ADMITTED).include?(symbol) }
+
+    expect(stranded).to be_empty,
+                        stranded.map { |symbol, sites|
+                          "#{symbol} is self-bearing (#{sites.first(2).join('; ')}) and not admitted"
+                        }.join("\n")
+  end
+
   describe "the gates, seen refusing" do
     it "refuses to admit an operator that does not read in every target" do
       throwaway = self.class.boot_expression

--- a/spec/operators_export_spec.rb
+++ b/spec/operators_export_spec.rb
@@ -10,8 +10,9 @@ require "json"
 # checked-in file equal to what its script produces right now.
 RSpec.describe "the exported tables" do
   {
-    "rust/src/bluebook/expression/operators.json" => "bin/operators",
-    "rust/src/runtime/mutation_ops.json"           => "bin/mutation_ops"
+    "rust/src/bluebook/expression/operators.json"      => "bin/operators",
+    "rust/src/runtime/mutation_ops.json"               => "bin/mutation_ops",
+    "lib/hecksagain/bluebook/expression/projection.json" => "bin/expression_projection --stdout"
   }.each do |checked_in_path, script|
     it "#{checked_in_path} matches #{script}'s current output" do
       root       = InMemoryDomain::ROOT

--- a/spec/syntax_conformance_spec.rb
+++ b/spec/syntax_conformance_spec.rb
@@ -224,7 +224,8 @@ RSpec.describe "the declared syntax" do
     next if builder.equal?(D::AttributeCollector)
 
     it "declares every word #{builder} answers (#{contexts.join(', ')})" do
-      declared = contexts.flat_map { |ctx| declared_in(ctx).map { |row| row[:word].to_sym } }.uniq
+      declared = contexts.flat_map { |ctx| declared_in(ctx).flat_map { |row| [row[:word], row[:was].to_s].reject(&:empty?) } }
+                         .map(&:to_sym).uniq
 
       if builder.is_a?(Class) && builder.include?(D::AttributeCollector)
         declared += LIVE_KEYWORDS.select { |row| row[:context] == "Type" }
@@ -239,6 +240,31 @@ RSpec.describe "the declared syntax" do
                                             "a bluebook could use them and nothing projected from the " \
                                             "language would know they exist"
     end
+  end
+
+  # THE RENAME COLUMN'S OWN GATES. A live row carrying `was:` is a word
+  # the language RESPELLED — and the promise of the column is that the
+  # old era keeps booting: the builder answers both spellings, the old
+  # spelling is not smuggled back in as its own row, and nothing renames
+  # a word to itself.
+  it "answers every renamed word in both its spellings" do
+    LIVE_KEYWORDS.reject { |row| row[:was].to_s.empty? }.each do |row|
+      answered = self.class.words_answered_by(row[:context])
+      expect(answered).to include(row[:word].to_sym),
+                          "#{row[:context]}.#{row[:word]} — the new spelling has no builder"
+      expect(answered).to include(row[:was].to_sym),
+                          "#{row[:context]}.#{row[:word]} was #{row[:was]}, and the old "                           "spelling stopped parsing — a rename never strands the old era"
+      expect(row[:was]).not_to eq(row[:word]), "#{row[:context]}.#{row[:word]} renames itself"
+    end
+  end
+
+  it "keeps no renamed-away spelling as a row of its own" do
+    respelled = KEYWORDS.reject { |row| row[:was].to_s.empty? }
+                        .map { |row| [row[:was], row[:context]] }
+    ghosts = respelled & KEYWORDS.map { |row| [row[:word], row[:context]] }
+
+    expect(ghosts).to be_empty,
+                      "old spellings declared twice — as was: and as a row: #{ghosts.inspect}"
   end
 
   # THE LIFECYCLE'S OWN TWO DIRECTIONS. A proposed word is declared and

--- a/spec/syntax_conformance_spec.rb
+++ b/spec/syntax_conformance_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe "the declared syntax" do
   BODIES        = rows("Body").map { |row| row[:name] }
   ARGUMENT_KIND = rows("ArgumentKind").map { |row| row[:name] }
 
+  # A word's LIFE decides which gates hold it. Admitted and deprecated
+  # words are LIVE — a builder answers them, and every builder⇄row gate
+  # below runs over these. A proposed word has no builder YET and a
+  # retired one has no builder ANY MORE, so holding either to a builder
+  # would make the lifecycle unusable: bin/evolve could never land a
+  # proposal green. They get their own gates instead (the last two
+  # examples of the word⇄builder section). An absent status reads as
+  # admitted — the grown-column convention, see syntax_lifecycle_spec.
+  def self.status_of(row) = row[:status].to_s.empty? ? "admitted" : row[:status].to_s
+
+  def self.live?(row) = %w[admitted deprecated].include?(status_of(row))
+
+  LIVE_KEYWORDS  = KEYWORDS.select { |row| live?(row) }
+  LIVE_KEYS      = LIVE_KEYWORDS.map { |row| [row[:word], row[:context]] }.uniq
+  LIVE_ARGUMENTS = ARGUMENTS.select { |row| live?(row) && LIVE_KEYS.include?([row[:keyword], row[:context]]) }
+
   # WHERE EACH CONTEXT'S WORDS ARE ANSWERED. `File` is the only one not answered
   # by a builder — `Hecks.bluebook` is reached through a module — and `Type` is
   # the only one whose "builder" is a mixin rather than a class, because the type
@@ -136,7 +152,7 @@ RSpec.describe "the declared syntax" do
     builder.instance_method(word)
   end
 
-  def declared_in(context) = KEYWORDS.select { |row| row[:context] == context }
+  def declared_in(context) = LIVE_KEYWORDS.select { |row| row[:context] == context }
 
   # ---------------------------------------------------------------- the cells
 
@@ -211,7 +227,7 @@ RSpec.describe "the declared syntax" do
       declared = contexts.flat_map { |ctx| declared_in(ctx).map { |row| row[:word].to_sym } }.uniq
 
       if builder.is_a?(Class) && builder.include?(D::AttributeCollector)
-        declared += KEYWORDS.select { |row| row[:context] == "Type" }
+        declared += LIVE_KEYWORDS.select { |row| row[:context] == "Type" }
                             .map { |row| row[:word].to_sym }
                             .select { |word| builder.instance_method(word).owner.equal?(D::AttributeCollector) }
       end
@@ -225,6 +241,28 @@ RSpec.describe "the declared syntax" do
     end
   end
 
+  # THE LIFECYCLE'S OWN TWO DIRECTIONS. A proposed word is declared and
+  # not yet implemented — a builder already answering it means it earned
+  # admission, and the row should say so. A retired word is the reverse:
+  # a builder still answering it means it never actually left.
+  it "leaves every proposed word unanswered — answered means admit it" do
+    early = KEYWORDS.select { |row| self.class.status_of(row) == "proposed" }
+                    .select { |row| self.class.words_answered_by(row[:context]).include?(row[:word].to_sym) }
+
+    expect(early).to be_empty,
+                     early.map { |row| "#{row[:context]}.#{row[:word]}" }.join(", ") +
+                     " — proposed, but the builder already answers; run bin/evolve admit"
+  end
+
+  it "leaves every retired word unanswered — answered means it never left" do
+    lingering = KEYWORDS.select { |row| self.class.status_of(row) == "retired" }
+                        .select { |row| self.class.words_answered_by(row[:context]).include?(row[:word].to_sym) }
+
+    expect(lingering).to be_empty,
+                         lingering.map { |row| "#{row[:context]}.#{row[:word]}" }.join(", ") +
+                         " — retired, but the builder still answers"
+  end
+
   # ------------------------------------------------------ arguments ⇄ signature
 
   it "joins every argument row to a word" do
@@ -235,7 +273,7 @@ RSpec.describe "the declared syntax" do
   end
 
   it "declares every keyword argument each word's builder takes, and no other" do
-    ARGUMENTS.group_by { |row| [row[:keyword], row[:context]] }.each do |(word, context), args|
+    LIVE_ARGUMENTS.group_by { |row| [row[:keyword], row[:context]] }.each do |(word, context), args|
       params  = method_for(word, context).parameters
       taken   = params.select { |kind, _| %i[key keyreq].include?(kind) }.map { |_, name| name.to_s }
       spelled = args.reject { |row| row[:named].empty? }.map { |row| row[:named] }.uniq
@@ -251,7 +289,7 @@ RSpec.describe "the declared syntax" do
   end
 
   it "declares no more positionals than each word's builder takes" do
-    ARGUMENTS.group_by { |row| [row[:keyword], row[:context]] }.each do |(word, context), args|
+    LIVE_ARGUMENTS.group_by { |row| [row[:keyword], row[:context]] }.each do |(word, context), args|
       positional = args.reject { |row| row[:at].empty? }
       next if positional.empty?
 
@@ -275,7 +313,7 @@ RSpec.describe "the declared syntax" do
   # checked one way on purpose: an optional parameter may be declared required,
   # but a required one may never be declared optional.
   it "never calls an argument optional that the builder demands" do
-    ARGUMENTS.group_by { |row| [row[:keyword], row[:context]] }.each do |(word, context), args|
+    LIVE_ARGUMENTS.group_by { |row| [row[:keyword], row[:context]] }.each do |(word, context), args|
       params = method_for(word, context).parameters
 
       params.each_with_index do |(kind, name), index|

--- a/spec/syntax_lifecycle_spec.rb
+++ b/spec/syntax_lifecycle_spec.rb
@@ -1,0 +1,92 @@
+
+require "spec_helper"
+
+# Every word of the bluebook surface now stands somewhere in its own
+# life — the same proposed → admitted → retired shape the expression
+# grammar's operators carry, plus `deprecated` (still read, on its way
+# out). A row defaults to admitted, so the syntax table stays a table of
+# words; only a word entering or leaving the language spells its status.
+#
+# (Constants here carry unique names on purpose: a constant assigned
+# inside an RSpec.describe block lands at TOP LEVEL — the block captures
+# its file's lexical scope — so a KEYWORDS here silently replaced
+# syntax_conformance_spec's stringified KEYWORDS for every file loaded
+# after it. Found as an order-dependent NoMethodError two files away.)
+#
+# What makes the status LOAD-BEARING rather than decorative is the
+# projection rule this file pins: a proposed or retired word reaches no
+# generated parser table (bin/ir_syntax, bin/ir_syntax_flags,
+# bin/ir_dispatch_words all reject them), so to every projected reader
+# such a word simply does not exist — the operator rule, applied at the
+# syntax layer. The language also declares its own VERSION now, on the
+# chapter itself, bumped when the admitted surface changes.
+RSpec.describe "the syntax lifecycle" do
+  def self.judged_meta = Hecksagain::Bluebook::MetaValidator.grammar_registry.bluebook("Bluebook")
+
+  def self.syntax = judged_meta.aggregates.find { |a| a.hecks_name == "Syntax" }
+
+  def self.rows(name)
+    syntax.value_objects.find { |vo| vo.hecks_name == name }.members.map(&:to_h)
+  end
+
+  WORD_STATUSES  = rows("Status").map { |row| row[:name] }
+  WORD_ROWS  = rows("Keyword")
+  ARGUMENT_ROWS = rows("Argument")
+  DECLARED_LANGUAGE_VERSION = judged_meta.version
+
+  # AN ABSENT STATUS READS AS ADMITTED — the same convention hecks_eras
+  # uses for a column grown after rows existed (canon_form NULL reads as
+  # an implicit 1). Spelling `status: "admitted"` on 197 rows would bury
+  # the table in ceremony, and applying the attribute DEFAULT to member
+  # rows on the Ruby side only would hand the golden IR a field Rust's
+  # parser does not mint — an IR-parity split bought for nothing. Only a
+  # word entering or leaving the language spells its status.
+  def self.status_of(row) = row[:status].to_s.empty? ? "admitted" : row[:status].to_s
+  def status_of(row)      = self.class.status_of(row)
+
+  it "declares the four stations of a word's life" do
+    expect(WORD_STATUSES).to eq(%w[proposed admitted deprecated retired])
+  end
+
+  it "gives every keyword and argument a status the set admits" do
+    (WORD_ROWS + ARGUMENT_ROWS).each do |row|
+      expect(WORD_STATUSES).to include(status_of(row)),
+                          "#{row[:word] || row[:keyword]} in #{row[:context]} carries " \
+                          "status #{row[:status].inspect}, which the language does not admit"
+    end
+  end
+
+  it "keeps every current word admitted — nothing is mid-transition" do
+    # The day a word is proposed or deprecated, this example changes with
+    # it, deliberately: a transition should be visible in the suite, not
+    # only in the table.
+    in_transition = (WORD_ROWS + ARGUMENT_ROWS).reject { |row| status_of(row) == "admitted" }
+    expect(in_transition).to be_empty,
+                             "words mid-transition: " \
+                             "#{in_transition.map { |row| row[:word] || row[:keyword] }.inspect}"
+  end
+
+  it "projects no proposed or retired word into any generated table" do
+    # The generators reject them at the source; this holds the rule from
+    # the reading side by deriving what each table WOULD hold and
+    # asserting the invisible statuses are absent from all of it.
+    visible = WORD_ROWS.reject { |row| %w[proposed retired].include?(status_of(row)) }
+                      .map { |row| row[:word] }
+    hidden = WORD_ROWS.map { |row| row[:word] } - visible
+
+    root = InMemoryDomain::ROOT
+    projections = [
+      `#{File.join(root, 'bin/ir_syntax')}`,
+      `#{File.join(root, 'bin/ir_dispatch_words')}`
+    ].join("\n")
+
+    hidden.each do |word|
+      expect(projections).not_to match(/"#{Regexp.escape(word)}"/),
+                                 "#{word} is proposed or retired and still reaches a projection"
+    end
+  end
+
+  it "declares the language's own version" do
+    expect(DECLARED_LANGUAGE_VERSION).to eq("1")
+  end
+end

--- a/spec/syntax_lifecycle_spec.rb
+++ b/spec/syntax_lifecycle_spec.rb
@@ -56,15 +56,13 @@ RSpec.describe "the syntax lifecycle" do
     end
   end
 
-  it "keeps every current word admitted — nothing is mid-transition" do
-    # The day a word is proposed or deprecated, this example changes with
-    # it, deliberately: a transition should be visible in the suite, not
-    # only in the table.
-    in_transition = (WORD_ROWS + ARGUMENT_ROWS).reject { |row| status_of(row) == "admitted" }
-    expect(in_transition).to be_empty,
-                             "words mid-transition: " \
-                             "#{in_transition.map { |row| row[:word] || row[:keyword] }.inspect}"
-  end
+  # ("Nothing mid-transition" was pinned here once — an empty-set gate on
+  # any non-admitted row. bin/evolve made it wrong: a proposal must be able
+  # to land green. Its job passed to syntax_conformance_spec's lifecycle
+  # directions — a proposed word must be UNANSWERED by its builder, a
+  # retired one must be unanswered again, and a live word is held to the
+  # builder exactly as before. The suite still names every transition; it
+  # just no longer forbids being in one.)
 
   it "projects no proposed or retired word into any generated table" do
     # The generators reject them at the source; this holds the rule from


### PR DESCRIPTION
## Summary

The full LOP/language-evolution arc, one commit per milestone. hecksagain treats itself as what it is — a language — and now applies its own discipline (declared, checked, projected, era'd) to its own words.

**M1 — Operators load-bearing by checking** (`8f4cdbe`). The grammar chapter's `Operator` lifecycle stops being decorative: an admission ledger (`lib/hecksagain/grammar/expression_operators.json`, parity step format) replays all 12 operators and both canonical-form rules through the chapter's own `Propose → Render(ruby) → Render(rust) → Admit` commands on every suite run; `spec/operator_conformance_spec.rb` (13 examples) holds the evaluator's tables to the admitted set both directions, closes the triangle with `Vocabulary::Comparison`, and pins that a proposed operator gets the *ordinary* unknown refusal — it doesn't exist.

**M2 — By-projection** (`4ffe1a6`). Checking becomes construction: the evaluator's operator table and canonical form's rules READ `lib/hecksagain/bluebook/expression/projection.json`, regenerated from the admitted set by `bin/expression_projection`; `bin/operators` derives from the domain too (byte-identical output — Rust untouched), joining the vocabulary's algebra. The dual authority is explicitly linked: the domain owns WHICH/ORDER, `Vocabulary::Comparison` owns WHAT-IT-COMPUTES, the generators are the join. Two measured findings documented where they bite: a generator whose output is its own boot input can never be shell-redirected, and `!=` is load-bearing for the chapter's own guards — a word the self-description uses cannot simply be retired.

**M3 — Word lifecycle + language version** (`c1e6aa0`). Every Keyword/Argument row carries `proposed/admitted/deprecated/retired` (absent reads as admitted — the grown-column convention); the three syntax projections reject proposed/retired rows; the chapter declares `version: "1"`. Golden moved +63 lines, suite-first; Rust parses the grown chapter identically unchanged.

**M4 — bin/evolve** (`18982dc`). The many-file word-change convention as a tool: `propose/admit/deprecate/retire`, each snapshotting, rewriting the row, regenerating projections + golden, running the gates, and restoring byte-for-byte on red with the failures as the checklist. Gates became lifecycle-aware: live words held to builders as before; a proposed word must be UNANSWERED (answered means admit it), a retired word unanswered again. Proven by driving it both directions.

**M5 — Language eras: `was:`** (`3e1cef5`). A renamed word keeps its old spelling in `was:`; the old spelling stays answered, parsed, and projected forever. Proven by a real rename — `sets` (was `then_set`) — with **not one corpus bluebook touched**: every example still spells `then_set` and the full parity run is the demonstration that a rename strands nothing. Identical-IR twins on both sides (`spec/dsl_spec.rb`, `rust/tests/sets_rename_test.rs`); `bin/evolve rename` with one-hop discipline.

**Follow-up — the discoveries become gates** (`10b39eb`). The three hard-way findings now refuse by name: `Grammar.self_bearing_operators` derives the operators the language's own predicates evaluate through (nine of twelve — including a `Translation Rule.Execute` use of `!=` nobody had catalogued), and both the generator and the conformance spec refuse a projection that strands one; `bin/expression_projection --bootstrap` rebuilds stage zero from the ledger alone, before any require, so a broken projection repairs itself (proven: garbage file → dead boot → bootstrap → byte-identical fixpoint); and `load_hygiene_spec` grew a tripwire for the RSpec top-level-constant trap. The bootstrap cycle itself stays — a self-describing language needs a stage zero the way a compiler does; breaking it is now recoverable and narrowing it is refused.

## Test plan
- [x] `bundle exec rspec` — 808 examples, 0 failures (774 → 808 across the arc)
- [x] `cargo test --release --workspace` — 15 test targets green, including the new rename test
- [x] `bin/parity` — AGREED across all runtimes and the Postgres era dance, after every milestone
- [x] Red-first / mutation verification at each milestone (ledger-minus-!=, fake evaluator operator, unimplemented-word admit refusal)
- [x] Pre-push hook re-ran parity on every push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cJcet8Ng4SdCSYhMkUnJL