### PR TITLE
Reaction defect isolation + JsonDoor facade

### DIFF
--- a/lib/hecksagain/facade.rb
+++ b/lib/hecksagain/facade.rb
@@ -40,3 +40,4 @@ end
 
 require_relative "facade/handle"
 require_relative "facade/surface"
+require_relative "facade/json_door"

--- a/lib/hecksagain/facade/json_door.rb
+++ b/lib/hecksagain/facade/json_door.rb
@@ -1,0 +1,144 @@
+require "json"
+require_relative "handle"
+require_relative "../naming"
+require_relative "../runtime/errors"
+require_relative "../runtime/value"
+
+module Hecksagain
+  module Facade
+    # THE JSON DOOR — WHERE Facade MEETS BODY-IN/BODY-OUT CALLERS.
+    #
+    # `Handle`/`Surface` are Ruby sugar over the dispatcher for a Ruby caller
+    # holding real objects — a symbol verb name, a `**kwargs` payload, a
+    # `Handle` back in hand. A REST-ish JSON API is a caller holding STRINGS
+    # instead: a URL segment naming a collection, a URL segment naming a
+    # record or a verb, a parsed request body whose every key arrived as a
+    # String because that is all JSON ever gives. Every app that wants to put
+    # a JSON API in front of a booted domain has to do that translation —
+    # name to class, string to symbol, nested `Runtime::Value` back to plain
+    # data — and one sibling app had already hand-written it once, bespoke,
+    # against its own routes, before this existed. This is that translation
+    # pulled out, generic, reading the SAME IR the rest of the facade already
+    # reads rather than re-deriving "how do I find an aggregate by name".
+    #
+    # NO HTTP LIVES HERE. Same discipline `Router` and `Surface` already
+    # hold: this module never sees a request object, never picks a status
+    # code, never calls `halt`. Every method here takes plain Ruby values in
+    # — a raw JSON String is the one exception, see `.parse` below, every
+    # other input is already-parsed data — and returns plain Ruby values
+    # out, or raises. Turning a raw request body into that input, and
+    # turning a raised exception into an HTTP status, both stay the calling
+    # app's job, exactly the way they already are for `Router#dispatch`.
+    #
+    # EVERY "THAT DOESN'T EXIST" CASE RAISES `Runtime::NotFound` — THE SAME
+    # CLASS EVERY TIME, NOT A NEW ONE PER CALLER. `Runtime::NotFound` already
+    # sits in `Runtime::DOMAIN_REFUSALS` (runtime/errors.rb) — the family a
+    # booted app already has, or trivially can have, ONE generic `error`
+    # handler for, mapping the whole family to a status code without a
+    # special case per refusal. A bespoke `JsonDoor::CollectionNotFound` (or
+    # three of those, one per flavor of "not found") would just force every
+    # app that adopts this door to widen its rescue clause to match it — the
+    # opposite of what a shared refusal family is for. So "no such
+    # aggregate", "no creating command", "no such command", and "no record
+    # with that id" all raise the one class, distinguished only by message.
+    module JsonDoor
+      module_function
+
+      # "Banking", "Customer" -> the `Banking::Customer` class `.find` /
+      # `.create_...` / etc already answer for — the same class
+      # `Facade::Handle`'s own reference accessors reach with
+      # `Object.const_get` (see handle.rb's `define_reference_accessors`).
+      #
+      # Checked against the CURRENT boot's IR first, not against Ruby's
+      # constant table directly — a name that names nothing in this
+      # registry should refuse before ever asking Ruby whether some
+      # same-named constant happens to exist (possibly a stale one, left
+      # over from an earlier boot in this same process — the exact hazard
+      # `AggregateDoor#port`'s own comment describes at length). Only once
+      # the IR confirms the aggregate is real does this read the constant
+      # the current boot's `Surface.install` actually minted for it.
+      def aggregate(dispatcher, domain, name)
+        ir = dispatcher.registry.bluebook(domain)&.aggregate(name)
+        raise Runtime::NotFound, "#{domain} declares no aggregate named #{name.inspect}" unless ir
+
+        Object.const_get("#{domain}::#{ir.hecks_name}")
+      end
+
+      # The one command a POST to a bare collection URL means — "make one of
+      # these". `AggregateDoor` already enforces exactly one creating
+      # command per aggregate (`IR::Command#creates?`, true exactly when the
+      # command declares no `references`); this just names it the same
+      # snake_case a Ruby caller would already ask the door for
+      # (`Naming.snake`, the identical call `AggregateDoor` itself makes
+      # when it defines that singleton method in the first place).
+      def creating_command(klass)
+        creating = klass.ir.commands.find(&:creates?)
+        raise Runtime::NotFound, "#{klass.ir.hecks_name} declares no creating command" unless creating
+
+        Naming.snake(creating.hecks_name)
+      end
+
+      # A URL segment or a JSON body's "command" field, checked against what
+      # the aggregate actually declares. `klass.commands` is the same
+      # sorted, snake_cased list `AggregateDoor` built for its own door, so
+      # a name this accepts is a name a `Handle` can actually dispatch.
+      def validate_command!(klass, name)
+        wanted = name.to_s
+        return wanted if klass.commands.include?(wanted)
+
+        raise Runtime::NotFound, "#{klass.ir.hecks_name} declares no command named #{wanted.inspect}"
+      end
+
+      # `klass.find` already answers nil-on-miss — the right shape for a
+      # Ruby caller that means to check for itself. A JSON caller asking for
+      # one record by id off a URL means to HAVE it, or answer 404 — this is
+      # that stricter wrapper, raising the same `Runtime::NotFound` the rest
+      # of this door raises rather than handing back nil for the caller to
+      # remember to check.
+      def find!(klass, id)
+        klass.find(id) or raise Runtime::NotFound, "no #{klass.ir.hecks_name} found for id #{id.inspect}"
+      end
+
+      # JSON only ever hands back String keys. A command's args, and every
+      # nested value-object literal inside them, need symbol keys before
+      # `Handle`/`Dispatcher` will accept them at all — this is that
+      # recursive conversion, blind to how deep a body nests.
+      def deep_symbolize(value)
+        case value
+        when Hash  then value.to_h { |k, v| [k.to_sym, deep_symbolize(v)] }
+        when Array then value.map { |item| deep_symbolize(item) }
+        else value
+        end
+      end
+
+      # The other direction: a `Handle`, or a query row's plain state hash,
+      # carrying a `Runtime::Value` at every level a value object sits at —
+      # down to plain Ruby a JSON encoder can walk without knowing what a
+      # `Runtime::Value` is.
+      #
+      # `Runtime::Value.materialize` (runtime/value.rb) already does the
+      # actual recursion — its `Hash` branch calls itself on every value,
+      # its `Value` branch unwraps through `#to_h`, which itself calls
+      # `materialize` on every field, so a value object three levels deep
+      # unwraps three levels deep for free. This is not a second unwrapper
+      # sitting next to it: `materialize` covers `Hash`/`Array`/`Value`
+      # already, and a `Handle` is none of those three, so the one thing
+      # this adds is `#to_h`'ing a `Handle` first so `materialize`'s own
+      # `Hash` case can take it from there.
+      def materialize(value)
+        value = value.to_h if value.is_a?(Handle)
+        Runtime::Value.materialize(value)
+      end
+
+      # The one place a raw JSON string is legitimate input for this door —
+      # a POST body, still text at the point a generic, HTTP-blind layer can
+      # see it. `JSON::ParserError` already names "this wasn't JSON" exactly
+      # right ; wrapping it in a bespoke `JsonDoor`-specific class would
+      # only be a second name for the same fact, so it propagates exactly as
+      # `JSON.parse` raises it — a calling app catches it the same standard
+      # way it would catch any other malformed-input error, no new class to
+      # learn.
+      def parse(raw_json) = JSON.parse(raw_json)
+    end
+  end
+end

--- a/lib/hecksagain/runtime/policy_interpreter.rb
+++ b/lib/hecksagain/runtime/policy_interpreter.rb
@@ -45,12 +45,38 @@ module Hecksagain
         record.merge(delivered: true)
       rescue *DOMAIN_REFUSALS => error
         # The target refused — a fact about the domain, recorded and not
-        # fatal to the command that emitted the event. Anything else (a
-        # NoMethodError in an interpreter, an unknown verb in the policy's
-        # own declaration) is a DEFECT and flies : it used to land here too,
-        # as `delivered: false` beside every legitimate refusal, which made
-        # a crashed runtime read as normal operation.
+        # fatal to the command that emitted the event.
         record.merge(delivered: false, reason: error.message)
+      rescue StandardError => error
+        # A DEFECT, not a refusal — a NoMethodError in an interpreter, a
+        # NameError from a missing constant, a TypeError from a bad
+        # assumption : exactly the class of thing DOMAIN_REFUSALS
+        # (errors.rb, see the comment above that constant) deliberately
+        # excludes, and for the reason that comment gives at length —
+        # folding a crash into the same `delivered: false` shape as an
+        # ordinary refusal makes a broken runtime read as normal operation
+        # in the log. This clause does not reopen that hole: it is a
+        # SECOND, narrower rescue, tried only once the first one above has
+        # already declined to match, so a legitimate refusal still takes
+        # the branch above and a defect always takes this one.
+        #
+        # Catching it HERE is safe for a fact this method's caller cannot
+        # see from where it sits: by the time `react` runs, the command
+        # that EMITTED `event` has already succeeded and PERSISTED —
+        # `Dispatcher#dispatch` calls `@policies.react` only after its own
+        # `announced` events are already in hand. Letting this exception
+        # keep propagating would not undo that command (nothing here is
+        # transactional across aggregates) — it would only blow up the
+        # ORIGINAL caller's `dispatch` call for a failure that happened in
+        # a DIFFERENT command, one the caller never asked to run and has no
+        # way to compensate for. So the defect is recorded, distinguishably
+        # (`defect: true`, plus the error's own class — nothing here is
+        # allowed to read like an ordinary refusal), warned to STDERR so it
+        # is never silent, and left exactly where it happened for a human
+        # to find — never re-raised, and never swallowed either.
+        warn "[hecksagain] defect in reaction — policy #{policy.name} on #{event.name} " \
+             "firing #{target}: #{error.class}: #{error.message}"
+        record.merge(delivered: false, reason: error.message, defect: true, error_class: error.class.name)
       end
     end
   end

--- a/lib/hecksagain/runtime/saga_interpreter.rb
+++ b/lib/hecksagain/runtime/saga_interpreter.rb
@@ -93,11 +93,36 @@ module Hecksagain
           @registry.saga_log << record.merge(delivered: true)
         rescue *DOMAIN_REFUSALS => error
           # Same rule as the policy interpreter : a refusal by the target is
-          # a recorded outcome ; a defect in the runtime is not, and now
-          # flies instead of being written into the saga log as though the
-          # step had simply been declined.
+          # a recorded outcome, and the leg that raised it UNWINDS — see
+          # `unwind`'s own comment for why the procedure runs its
+          # compensation here rather than leaving the money (or whatever
+          # else a leg moved) sitting out.
           @registry.saga_log << record.merge(delivered: false, reason: error.message)
           unwind(pm, event, instance, correlation, domain)
+        rescue StandardError => error
+          # A DEFECT, not a refusal — see PolicyInterpreter#deliver's own
+          # comment for the full reasoning: the same DOMAIN_REFUSALS split,
+          # and the same "the triggering command already succeeded and
+          # persisted by the time this runs" fact that makes catching it
+          # here safe rather than reckless. Recorded distinguishably
+          # (`defect: true`, plus the error's own class) and warned to
+          # STDERR rather than left to blow up the ORIGINAL dispatch that
+          # started this saga leg.
+          #
+          # DELIBERATELY DOES NOT `unwind`, unlike the branch above — that
+          # is this method's one asymmetry with the policy interpreter's.
+          # `unwind` runs the domain's OWN `on :refused` compensation, which
+          # exists to undo a leg the domain itself declined. A crash is not
+          # a decision the domain made ; running the compensating dispatch
+          # for it would misrepresent what happened (there was no refusal
+          # to compensate for) and could dispatch a real command against
+          # state nobody actually decided to change. The instance is left
+          # exactly where it landed, for a human to find via the warning
+          # and the log.
+          warn "[hecksagain] defect in saga #{pm.name} — instance #{correlation.inspect} " \
+               "dispatching #{spec.command_name}: #{error.class}: #{error.message}"
+          @registry.saga_log << record.merge(delivered: false, reason: error.message,
+                                             defect: true, error_class: error.class.name)
         end
       end
 

--- a/spec/facade/json_door_spec.rb
+++ b/spec/facade/json_door_spec.rb
@@ -1,0 +1,157 @@
+require "spec_helper"
+
+RSpec.describe Hecksagain::Facade::JsonDoor do
+  # `described_class` reads exactly as `Hecksagain::Facade::JsonDoor`
+  # throughout this file — no separate alias needed.
+  let(:json_door) { described_class }
+
+  # `boot_in_memory` (spec_helper.rb, `InMemoryDomain`) is the shared
+  # Memory-adapter boot every spec in this suite already reaches for —
+  # Pizzas::Order, rebound to Memory rather than a real adapter, matching
+  # this codebase's standing preference that specs boot against Memory and
+  # reserve real-adapter specs for testing that adapter itself.
+  def order(dispatcher)
+    Pizzas::Order.create_pizza(
+      name: { value: "Margherita" },
+      pizza: { price_cents: { cents: 1200 }, size: { value: "large" } }
+    )
+  end
+
+  describe ".aggregate" do
+    it "resolves a domain module name and an aggregate name to the installed Facade class" do
+      dispatcher = boot_in_memory
+
+      expect(json_door.aggregate(dispatcher, "Pizzas", "Order")).to equal(Pizzas::Order)
+    end
+
+    it "raises Runtime::NotFound for a domain the registry never booted" do
+      dispatcher = boot_in_memory
+
+      expect { json_door.aggregate(dispatcher, "NoSuchDomain", "Order") }
+        .to raise_error(Hecksagain::Runtime::NotFound, /NoSuchDomain/)
+    end
+
+    it "raises Runtime::NotFound for an aggregate the domain never declared" do
+      dispatcher = boot_in_memory
+
+      expect { json_door.aggregate(dispatcher, "Pizzas", "Calzone") }
+        .to raise_error(Hecksagain::Runtime::NotFound, /Calzone/)
+    end
+  end
+
+  describe ".creating_command" do
+    it "names the one command an aggregate declares creates? for, snake_cased" do
+      boot_in_memory
+
+      expect(json_door.creating_command(Pizzas::Order)).to eq("create_pizza")
+    end
+
+    it "raises Runtime::NotFound when the aggregate declares no creating command" do
+      # A real corpus aggregate always has exactly one (the meta-domain
+      # itself checks for it at boot) — so the "none" branch is proven
+      # against a minimal stand-in shaped the same way `AggregateDoor`
+      # shapes the real thing (`klass.ir.commands`, each answering
+      # `creates?`), not a mock of Hecksagain's own classes.
+      non_creating_command = Struct.new(:hecks_name) { def creates? = false }.new("Rename")
+      ir = Struct.new(:hecks_name, :commands).new("Widget", [non_creating_command])
+      klass = Struct.new(:ir).new(ir)
+
+      expect { json_door.creating_command(klass) }
+        .to raise_error(Hecksagain::Runtime::NotFound, /Widget/)
+    end
+  end
+
+  describe ".validate_command!" do
+    it "accepts a declared command name" do
+      boot_in_memory
+
+      expect(json_door.validate_command!(Pizzas::Order, "add_topping")).to eq("add_topping")
+    end
+
+    it "raises Runtime::NotFound for a name the aggregate never declared" do
+      boot_in_memory
+
+      expect { json_door.validate_command!(Pizzas::Order, "cancel_order") }
+        .to raise_error(Hecksagain::Runtime::NotFound, /cancel_order/)
+    end
+  end
+
+  describe ".find!" do
+    it "returns the found record" do
+      dispatcher = boot_in_memory
+      pizza = order(dispatcher)
+
+      found = json_door.find!(Pizzas::Order, pizza.id)
+
+      expect(found).to eq(pizza)
+    end
+
+    it "raises Runtime::NotFound rather than answering nil for a missing id" do
+      boot_in_memory
+
+      expect { json_door.find!(Pizzas::Order, "no-such-id") }
+        .to raise_error(Hecksagain::Runtime::NotFound, /no-such-id/)
+    end
+  end
+
+  describe ".deep_symbolize" do
+    it "symbolizes hash keys and maps arrays, arbitrarily deep, leaving scalars alone" do
+      parsed = {
+        "pizza" => { "price_cents" => { "cents" => 1200 }, "size" => { "value" => "large" } },
+        "toppings" => [{ "name" => "basil", "amount" => 2 }, { "name" => "olives", "amount" => 1 }],
+        "name" => { "value" => "Margherita" }
+      }
+
+      result = json_door.deep_symbolize(parsed)
+
+      expect(result).to eq(
+        pizza: { price_cents: { cents: 1200 }, size: { value: "large" } },
+        toppings: [{ name: "basil", amount: 2 }, { name: "olives", amount: 1 }],
+        name: { value: "Margherita" }
+      )
+    end
+  end
+
+  describe ".materialize" do
+    it "deep-unwraps a Handle's nested Runtime::Value fields to plain Ruby" do
+      dispatcher = boot_in_memory
+      pizza = order(dispatcher)
+
+      result = json_door.materialize(pizza)
+
+      expect(result).to eq(
+        id: pizza.id,
+        name: { value: "Margherita" },
+        pizza: { price_cents: { cents: 1200 }, size: { value: "large" } },
+        toppings: [],
+        customer_name: nil,
+        status: "available"
+      )
+      # Not just equal in VALUE — nothing left is still a Runtime::Value,
+      # two levels down (Order -> Pizza -> Price), which `#eq` alone
+      # wouldn't catch since Runtime::Value defines `==` by content.
+      expect(result[:pizza][:price_cents]).to be_a(Hash)
+      expect(result[:pizza][:price_cents]).not_to be_a(Hecksagain::Runtime::Value)
+    end
+
+    it "deep-unwraps a plain state hash the same way, without needing a Handle" do
+      dispatcher = boot_in_memory
+      pizza = order(dispatcher)
+
+      result = json_door.materialize(pizza.to_h)
+
+      expect(result[:pizza]).to eq(price_cents: { cents: 1200 }, size: { value: "large" })
+    end
+  end
+
+  describe ".parse" do
+    it "parses a raw JSON body string" do
+      expect(json_door.parse('{"name":"Margherita","toppings":["basil"]}'))
+        .to eq("name" => "Margherita", "toppings" => ["basil"])
+    end
+
+    it "propagates JSON::ParserError, undecorated, for malformed input" do
+      expect { json_door.parse("{not valid json") }.to raise_error(JSON::ParserError)
+    end
+  end
+end

--- a/spec/runtime/policy_spec.rb
+++ b/spec/runtime/policy_spec.rb
@@ -87,4 +87,40 @@ RSpec.describe "a policy" do
 
     expect(Pizzas::Order.find(pizza.id).status).to eq("sold")
   end
+
+  # `reaction_defects_spec.rb` proves the split at PolicyInterpreter's own
+  # level, in isolation. This proves it end to end, through the SAME
+  # `Dispatcher#dispatch` a real caller uses : the triggering command
+  # (`Flip`) has already succeeded and persisted by the time its own
+  # `Flipped` event fires `LogOnFlip`, and a genuine defect in the
+  # REACTION's target must not reach back and fail the caller's own
+  # dispatch for a command it already got right.
+  #
+  # `reenter` is overridden on this one `runtime` instance, not stubbed with
+  # a mocking framework this codebase otherwise never reaches for — the
+  # override only intercepts the one verb this test cares about breaking
+  # (`Reflex::Light.Log`, `LogOnFlip`'s own trigger) and calls straight
+  # through to the real dispatch for everything else, so `Flip` itself, and
+  # every other path this fixture exercises, runs unmodified.
+  it "keeps the triggering command's own success when the reaction it fires is a defect, not a refusal" do
+    runtime = boot_reflex
+    real_reenter = runtime.method(:reenter)
+    runtime.define_singleton_method(:reenter) do |verb, **args|
+      raise NoMethodError, "undefined method `boom' for nil" if verb == "Reflex::Light.Log"
+
+      real_reenter.call(verb, **args)
+    end
+
+    result = nil
+    expect { result = runtime.dispatch("Reflex::Light.Flip", name: { value: "light-1" }, id: "light-1") }
+      .to output(/LogOnFlip.*Flipped.*Reflex::Light\.Log.*boom/m).to_stderr
+
+    expect(result.events.map(&:name)).to eq(["Flipped"])
+    expect(Reflex::Light.find("light-1").condition.to_h).to eq(value: "on")
+
+    expect(runtime.reactions).to contain_exactly(
+      hash_including(policy: "LogOnFlip", on: "Flipped", trigger: "Reflex::Light.Log",
+                     delivered: false, defect: true, error_class: "NoMethodError")
+    )
+  end
 end

--- a/spec/runtime/reaction_defects_spec.rb
+++ b/spec/runtime/reaction_defects_spec.rb
@@ -7,9 +7,16 @@ require "spec_helper"
 # the command that emitted the event still stands, and the log says why.
 #
 # The runtime BREAKING (a NoMethodError in an interpreter, a NameError from a
-# missing constant) is a defect. It used to land in the same place, via a
-# blanket `rescue StandardError`, and be written as `delivered: false` beside
-# every legitimate refusal — so a crashed runtime read as normal operation.
+# missing constant) is a defect. It once had two wrong homes in a row : first
+# a blanket `rescue StandardError` that wrote it as `delivered: false` beside
+# every legitimate refusal, so a crashed runtime read as normal operation ;
+# then, after that was narrowed to DOMAIN_REFUSALS alone, nothing caught it at
+# all, so it propagated straight through the ALREADY-SUCCEEDED triggering
+# command's own `dispatch` call and blew that up too. Neither is right : a
+# defect is now caught (so the triggering command's success stands), but
+# recorded distinguishably (`defect: true`, the error's own class) rather than
+# folded into an ordinary refusal's shape, and warned to STDERR so it is never
+# silent.
 RSpec.describe "a reaction that cannot be delivered" do
   let(:event) do
     Hecksagain::Runtime::Event.new(
@@ -52,13 +59,15 @@ RSpec.describe "a reaction that cannot be delivered" do
     expect(registry.reaction_log.first).to include(delivered: false, reason: "bell already rung")
   end
 
-  it "RAISES a defect in the runtime rather than logging it as an undelivered reaction" do
+  it "RECORDS a defect in the runtime, distinguishably, rather than raising or logging it as a refusal" do
     registry = registry_for(policy)
     interpreter = Hecksagain::Runtime::PolicyInterpreter.new(
       registry, door: door_raising(NoMethodError.new("undefined method `boom'"))
     )
 
-    expect { interpreter.react(event, "Reflex") }.to raise_error(NoMethodError, /boom/)
-    expect(registry.reaction_log).to be_empty
+    expect { interpreter.react(event, "Reflex") }.to output(/ReactToRing.*Rang.*boom/m).to_stderr
+    expect(registry.reaction_log.first).to include(
+      delivered: false, reason: "undefined method `boom'", defect: true, error_class: "NoMethodError"
+    )
   end
 end

--- a/spec/runtime/saga_spec.rb
+++ b/spec/runtime/saga_spec.rb
@@ -82,6 +82,50 @@ RSpec.describe "a process manager" do
     expect(Wire::Drawer.find("left").cents.to_h).to eq(cents: 9_500)
   end
 
+  # Same split as the policy interpreter, proven end to end through the same
+  # `Dispatcher#dispatch` a real caller uses: `Wire.Ask` has already
+  # succeeded and persisted `WireAsked` by the time the procedure's own
+  # first leg (`Wire::Drawer.Take`) runs, and a genuine defect in THAT leg
+  # must not reach back and fail `Ask`'s own dispatch.
+  #
+  # `reenter` is overridden on this one `runtime`, not stubbed with a
+  # mocking framework — same technique, and same reasoning, as
+  # `spec/runtime/policy_spec.rb`'s equivalent test: only the one verb this
+  # test means to break is intercepted, everything else runs unmodified.
+  it "keeps the triggering command's own success, and skips unwind, when a saga leg is a defect not a refusal" do
+    runtime = funded
+    real_reenter = runtime.method(:reenter)
+    runtime.define_singleton_method(:reenter) do |verb, **args|
+      raise NoMethodError, "undefined method `boom' for nil" if verb == "Wire::Drawer.Take"
+
+      real_reenter.call(verb, **args)
+    end
+
+    result = nil
+    expect {
+      result = runtime.dispatch("Wire::Wire.Ask",
+                                reference: { value: "wire-defect" }, amount: { cents: 500 },
+                                source: "left", destination: "right")
+    }.to output(/Carry.*wire-defect.*Wire::Drawer\.Take.*boom/m).to_stderr
+
+    expect(result.events.map(&:name)).to eq(["WireAsked"])
+    expect(Wire::Wire.find("wire-defect").status).to eq("asked")
+
+    # The money never left — the leg that would have taken it is exactly
+    # the one that crashed instead of running.
+    expect(Wire::Drawer.find("left").cents.to_h).to eq(cents: 10_000)
+
+    expect(runtime.sagas).to include(
+      hash_including(process_manager: "Carry", instance: "wire-defect", dispatch: "Wire::Drawer.Take",
+                     delivered: false, defect: true, error_class: "NoMethodError")
+    )
+
+    # NO unwind : `on :refused` never fires for a defect, so the instance
+    # stays exactly where it landed rather than moving to "returned".
+    expect(runtime.sagas).not_to include(hash_including(on: "refused"))
+    expect(runtime.registry.saga_instances["Carry"]["wire-defect"][:state]).to eq("asked")
+  end
+
   it "records an event that arrives in the wrong phase, and does not advance" do
     runtime = funded
     runtime.dispatch("Wire::Drawer.Shut", number: { value: "right" })


### PR DESCRIPTION
Two independent pieces, kept as separate commits:

## 1. A defect in a reaction no longer blows up the command that already succeeded

`PolicyInterpreter#deliver` and `SagaInterpreter#deliver_saga_dispatch`
both narrowly rescue `DOMAIN_REFUSALS`, on purpose — a blanket rescue
used to fold a crashed runtime into the same `delivered: false` shape
as an ordinary refusal, making a defect read as normal operation in
the log. But narrowing to `DOMAIN_REFUSALS` alone left the opposite
bug: a genuine defect (NoMethodError, a real interpreter bug) had
nowhere to land, so it propagated out of `react`/`advance`, through
`Dispatcher#dispatch`, and blew up the ORIGINAL caller — even though
that caller's own command had already succeeded and persisted by the
time a reaction fires.

Fixed with a second, narrower rescue in each interpreter: the defect
is caught, recorded distinguishably (`defect: true` + the error's own
class, additive alongside `delivered`/`reason`, never folded into an
ordinary refusal's shape), and warned to STDERR so it's never silent.
The saga path's defect branch deliberately skips `unwind` (the
domain's own refusal-compensation) since running compensation for a
crash that isn't a real domain refusal would misrepresent what
happened.

## 2. `Hecksagain::Facade::JsonDoor`

A generic JSON translation layer for REST-ish callers, extracted from
what had been bespoke, hand-written per-app code. Handle/Surface are
Ruby sugar for a caller holding real objects; a JSON API caller holds
strings instead — a route segment naming a collection, a parsed body
with string keys. JsonDoor is that translation, generic, reading the
same IR the rest of the facade already reads.

No HTTP lives here, same discipline as Router/Surface: plain Ruby
values in, plain Ruby values or a raise out. Every "doesn't exist"
case raises the one `Runtime::NotFound` already in `DOMAIN_REFUSALS`
rather than a bespoke error class, so an adopting app gets one
generic handler for the whole family.

## Verification

Full suite: 1159 examples, 0 failures. Both `spec/facade/json_door_spec.rb`
and the new policy/saga defect coverage pass individually and as part
of the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)