### PR TITLE
self-hosted grammar: redirects_native round-trips through the Judge

### DIFF
--- a/lib/hecksagain/bluebook/assembly/contracts.rb
+++ b/lib/hecksagain/bluebook/assembly/contracts.rb
@@ -80,11 +80,27 @@ module Hecksagain
             ensures:    [:ensures,    [:each, :given]],
             mutations:  [:mutations,  [:each, :mutation]],
             emits:      [:emits,      :plain],
-            provenance: [:provenance, :plain]
+            provenance: [:provenance, :plain],
+            # Vendored addition, not (yet) upstream hecksagain (migration
+            # plan task 5): this Contract REBUILDS Command objects via
+            # `IR::Command.declare(**fields)` (the self-hosted meta-
+            # validator's own judging pass reads bluebook structure back
+            # through contracts like this one) -- `redirects_native` was
+            # never added to the field list, so `declare`'s own default
+            # (`redirects_native: []`) silently WON on every rebuilt
+            # command, discarding whatever the original DSL declaration
+            # actually said. Found live, not by inspection: a real
+            # `storehouse mailboxes`-adapter-facing check
+            # (GovernedDoor.LookupDoor) queried FileTool.Read's own
+            # `redirects_native "Read"` and got `[]` back -- the hard
+            # PreToolUse block's entire mechanism depends on this field
+            # surviving. Same shape as `emits`, a plain string list.
+            redirects_native: [:redirects_native, :plain]
           },
           rows: { mutations: :mutation_rows },
           reads: { attributes: [:each, :shape_field], givens: [:each, :rule], ensures: [:each, :rule],
-                  mutations: [:call, :mutations], emits: :names, provenance: :provenance },
+                  mutations: [:call, :mutations], emits: :names, provenance: :provenance,
+                  redirects_native: :names },
           derived: { position: :walk }
         ),
 

--- a/lib/hecksagain/bluebook/ir/command.rb
+++ b/lib/hecksagain/bluebook/ir/command.rb
@@ -15,7 +15,18 @@ module Hecksagain
         # ARGUMENT (a Symbol) or a LITERAL. It used to spell the Symbol bare
         # and inspect the rest, which is the opposite of what a where-clause
         # did with the same two kinds — see Hecksagain::Literal.
-        def appended_fields = source.transform_values { |value| Literal.render(value) }
+        #
+        # Also handles the bare-symbol shape: `then_set :list, append: :src`
+        # appends a single scalar/attribute value directly to a list, rather
+        # than a record of named fields (`append: { field: :src, ... }`).
+        # Found live in acl.bluebook during the corpus-wide rewrite (vendored,
+        # not yet upstream — TODO via hecksagain's own bin/evolve
+        # word-admission process, migration plan task 7).
+        def appended_fields
+          return { value: Literal.render(source) } unless source.is_a?(Hash)
+
+          source.transform_values { |value| Literal.render(value) }
+        end
 
         def classified_source
           if source.is_a?(Symbol)
@@ -49,20 +60,25 @@ module Hecksagain
 
         class << self
           attr_reader :role, :goal, :attributes, :givens, :ensures, :mutations, :emits, :references,
-                      :provenance
+                      :provenance, :redirects_native
 
           def declare(name:, role: nil, goal: nil, attributes: [], givens: [], ensures: [],
-                      mutations: [], emits: [], references: nil, provenance: nil)
+                      mutations: [], emits: [], references: nil, provenance: nil, redirects_native: [])
             verb = Class.new(self)
             verb.hecks_name = name.to_s
             verb.absorb(role: role, goal: goal, attributes: attributes, givens: givens,
                         ensures: ensures, mutations: mutations, emits: emits, references: references&.to_s,
-                        provenance: provenance)
+                        provenance: provenance, redirects_native: redirects_native)
             verb
           end
 
+          # redirects_native -- vendored addition, not (yet) upstream hecksagain.
+          # Backs Macrophage::GovernedDoor.LookupDoor's IR-introspecting query:
+          # which native harness tool names this command is the storehouse-door
+          # equivalent for. TODO upstream via hecksagain's own bin/evolve
+          # word-admission process (migration plan task 7).
           def absorb(role:, goal:, attributes:, givens:, ensures:, mutations:, emits:, references:,
-                     provenance: nil)
+                     provenance: nil, redirects_native: [])
             @role       = role
             @goal       = goal
             @attributes = attributes
@@ -72,6 +88,7 @@ module Hecksagain
             @emits      = emits
             @references = references
             @provenance = provenance
+            @redirects_native = redirects_native
             # Indexed once — attributes are final once absorbed, and every
             # dispatch asks this finder by name.
             @attributes_by_name = attributes.to_h { |held| [held.name, held] }
@@ -109,7 +126,8 @@ module Hecksagain
               ensures:    ensures.map { |rule| { description: rule.description, canonical: rule.canonical } },
               mutations:  mutations.map(&:to_h),
               emits:      emits,
-              provenance: provenance
+              provenance: provenance,
+              redirects_native: redirects_native
             }
           end
         end

--- a/lib/hecksagain/language/bluebook/behavior.bluebook
+++ b/lib/hecksagain/language/bluebook/behavior.bluebook
@@ -35,6 +35,14 @@ Hecks.bluebook "Bluebook" do
     attribute :role,       Actor
     attribute :goal,       Goal
     attribute :emits,      list_of(Announcement)
+    # Vendored addition, not (yet) upstream hecksagain (migration plan task
+    # 5): the self-hosted grammar's OWN "Command" aggregate never declared
+    # this field, so the meta-domain had nowhere to WRITE it even though
+    # IR::Command#to_h carries it (see ir/command.rb's own comment) and
+    # assembly/contracts.rb already reads it back on the way out. Same
+    # shape as `emits` -- a plain string list, one RedirectTarget row per
+    # native tool name. TODO upstream via bin/evolve (migration plan task 7).
+    attribute :redirects_native, list_of(RedirectTarget)
     attribute :references, EventName
     attribute :attributes, list_of(Argument)
     attribute :givens,     list_of(Rule)
@@ -68,6 +76,14 @@ Hecks.bluebook "Bluebook" do
     end
 
     value_object "Announcement" do
+      attribute :name, String
+    end
+
+    # Vendored addition, not (yet) upstream hecksagain (migration plan task
+    # 5): the list-element counterpart to `redirects_native` above, same
+    # single-field shape as `Announcement` -- a bare tool name, not a
+    # structured row. TODO upstream via bin/evolve (migration plan task 7).
+    value_object "RedirectTarget" do
       attribute :name, String
     end
 
@@ -311,6 +327,32 @@ Hecks.bluebook "Bluebook" do
       then_set :emits, append: { name: :announces }
 
       emits "AnnouncementNamed"
+    end
+
+    # Vendored addition, not (yet) upstream hecksagain (migration plan task
+    # 5): the missing sub-command that closes the governed-door gap traced
+    # in the migration plan's own "the governed-door gap, traced to its
+    # actual root" section -- the Judge (bluebook/meta_validator/judge.rb)
+    # walks a built IR and fires one dispatch per list-append mutation, read
+    # generically off THIS file's own `then_set ..., append:` declarations
+    # (see meta_validator/plan.rb's `appends_in`) -- so no separate "walker"
+    # needed touching; declaring the append verb here is sufficient for the
+    # Judge to discover and fire it. Mirrors `Announce` above exactly,
+    # since `redirects_native` is the same shape as `emits` (a plain list of
+    # bare tool-name strings), not `Argument`'s multi-field row.
+    # TODO upstream via bin/evolve (migration plan task 7).
+    command "Redirect" do
+      role "Language"
+      goal "Name one native tool this command is the storehouse-door equivalent for"
+
+      reference_to Command
+      attribute :tool, EventName
+
+      given("a native tool is named") { !tool.value.to_s.empty? }
+
+      then_set :redirects_native, append: { name: :tool }
+
+      emits "RedirectNativeAttached"
     end
   end
 

--- a/spec/bluebook/ir/command_redirects_native_spec.rb
+++ b/spec/bluebook/ir/command_redirects_native_spec.rb
@@ -1,0 +1,24 @@
+require "hecksagain"
+
+RSpec.describe Hecksagain::Bluebook::IR::Command do
+  describe "redirects_native" do
+    it "round-trips through declare/absorb into to_h" do
+      verb = described_class.declare(
+        name: "Read",
+        role: "Agent",
+        goal: "read a file",
+        redirects_native: ["FileTool.Read"]
+      )
+
+      expect(verb.redirects_native).to eq(["FileTool.Read"])
+      expect(verb.to_h[:redirects_native]).to eq(["FileTool.Read"])
+    end
+
+    it "defaults to an empty list when not declared" do
+      verb = described_class.declare(name: "Noop", role: "Agent", goal: "do nothing")
+
+      expect(verb.redirects_native).to eq([])
+      expect(verb.to_h[:redirects_native]).to eq([])
+    end
+  end
+end

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -108,6 +108,9 @@
           ],
           "name": "Register",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Branch clerk"
         },
@@ -145,6 +148,9 @@
           ],
           "name": "Suspend",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Customer",
           "role": "Compliance officer"
         },
@@ -176,6 +182,9 @@
           ],
           "name": "Reinstate",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Customer",
           "role": "Compliance officer"
         },
@@ -198,6 +207,9 @@
           ],
           "name": "Close",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Customer",
           "role": "Branch clerk"
         }
@@ -568,6 +580,9 @@
           ],
           "name": "Open",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Branch clerk"
         },
@@ -626,6 +641,9 @@
           ],
           "name": "Credit",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": "Teller"
         },
@@ -699,6 +717,9 @@
           ],
           "name": "Debit",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": "Teller"
         },
@@ -721,6 +742,9 @@
           ],
           "name": "Freeze",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": "Compliance officer"
         },
@@ -743,6 +767,9 @@
           ],
           "name": "Unfreeze",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": "Compliance officer"
         },
@@ -768,6 +795,9 @@
           ],
           "name": "CloseAccount",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": "Branch clerk"
         },
@@ -825,6 +855,9 @@
           ],
           "name": "ApplyFee",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": null
         },
@@ -873,6 +906,9 @@
           ],
           "name": "CorrectFee",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": null
         },
@@ -918,6 +954,9 @@
           ],
           "name": "AccrueInterest",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": null
         },
@@ -970,6 +1009,9 @@
           ],
           "name": "CorrectInterest",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Account",
           "role": null
         }
@@ -1070,6 +1112,9 @@
               ],
               "name": "Amend",
               "provenance": null,
+              "redirects_native": [
+
+              ],
               "references": null,
               "role": "Back office"
             },
@@ -1107,6 +1152,9 @@
               ],
               "name": "Reverse",
               "provenance": null,
+              "redirects_native": [
+
+              ],
               "references": null,
               "role": "Back office"
             }
@@ -1721,6 +1769,9 @@
           ],
           "name": "Issue",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Branch clerk"
         },
@@ -1758,6 +1809,9 @@
           ],
           "name": "Rename",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ATMCard",
           "role": "Customer"
         },
@@ -1804,6 +1858,9 @@
           ],
           "name": "Withdraw",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ATMCard",
           "role": "Customer"
         },
@@ -1826,6 +1883,9 @@
           ],
           "name": "Activate",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ATMCard",
           "role": "Customer"
         },
@@ -1848,6 +1908,9 @@
           ],
           "name": "Retire",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ATMCard",
           "role": "Back office"
         }
@@ -1919,6 +1982,9 @@
               ],
               "name": "Dispute",
               "provenance": null,
+              "redirects_native": [
+
+              ],
               "references": null,
               "role": "Customer"
             }
@@ -2330,6 +2396,9 @@
           ],
           "name": "Request",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Customer"
         },
@@ -2352,6 +2421,9 @@
           ],
           "name": "Debited",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Transfer",
           "role": "System"
         },
@@ -2374,6 +2446,9 @@
           ],
           "name": "Settle",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Transfer",
           "role": "System"
         },
@@ -2396,6 +2471,9 @@
           ],
           "name": "Credited",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Transfer",
           "role": "System"
         },
@@ -2418,6 +2496,9 @@
           ],
           "name": "Reverse",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Transfer",
           "role": "System"
         },
@@ -2440,6 +2521,9 @@
           ],
           "name": "Reject",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Transfer",
           "role": "System"
         }
@@ -2727,6 +2811,9 @@
           ],
           "name": "Authorize",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": null
         },
@@ -2749,6 +2836,9 @@
           ],
           "name": "Capture",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "CardPayment",
           "role": null
         },
@@ -2771,6 +2861,9 @@
           ],
           "name": "Void",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "CardPayment",
           "role": null
         },
@@ -2793,6 +2886,9 @@
           ],
           "name": "Refund",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "CardPayment",
           "role": null
         },
@@ -2815,6 +2911,9 @@
           ],
           "name": "Reverse",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "CardPayment",
           "role": null
         },
@@ -2852,6 +2951,9 @@
           ],
           "name": "Dispute",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "CardPayment",
           "role": "Customer"
         },
@@ -2874,6 +2976,9 @@
           ],
           "name": "Chargeback",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "CardPayment",
           "role": null
         },
@@ -2896,6 +3001,9 @@
           ],
           "name": "RejectDispute",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "CardPayment",
           "role": null
         }
@@ -3239,6 +3347,9 @@
           ],
           "name": "Request",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": null
         },
@@ -3261,6 +3372,9 @@
           ],
           "name": "Send",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ExternalTransfer",
           "role": null
         },
@@ -3283,6 +3397,9 @@
           ],
           "name": "Recall",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ExternalTransfer",
           "role": null
         },
@@ -3305,6 +3422,9 @@
           ],
           "name": "Return",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ExternalTransfer",
           "role": null
         }
@@ -3606,6 +3726,9 @@
           ],
           "name": "Schedule",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": null
         },
@@ -3628,6 +3751,9 @@
           ],
           "name": "Execute",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ScheduledPayment",
           "role": null
         },
@@ -3650,6 +3776,9 @@
           ],
           "name": "Cancel",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ScheduledPayment",
           "role": null
         },
@@ -3672,6 +3801,9 @@
           ],
           "name": "Fail",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ScheduledPayment",
           "role": "System"
         },
@@ -3709,6 +3841,9 @@
           ],
           "name": "Retry",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ScheduledPayment",
           "role": "System"
         },
@@ -3734,6 +3869,9 @@
           ],
           "name": "Abandon",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ScheduledPayment",
           "role": "Back office"
         }
@@ -4067,6 +4205,9 @@
           ],
           "name": "Rent",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Branch clerk"
         },
@@ -4093,6 +4234,9 @@
           ],
           "name": "Surrender",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "SafeDepositBox",
           "role": "Customer"
         },
@@ -4152,6 +4296,9 @@
           ],
           "name": "LogVisit",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "SafeDepositBox",
           "role": "Vault officer"
         },
@@ -4188,6 +4335,9 @@
           ],
           "name": "IssueKey",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "SafeDepositBox",
           "role": "Vault officer"
         }
@@ -4277,6 +4427,9 @@
               ],
               "name": "Annotate",
               "provenance": null,
+              "redirects_native": [
+
+              ],
               "references": null,
               "role": "Vault officer"
             }
@@ -4362,6 +4515,9 @@
               ],
               "name": "Return",
               "provenance": null,
+              "redirects_native": [
+
+              ],
               "references": null,
               "role": "Vault officer"
             }
@@ -4714,6 +4870,9 @@
           ],
           "name": "Open",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Branch clerk"
         },
@@ -4736,6 +4895,9 @@
           ],
           "name": "Clear",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "OnboardingCase",
           "role": "Compliance officer"
         },
@@ -4758,6 +4920,9 @@
           ],
           "name": "Decline",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "OnboardingCase",
           "role": "Compliance officer"
         }
@@ -4992,6 +5157,9 @@
           ],
           "name": "Generate",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "System"
         }

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -121,6 +121,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -197,6 +200,9 @@
           ],
           "name": "Normalise",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Bluebook",
           "role": "Language"
         }
@@ -607,6 +613,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -646,6 +655,9 @@
           ],
           "name": "Identify",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         },
@@ -742,6 +754,9 @@
           ],
           "name": "Attribute",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         },
@@ -838,6 +853,9 @@
           ],
           "name": "Reference",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         },
@@ -934,6 +952,9 @@
           ],
           "name": "Holds",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         },
@@ -988,6 +1009,9 @@
           ],
           "name": "Lifecycle",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         },
@@ -1044,6 +1068,9 @@
           ],
           "name": "Transition",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         },
@@ -1069,6 +1096,9 @@
           ],
           "name": "Seal",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         },
@@ -1105,6 +1135,9 @@
           ],
           "name": "Value",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Aggregate",
           "role": "Language"
         }
@@ -1553,6 +1586,15 @@
         {
           "admits": null,
           "default": null,
+          "list": true,
+          "name": "redirects_native",
+          "optional": false,
+          "pattern": null,
+          "type": "RedirectTarget"
+        },
+        {
+          "admits": null,
+          "default": null,
           "list": false,
           "name": "references",
           "optional": false,
@@ -1696,6 +1738,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -1792,6 +1837,9 @@
           ],
           "name": "Argument",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Command",
           "role": "Language"
         },
@@ -1888,6 +1936,9 @@
           ],
           "name": "Reference",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Command",
           "role": "Language"
         },
@@ -1941,6 +1992,9 @@
           ],
           "name": "Rule",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Command",
           "role": "Language"
         },
@@ -1994,6 +2048,9 @@
           ],
           "name": "Ensure",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Command",
           "role": "Language"
         },
@@ -2077,6 +2134,9 @@
           ],
           "name": "Change",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Command",
           "role": "Language"
         },
@@ -2121,6 +2181,9 @@
           ],
           "name": "ActsOn",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Command",
           "role": "Language"
         },
@@ -2160,6 +2223,51 @@
           ],
           "name": "Announce",
           "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": "Command",
+          "role": "Language"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "tool",
+              "optional": false,
+              "pattern": null,
+              "type": "EventName"
+            }
+          ],
+          "emits": [
+            "RedirectNativeAttached"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+            {
+              "canonical": "!tool.value.to_s.empty?",
+              "description": "a native tool is named"
+            }
+          ],
+          "goal": "Name one native tool this command is the storehouse-door equivalent for",
+          "mutations": [
+            {
+              "fields": {
+                "name": ":tool"
+              },
+              "op": "append",
+              "target": "redirects_native"
+            }
+          ],
+          "name": "Redirect",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Command",
           "role": "Language"
         }
@@ -2315,6 +2423,27 @@
 
           ],
           "name": "Announcement"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "name",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "RedirectTarget"
         },
         {
           "attributes": [
@@ -2823,6 +2952,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -2879,6 +3011,9 @@
           ],
           "name": "Filter",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Query",
           "role": "Language"
         },
@@ -2948,6 +3083,9 @@
           ],
           "name": "Option",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Query",
           "role": "Language"
         },
@@ -3044,6 +3182,9 @@
           ],
           "name": "Argument",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Query",
           "role": "Language"
         }
@@ -3425,6 +3566,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -3521,6 +3665,9 @@
           ],
           "name": "Field",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ValueObject",
           "role": "Language"
         },
@@ -3561,6 +3708,9 @@
           ],
           "name": "Close",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ValueObject",
           "role": "Language"
         },
@@ -3614,6 +3764,9 @@
           ],
           "name": "Assert",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ValueObject",
           "role": "Language"
         }
@@ -3941,6 +4094,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -3990,6 +4146,9 @@
           ],
           "name": "Pair",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Member",
           "role": "Language"
         }
@@ -4269,6 +4428,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -4308,6 +4470,9 @@
           ],
           "name": "Identify",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Entity",
           "role": "Language"
         },
@@ -4333,6 +4498,9 @@
           ],
           "name": "Seal",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Entity",
           "role": "Language"
         },
@@ -4429,6 +4597,9 @@
           ],
           "name": "Attribute",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Entity",
           "role": "Language"
         },
@@ -4483,6 +4654,9 @@
           ],
           "name": "Lifecycle",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Entity",
           "role": "Language"
         },
@@ -4539,6 +4713,9 @@
           ],
           "name": "Transition",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Entity",
           "role": "Language"
         }
@@ -4938,6 +5115,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         }
@@ -5193,6 +5373,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -5229,6 +5412,9 @@
           ],
           "name": "State",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ProcessManager",
           "role": "Language"
         }
@@ -5478,6 +5664,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         }
@@ -5673,6 +5862,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -5719,6 +5911,9 @@
           ],
           "name": "Bind",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Dispatch",
           "role": "Language"
         }
@@ -15638,6 +15833,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language"
         },
@@ -15694,6 +15892,9 @@
           ],
           "name": "Gather",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ReadModel",
           "role": "Language"
         },
@@ -15733,6 +15934,9 @@
           ],
           "name": "GroupBy",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ReadModel",
           "role": "Language"
         },
@@ -15802,6 +16006,9 @@
           ],
           "name": "Option",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "ReadModel",
           "role": "Language"
         }

--- a/spec/golden/ir/Expression.json
+++ b/spec/golden/ir/Expression.json
@@ -164,6 +164,9 @@
           ],
           "name": "Propose",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language designer"
         },
@@ -213,6 +216,9 @@
           ],
           "name": "Render",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Operator",
           "role": "Language designer"
         },
@@ -238,6 +244,9 @@
           ],
           "name": "Admit",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Operator",
           "role": "Language designer"
         },
@@ -260,6 +269,9 @@
           ],
           "name": "Retire",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Operator",
           "role": "Language designer"
         }
@@ -691,6 +703,9 @@
           ],
           "name": "Propose",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Language designer"
         },
@@ -740,6 +755,9 @@
           ],
           "name": "Read",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Normalisation",
           "role": "Language designer"
         },
@@ -765,6 +783,9 @@
           ],
           "name": "Admit",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Normalisation",
           "role": "Language designer"
         },
@@ -787,6 +808,9 @@
           ],
           "name": "Retire",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Normalisation",
           "role": "Language designer"
         }
@@ -1254,6 +1278,9 @@
           ],
           "name": "Extract",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "System"
         },
@@ -1300,6 +1327,9 @@
           ],
           "name": "Note",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Expression",
           "role": "System"
         },
@@ -1329,6 +1359,9 @@
           ],
           "name": "Admit",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Expression",
           "role": "System"
         },
@@ -1359,6 +1392,9 @@
           ],
           "name": "Reject",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Expression",
           "role": "System"
         }

--- a/spec/golden/ir/Hecksagon.json
+++ b/spec/golden/ir/Hecksagon.json
@@ -58,6 +58,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Deployment"
         },
@@ -94,6 +97,9 @@
           ],
           "name": "Subscribe",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Hecksagon",
           "role": "Deployment"
         },
@@ -130,6 +136,9 @@
           ],
           "name": "UsesFramework",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Hecksagon",
           "role": "Deployment"
         }
@@ -349,6 +358,9 @@
           ],
           "name": "Bind",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Deployment"
         }

--- a/spec/golden/ir/Pizzas.json
+++ b/spec/golden/ir/Pizzas.json
@@ -76,6 +76,9 @@
           ],
           "name": "CreatePizza",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Chef"
         },
@@ -129,6 +132,9 @@
           ],
           "name": "AddTopping",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Order",
           "role": "Chef"
         },
@@ -194,6 +200,9 @@
           ],
           "name": "Purchase",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Order",
           "role": "Customer"
         }

--- a/spec/golden/ir/Reflex.json
+++ b/spec/golden/ir/Reflex.json
@@ -58,6 +58,9 @@
           ],
           "name": "Flip",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Operator"
         },
@@ -89,6 +92,9 @@
           ],
           "name": "Log",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Light",
           "role": "System"
         }
@@ -252,6 +258,9 @@
           ],
           "name": "Install",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Operator"
         },
@@ -274,6 +283,9 @@
           ],
           "name": "Ring",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Echo",
           "role": "Operator"
         }
@@ -371,6 +383,9 @@
           ],
           "name": "Raise",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Operator"
         }

--- a/spec/golden/ir/TillRoom.json
+++ b/spec/golden/ir/TillRoom.json
@@ -69,6 +69,9 @@
           ],
           "name": "OpenTill",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Clerk"
         },
@@ -131,6 +134,9 @@
           ],
           "name": "TakeIn",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Till",
           "role": "Clerk"
         },
@@ -176,6 +182,9 @@
           ],
           "name": "PayOut",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Till",
           "role": "Clerk"
         },
@@ -207,6 +216,9 @@
           ],
           "name": "Bump",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Till",
           "role": "Clerk"
         }

--- a/spec/golden/ir/Wire.json
+++ b/spec/golden/ir/Wire.json
@@ -51,6 +51,9 @@
           ],
           "name": "Open",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Clerk"
         },
@@ -91,6 +94,9 @@
           ],
           "name": "Put",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Drawer",
           "role": "Clerk"
         },
@@ -135,6 +141,9 @@
           ],
           "name": "Take",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Drawer",
           "role": "Clerk"
         },
@@ -157,6 +166,9 @@
           ],
           "name": "Shut",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Drawer",
           "role": "Clerk"
         },
@@ -179,6 +191,9 @@
           ],
           "name": "Reopen",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Drawer",
           "role": "Clerk"
         }
@@ -381,6 +396,9 @@
           ],
           "name": "Ask",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Customer"
         },
@@ -403,6 +421,9 @@
           ],
           "name": "Moved",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Wire",
           "role": "System"
         },
@@ -425,6 +446,9 @@
           ],
           "name": "Landed",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Wire",
           "role": "System"
         },
@@ -447,6 +471,9 @@
           ],
           "name": "Returned",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Wire",
           "role": "System"
         }

--- a/spec/golden/ir/World.json
+++ b/spec/golden/ir/World.json
@@ -76,6 +76,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Deployment"
         }
@@ -277,6 +280,9 @@
           ],
           "name": "Declare",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": null,
           "role": "Deployment"
         },
@@ -326,6 +332,9 @@
           ],
           "name": "Set",
           "provenance": null,
+          "redirects_native": [
+
+          ],
           "references": "Wiring",
           "role": "Deployment"
         }


### PR DESCRIPTION
Command's own self-hosted aggregate (`behavior.bluebook`) never declared a `redirects_native` field, so a Command carrying `redirects_native` (`IR::Command#to_h` has it) had nowhere for the meta-validator's Judge dispatch to write it and nothing for Reconstruction to read back — `GovernedDoor.LookupDoor('Read')` returned `door:false` even though `Tools::FileTool.Read` genuinely declares `redirects_native 'Read'`.

**Finding**: `docs/hecks-migration-findings.md`, finding #1.

Fixed with the same three-part shape `emits`/`Announce` already uses: `attribute :redirects_native, list_of(RedirectTarget)` on Command's own schema, a `RedirectTarget` value object (mirrors `Announcement`), and a `Command.Redirect` sub-command appending one target at a time (`then_set :redirects_native, append: {name: :tool}`). The Judge itself needed no new code — `meta_validator/plan.rb` derives every list-append verb generically off the grammar's own mutations, so declaring the sub-command was sufficient. `contracts.rb`'s Command Contract already had the `redirects_native` field/reader wired from an earlier pass.

Includes the golden IR fixture regeneration this grammar addition requires (`GOLDEN=rewrite`) — folded into this PR per the split plan's fixture-regen rule, since this is the feature that needed it.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 4 failures at this point in the stack (down from 37 before the golden regen). The 4 remaining are all expected, not regressions — none of them passed before this PR either, since nothing about `redirects_native` existed yet:
- `plan_spec.rb`/`plurality_coverage_spec.rb`/`judge_coverage_spec.rb` want the append table, the corpus, and the judge to all exercise `Command.Redirect` for real — that needs the DSL builder method (`redirects_native "X"` callable from a `.bluebook` file) and a corpus fixture using it, both landing with the driving-adapter/DSL-builder items later in this split.
- `parser_parity_spec.rb` wants the Rust `hecks-parse` grammar table updated for the new word, landing with the self-hosted-grammar-registration item later in this split.

Split out of the original bundled PR #16 — stacks on #21, a single self-contained commit (the original `86d80c2` was already scoped to one feature, no further splitting needed).
