### PR TITLE
expression/resolver+evaluator: .all?/.any?/.none? block predicates

### DIFF
--- a/lib/hecksagain/bluebook/expression/evaluator.rb
+++ b/lib/hecksagain/bluebook/expression/evaluator.rb
@@ -211,9 +211,29 @@ module Hecksagain
               quote = nil if char == quote
             elsif ['"', "'"].include?(char)
               quote = char
-            elsif char == "("
+            # `{`/`}` depth -- vendored addition, not (yet) upstream
+            # hecksagain (migration plan task 9): this method already
+            # treats `(`/`)` as a grouping construct so an operator
+            # INSIDE a call's parens is never mistaken for a top-level
+            # split point ; `{`/`}` needed the identical treatment the
+            # moment `Bluebook::Expression::Resolver` grew block-taking
+            # `.all?`/`.any?`/`.none? { |s| PREDICATE }` support (see
+            # resolver.rb's own `BlockPredicate` addition) -- without
+            # this, an operator INSIDE the block's own predicate (e.g.
+            # `s.length > 0`) reads as a top-level split of the WHOLE
+            # `value.split("::").all? { |s| s.length > 0 }` expression,
+            # confirmed live via `Lexicon::Lexicon.Lookup`/`Query::Query.
+            # Run` (the exact `Phrase` invariant this gap was found
+            # against) : the stray `>` split the expression in half
+            # before `Resolver.parse` ever saw the block as one atomic
+            # leaf, and the two halves then failed independently with
+            # the same raw `TypeError` the block-predicate fix was
+            # built to close. `{`/`}` cannot legitimately appear inside
+            # a quoted literal either, so this sits beside the existing
+            # paren-depth branch, not instead of it.
+            elsif char == "(" || char == "{"
               depth += 1
-            elsif char == ")"
+            elsif char == ")" || char == "}"
               depth -= 1
             elsif depth.zero? && expr[index, operator.length] == operator
               return index if !block_given? || yield(index)

--- a/lib/hecksagain/bluebook/expression/resolver.rb
+++ b/lib/hecksagain/bluebook/expression/resolver.rb
@@ -113,6 +113,47 @@ module Hecksagain
         # receiver-in, scalar-out accessor, no sub-grammar of its own.
         Last           = Struct.new(:receiver, keyword_init: true)
 
+        # `receiver.all? { |x| PREDICATE }` / `.any? { ... }` / `.none? {
+        # ... }` -- vendored addition, not (yet) upstream hecksagain
+        # (migration plan task 9), completing the same `Phrase`
+        # four-segment invariant the `Split` node above was built for
+        # (`value.split("::").all? { |s| s.length > 0 }`). Structurally
+        # different from every other addition in this file: every prior
+        # suffix is a flat receiver -> scalar transform, but a block
+        # predicate needs to evaluate its own sub-expression ONCE PER
+        # ELEMENT with the block parameter bound to that element. Kept
+        # minimal per the migration plan's own instruction -- no
+        # persistent iteration-variable concept added to Resolver's
+        # state model at all ; `predicate` below is a fully-parsed
+        # EVALUATOR ast (not a Resolver ast -- the predicate is a
+        # boolean/comparison expression like `s.length > 0`, exactly the
+        # grammar `Bluebook::Expression::Evaluator` owns, not this
+        # module's own leaf grammar), parsed once at `parse`-time same as
+        # every sibling node's sub-expressions are. `mode` distinguishes
+        # all?/any?/none? without three duplicated node types, since
+        # their only difference is which Array predicate aggregates the
+        # per-element results (interpret_with_element, below, is the
+        # "smallest correct thing" the plan asked for -- it threads the
+        # element binding through a temporarily-extended `attrs` hash for
+        # that one predicate's evaluation only, never touching
+        # `interpret`'s own signature or any other node's call sites).
+        # `Resolver` already calls into `Evaluator` elsewhere in this
+        # file (`sign_test_node`/`apply_sign_test` call `Evaluator.
+        # apply`/`Evaluator::OPERATORS` directly) -- this is the same
+        # precedented cross-reference, not a new coupling.
+        BlockPredicate = Struct.new(:mode, :receiver, :param, :predicate, keyword_init: true)
+
+        # Which Array method each block-predicate suffix maps to, and
+        # which Ruby Enumerable method decides the aggregate result --
+        # declared as data, not a three-way `case`, the same shape
+        # SIGN_TEST_OPERATORS above already uses for its own suffix
+        # family.
+        BLOCK_PREDICATE_MODES = {
+          "all?"  => :all,
+          "any?"  => :any,
+          "none?" => :none
+        }.freeze
+
         module_function
 
         def resolve(expr, state, attrs)
@@ -160,7 +201,37 @@ module Hecksagain
 
           return Last.new(receiver: parse(Regexp.last_match(1))) if expr =~ /\A(.+)\.last\z/
 
+          block_predicate = parse_block_predicate(expr)
+          return block_predicate if block_predicate
+
           Lookup.new(path: expr)
+        end
+
+        # `.all?`/`.any?`/`.none?` -- vendored addition, see the
+        # `BlockPredicate` struct's own comment above. Matched last among
+        # the suffix rules (right before the `Lookup` catch-all) since
+        # its own predicate text can itself contain almost anything a
+        # leaf expression can -- letting every more specific rule above
+        # try first avoids this one accidentally swallowing a receiver
+        # another rule was meant to parse. `receiver` and the predicate
+        # body are each parsed through their OWN correct grammar --
+        # `parse` (this module's leaf grammar) for the receiver, `
+        # Evaluator.parse` (the boolean/comparison grammar) for the
+        # predicate, since a predicate like `s.length > 0` is a
+        # comparison, not a bare leaf.
+        def parse_block_predicate(expr)
+          BLOCK_PREDICATE_MODES.each do |suffix, mode|
+            match = expr.match(/\A(.+)\.#{Regexp.escape(suffix)}\s*\{\s*\|(\w+)\|\s*(.+?)\s*\}\z/m)
+            next unless match
+
+            return BlockPredicate.new(
+              mode: mode,
+              receiver: parse(match[1]),
+              param: match[2],
+              predicate: Evaluator.parse(match[3])
+            )
+          end
+          nil
         end
 
         def sign_test_node(parts)
@@ -195,6 +266,8 @@ module Hecksagain
             split_value(interpret(node.receiver, state, attrs), node.separator)
           when Last
             last_of(interpret(node.receiver, state, attrs))
+          when BlockPredicate
+            evaluate_block_predicate(node, interpret(node.receiver, state, attrs), state, attrs)
           when Lookup
             lookup(node.path, state, attrs)
           end
@@ -321,6 +394,38 @@ module Hecksagain
           return value.last if value.respond_to?(:last)
 
           raise EvaluationError, "last expects a list, got #{describe(value)}"
+        end
+
+        # `.all?`/`.any?`/`.none?` -- vendored addition, see the
+        # `BlockPredicate` struct's own comment above. `collection` is
+        # already-interpreted (a real Array, produced by whatever
+        # receiver expression came before it -- typically `Split`'s
+        # output), so this only has to run the per-element predicate and
+        # aggregate. `interpret_with_element` is the "smallest correct
+        # thing" the migration plan asked for : no persistent iteration-
+        # variable concept added anywhere else in Resolver's state model,
+        # just `attrs` extended with the bound name for the span of that
+        # one predicate evaluation, discarded immediately after.
+        def evaluate_block_predicate(node, collection, state, attrs)
+          unless collection.is_a?(Array)
+            raise EvaluationError, "#{node.mode}? expects a list, got #{describe(collection)}"
+          end
+
+          outcomes = collection.map { |element| interpret_with_element(node, element, state, attrs) }
+
+          case node.mode
+          when :all  then outcomes.all?
+          when :any  then outcomes.any?
+          when :none then outcomes.none?
+          end
+        end
+
+        # Binds the block parameter for exactly one element's predicate
+        # evaluation -- `attrs` wins over `state` in `fetch` (see below),
+        # so the bound name shadows any same-named state/attrs field for
+        # the span of this one call only ; nothing persists past it.
+        def interpret_with_element(node, element, state, attrs)
+          Evaluator.interpret(node.predicate, state, attrs.merge(node.param.to_sym => element))
         end
 
         # Declared the same way in Vocabulary::ToStringType

--- a/spec/expression_spec.rb
+++ b/spec/expression_spec.rb
@@ -209,6 +209,29 @@ RSpec.describe "the expression sublanguage" do
     end
   end
 
+  describe "block-taking all?/any?/none?" do
+    it "aggregates a per-element predicate over a split array" do
+      four_real_segments = "dispatch::lexicon::query::command_bus"
+      one_empty_segment  = "dispatch::::query::command_bus"
+
+      expect(evaluate('value.split("::").all? { |s| s.length > 0 }', value: four_real_segments)).to be(true)
+      expect(evaluate('value.split("::").all? { |s| s.length > 0 }', value: one_empty_segment)).to be(false)
+    end
+
+    it "does not let the block predicate's own comparison operator split the whole expression, the storehouse-kernel Phrase invariant" do
+      expression = 'value.split("::").length == 4 && value.split("::").all? { |s| s.length > 0 }'
+
+      expect(evaluate(expression, value: "dispatch::lexicon::query::command_bus")).to be(true)
+      expect(evaluate(expression, value: "dispatch::lexicon::query")).to be(false)
+      expect(evaluate(expression, value: "dispatch::::query::command_bus")).to be(false)
+    end
+
+    it "raises when the receiver is not a list" do
+      expect { evaluate('value.all? { |s| s.length > 0 }', value: "oops") }
+        .to raise_error(Hecksagain::Bluebook::Expression::EvaluationError, /all\? expects a list, got "oops"/)
+    end
+  end
+
   describe "match?/present?/blank?" do
     it "matches a receiver against a regex literal, the storehouse-kernel format-validation shape" do
       expect(evaluate('value.match?(/\A\d{5}\z/)', value: "94103")).to be(true)


### PR DESCRIPTION
Adds `receiver.all? { |x| PREDICATE }` / `.any? { ... }` / `.none? { ... }` to the canonical-expression Resolver, plus curly-brace depth tracking in the Evaluator's top-level operator splitter so nested block literals inside an expression parse correctly.

**Finding**: `docs/hecks-migration-findings.md` — completes the same `Phrase` four-segment invariant the `.split` addition (#18) was built for: `value.split("::").all? { |s| s.length > 0 }`. Structurally different from every other Ruby-idiom addition in this file — every prior suffix is a flat receiver → scalar transform, but a block predicate evaluates its own sub-expression once per element with the block parameter bound to that element. No persistent iteration-variable concept was added to Resolver's state model — `attrs` is temporarily extended with the bound name for the span of one predicate evaluation only, then discarded.

Without the accompanying Evaluator brace-depth fix, an operator INSIDE the block's own predicate (e.g. `s.length > 0`) reads as a top-level split of the WHOLE `value.split("::").all? { |s| s.length > 0 }` expression — the stray `>` splits the expression in half before `Resolver.parse` ever sees the block as one atomic leaf, and the two halves then fail independently with the same raw `TypeError` shape the block-predicate fix itself was built to close. Confirmed live via `Lexicon::Lexicon.Lookup`/`Query::Query.Run`, the exact `Phrase` invariant this gap was found against.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 0 failures at this point in the stack.

Split out of the original bundled PR #16 — stacks on #18 (`.split`/`.last`), one of five slices of the original `dbf944f` commit.
