### PR TITLE
facade/handle.rb: fix to_h letting a declared :id attribute clobber the bare identity

### DIFF
--- a/lib/hecksagain/facade/handle.rb
+++ b/lib/hecksagain/facade/handle.rb
@@ -29,7 +29,19 @@ module Hecksagain
       end
 
       def [](key) = @state[key.to_sym]
-      def to_h    = { id: @id }.merge(@state)
+
+      # `id: @id` LAST, not first — an aggregate is free to declare its own
+      # attribute literally named `id` (BurningManPrep's `Item`, `attribute
+      # :id, ItemId`, is real corpus now: `identified_by { id.value }` reads
+      # THAT attribute for identity). When it does, `@state[:id]` holds the
+      # full wrapped value object, not the bare identity string — merging
+      # `@state` on top of `{ id: @id }` let that wrapped VO silently
+      # clobber the correct bare `@id`, so every caller of `to_h` (the JSON
+      # door's own `/api/:coll` listing, in particular) got an object where
+      # a plain identity string belonged. `@id` merged LAST always wins,
+      # so `to_h[:id]` is always the true bare identity, regardless of
+      # whether the aggregate also happens to declare a same-named field.
+      def to_h = @state.merge(id: @id)
 
       def fqn = "#{@domain}::#{@ir.hecks_name}"
 

--- a/spec/facade/handle_spec.rb
+++ b/spec/facade/handle_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "tempfile"
 
 RSpec.describe Hecksagain::Facade::Handle do
   BANKING_BLUEBOOK = File.join(InMemoryDomain::ROOT, "examples/banking/bluebook/banking.bluebook")
@@ -85,5 +86,74 @@ RSpec.describe Hecksagain::Facade::Handle do
     # hash, so a stray `nil` key had nowhere to hide.
     box.surrender
     expect(box.status).to eq("vacant")
+  end
+
+  # `to_h` used to be `{ id: @id }.merge(@state)` — `@state` merged LAST,
+  # so an aggregate free to declare its own attribute literally named `id`
+  # (real corpus now: BurningManPrep's `Item`, `attribute :id, ItemId`,
+  # `identified_by { id.value }`) got that attribute's own WRAPPED value
+  # object silently clobbering the correctly-unwrapped bare `@id`. The
+  # JSON door's own `/api/:coll` listing is the caller that actually hit
+  # this: every record's own `id` key came back `{value: "..."}` instead
+  # of a bare string, which collapsed an entire collection's own client-
+  # side id-keyed cache down to one entry (every wrapped-hash key stringifies
+  # the same way).
+  it "keeps a declared attribute literally named id from clobbering the bare identity in to_h" do
+    registry = Hecksagain::Runtime::Registry.new
+    source = <<~BLUEBOOK
+      Hecks.bluebook "Thingy" do
+        aggregate "Thing" do
+          identified_by { id.value }
+
+          value_object "ThingId" do
+            attribute :value, String
+          end
+
+          value_object "ThingName" do
+            attribute :value, String
+          end
+
+          attribute :id,   ThingId
+          attribute :name, ThingName
+
+          command "Mint" do
+            attribute :id,   ThingId
+            attribute :name, ThingName
+            emits "Minted"
+          end
+        end
+      end
+    BLUEBOOK
+    file = Tempfile.new(["thing-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+
+      Hecks.hecksagon("Thingy") do
+        ::Thingy::Thing.persisted_by("Memory")
+      end
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(Hecksagain::Runtime::Dispatcher.new(registry))
+
+    thing = Thingy::Thing.mint(id: { value: "t1" }, name: { value: "goggles" })
+
+    expect(thing.id).to eq("t1")
+    expect(thing.to_h[:id]).to eq("t1")
+
+    # Scope check: this fix is about `:id` specifically clobbering itself,
+    # not a general re-unwrap of every field — an ordinary declared
+    # attribute stays exactly what it always was, a `Runtime::Value`.
+    expect(thing.to_h[:name]).to be_a(Hecksagain::Runtime::Value)
+    expect(thing.to_h[:name].to_h).to eq({ value: "goggles" })
+  ensure
+    file&.close!
   end
 end


### PR DESCRIPTION
## What

`Handle#to_h` was `{ id: @id }.merge(@state)` — `@state` merged LAST, so an aggregate free to declare its own attribute literally named `id` (real corpus now: BurningManPrep's `Item`, `attribute :id, ItemId`) had that attribute's own wrapped value object silently clobber the correctly-unwrapped bare `@id`.

## Where it actually bit

Live in embryonaut_console against burning-man-prep: the JSON door's `/api/:coll` listing returned every record's `id` key as `{value: "..."}` instead of a bare string. The frontend builds `byId[k] = Object.fromEntries(itemsByColl[k].map(item => [item.id, item]))` — every wrapped-hash `item.id` stringifies to the same JS object key, so all 8 Item records collapsed into one `byId.items` entry. PersonalList's "Items" rows-shape field showed raw UUIDs instead of resolved names ("goggles") as a result — the underlying data was always correct, only the id round-trip through `to_h` was broken.

## Fix

Merge `id: @id` LAST instead, so it always wins regardless of whether the aggregate also declares a same-named field.

## Tests

New regression test in `spec/facade/handle_spec.rb` — self-contained (a throwaway `Thing` aggregate declaring `attribute :id, ThingId`), since no existing corpus bluebook happens to declare an attribute literally named `id`. Full suite green, 1180 examples / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)