### PR TITLE
expression/resolver: bare-lookup single-field VO scalar unwrap

### DIFF
--- a/lib/hecksagain/bluebook/expression/resolver.rb
+++ b/lib/hecksagain/bluebook/expression/resolver.rb
@@ -533,7 +533,7 @@ module Hecksagain
         end
 
         def lookup(expr, state, attrs)
-          return fetch(expr, state, attrs) unless expr.include?(".")
+          return unwrap_scalar(fetch(expr, state, attrs)) unless expr.include?(".")
 
           head, *rest = expr.split(".")
           rest.reduce(fetch(head, state, attrs)) do |value, segment|
@@ -541,6 +541,38 @@ module Hecksagain
 
             value[segment.to_sym] || value[segment]
           end
+        end
+
+        # `field == "literal"` -- vendored addition, not (yet) upstream
+        # hecksagain (migration plan task 8): the third-most pervasive
+        # dispatch-time gap this pass found, same family as `.match?`/
+        # `.present?` above -- a BARE lookup of a single-field
+        # scalar-convenience value object (the exact shape `Value.
+        # from_identifier`/`Value::Coercion#fields_for`'s own single-
+        # field auto-unwrap already treats as "this VO IS its scalar"
+        # everywhere else in this runtime) came back as the `Value`
+        # wrapper itself, never unwrapped for READING -- so `Value#==`
+        # (which only ever equals another `Value` instance) silently
+        # refused every `guarantees "..." do status == "active" end` /
+        # `expects "..." do trash_day.present? end`-shaped bare
+        # comparison against a raw literal. Confirmed corpus-wide, not
+        # one file's mistake: bin-buddy alone has this exact `field ==
+        # "literal"` shape in plan.bluebook, service_task.bluebook,
+        # route.bluebook, and subscription.bluebook, all equally silent
+        # until a real dispatch (never validate) exercised the
+        # predicate. Scoped narrowly to the single-field `{value: X}`
+        # shape only -- ONLY the dotted path's terminal (bare) lookup
+        # unwraps; a DOTTED lookup (`field.value`, `field.sub_field`)
+        # still walks the wrapper's own `#[]`, unaffected, because
+        # nothing in this corpus spells the scalar case that way (grep-
+        # confirmed zero `.value ==`/`.value.` usage anywhere) and a
+        # genuinely multi-field VO still needs `#[]` addressing to reach
+        # a specific field.
+        def unwrap_scalar(value)
+          return value unless value.respond_to?(:to_h) && !value.is_a?(Hash) && !value.is_a?(Array)
+
+          hash = value.to_h
+          hash.size == 1 && hash.key?(:value) ? hash[:value] : value
         end
 
         def fetch(name, state, attrs)

--- a/spec/expression_spec.rb
+++ b/spec/expression_spec.rb
@@ -248,6 +248,25 @@ RSpec.describe "the expression sublanguage" do
     end
   end
 
+  describe "bare-lookup single-field VO scalar unwrap" do
+    SingleFieldDouble = Struct.new(:value) do
+      def to_h = { value: value }
+    end
+
+    it "unwraps a bare (undotted) lookup of a single-field VO to its raw scalar" do
+      wrapped = SingleFieldDouble.new("active")
+
+      expect(evaluate('status == "active"', status: wrapped)).to be(true)
+      expect(evaluate('status == "inactive"', status: wrapped)).to be(false)
+    end
+
+    it "leaves a dotted lookup walking the wrapper's own #[] untouched" do
+      wrapped = SingleFieldDouble.new("active")
+
+      expect(evaluate('status.value == "active"', status: wrapped)).to be(true)
+    end
+  end
+
   describe "match?/present?/blank?" do
     it "matches a receiver against a regex literal, the storehouse-kernel format-validation shape" do
       expect(evaluate('value.match?(/\A\d{5}\z/)', value: "94103")).to be(true)


### PR DESCRIPTION
Fixes `lookup`'s bare (undotted) path to unwrap a single-field scalar-convenience value object before returning it — the exact shape `Value.from_identifier`/`Value::Coercion#fields_for`'s own single-field auto-unwrap already treats as "this VO IS its scalar" everywhere else in this runtime.

**Finding**: `docs/hecks-migration-findings.md` — the third-most pervasive dispatch-time gap this pass found, same family as `.match?`/`.present?` (#17). A bare lookup of a single-field VO came back as the `Value` wrapper itself, never unwrapped for reading — so `Value#==` (which only ever equals another `Value` instance) silently refused every `guarantees "..." do status == "active" end` / `expects "..." do trash_day.present? end`-shaped bare comparison against a raw literal. Confirmed corpus-wide: bin-buddy alone has this exact `field == "literal"` shape in `plan.bluebook`, `service_task.bluebook`, `route.bluebook`, and `subscription.bluebook`, all equally silent until a real dispatch (never `validate`) exercised the predicate.

Scoped narrowly to the single-field `{value: X}` shape only — ONLY the dotted path's terminal (bare) lookup unwraps; a dotted lookup (`field.value`, `field.sub_field`) still walks the wrapper's own `#[]`, unaffected, because nothing in this corpus spells the scalar case that way (grep-confirmed zero `.value ==`/`.value.` usage anywhere) and a genuinely multi-field VO still needs `#[]` addressing to reach a specific field.

This is the sixth and final slice of the original `dbf944f` commit, and is a distinct kind of change from the other five stacked below it: those add new Ruby-idiom METHODS to the expression grammar (`.match?`/`.present?`/`.blank?`/`.split`/`.last`/block predicates/`.start_with?`/`.end_with?`); this changes the existing bare-`Lookup` interpretation itself — a real correctness fix rather than new vocabulary. Not called out as its own item in the original split plan; found while reading the real diff for items 01-04 and added as item 04a with the plan file updated accordingly.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 0 failures at this point in the stack. Diffing the reconstructed `resolver.rb`/`evaluator.rb` against `dbf944f`'s own final tree at this point in the stack (after this PR) is byte-identical — confirms all six slices of the original commit are accounted for with nothing dropped or duplicated.

Split out of the original bundled PR #16 — stacks on #20.
