### PR TITLE
query DSL: group_by aggregation

### DIFF
--- a/lib/hecksagain/bluebook/dsl/query_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/query_builder.rb
@@ -13,6 +13,16 @@ module Hecksagain
 
         def description(value) = @description = value
 
+        # `group_by :field` -- a real, third scalar-reduction shape
+        # alongside `count`/`median`, except it doesn't reduce to ONE
+        # scalar -- it partitions the where-filtered set by `field`'s
+        # value and tallies each partition, matching what deciderate's
+        # own `PerPlayer`/leaderboard queries need ("the player
+        # leaderboard : submissions tallied per player"). See
+        # Runtime::QueryInterpreter#call's own comment for the
+        # evaluation side.
+        def group_by(field) = @group_by_field = field.to_sym
+
         # A query parameter naming another aggregate's own identity
         # (Card.Active's own `Board`, filtering to one board's cards) —
         # just a plain attribute typed as a reference,
@@ -41,7 +51,8 @@ module Hecksagain
             authorization: @authorization,
             null_semantics: @null_semantics,
             inspection: @inspection,
-            index_hints: @index_hints || []
+            index_hints: @index_hints || [],
+            group_by_field: @group_by_field
           )
         end
 

--- a/lib/hecksagain/bluebook/ir/query.rb
+++ b/lib/hecksagain/bluebook/ir/query.rb
@@ -21,12 +21,16 @@ module Hecksagain
       class Query < QuerySpecification::Common::Options
         include Construct
 
-        attr_reader :name, :description, :attributes
+        attr_reader :name, :description, :attributes, :group_by_field
 
+        # `group_by_field:`, vendored addition not (yet) upstream
+        # hecksagain (migration plan task 8): `group_by :field` -- a
+        # third aggregation shape, partition-and-tally rather than
+        # reduce-to-one-scalar. See QueryBuilder#group_by's own comment.
         def initialize(name:, description: nil, attributes: [], wheres: [],
                        order_by: nil, limit: nil, offset: nil, cursor: nil,
                        consistency: nil, freshness: nil, authorization: nil, null_semantics: nil,
-                       inspection: nil, index_hints: [])
+                       inspection: nil, index_hints: [], group_by_field: nil)
           null_semantics ||= QuerySpecification::Common::NullSemantics.default
           super(wheres: wheres, order_by: order_by, limit: limit, offset: offset, cursor: cursor,
                 consistency: consistency, freshness: freshness, authorization: authorization,
@@ -35,6 +39,7 @@ module Hecksagain
           @hecks_name  = @name
           @description = description
           @attributes  = attributes
+          @group_by_field = group_by_field
         end
 
         def attribute(named) = @attributes.find { |a| a.name == named.to_sym }

--- a/lib/hecksagain/runtime/query_interpreter.rb
+++ b/lib/hecksagain/runtime/query_interpreter.rb
@@ -34,6 +34,25 @@ module Hecksagain
         declared = ReferenceHop.apply(declared, args, registry: @registry, domain: domain, aggregate: aggregate)
 
         repository = @registry.repository(domain, aggregate)
+
+        # Vendored addition, not (yet) upstream hecksagain (migration
+        # plan task 8): `group_by :field` -- the SAME filtered-set
+        # starting point as an ordinary query, partitioned by `field`'s
+        # value instead of returned as a flat list (deciderate's own
+        # leaderboard queries: "submissions tallied per player").
+        # Returns one row per distinct value, `field => value, count:
+        # N`, ordered by count descending (a leaderboard's own natural
+        # order) then by the group value for ties, so output is
+        # deterministic. `comparable` unwraps a VO/Hash field the same
+        # way `ordered` already does.
+        if declared.group_by_field
+          field = declared.group_by_field
+          groups = interpret(repository.all, declared, args)
+                     .group_by { |row| comparable(row[field]) }
+          return groups.map { |value, rows| { field => value, count: rows.size } }
+                       .sort_by { |row| [-row[:count], row[field].to_s] }
+        end
+
         if (native = Ports::Query.execute(repository, declared, args, context: { domain: domain, aggregate: aggregate }))
           records = native
           # `record.state.merge(id: record.id)` — id LAST, not first. See

--- a/spec/query_group_by_growth_spec.rb
+++ b/spec/query_group_by_growth_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for `group_by :field` — finding #10, a third
+# query-aggregation shape alongside `count`/`median`: partitions the
+# where-filtered set by a field's value and tallies each partition, one
+# row per distinct value, ordered by count descending then by the value
+# itself.
+#
+# `meta_validation: false` — the self-hosted grammar's own Query
+# contract doesn't carry `group_by_field` through its own Judge round-trip
+# yet (a separate, later-landing item in this split); turned off here so
+# what's under test is this PR's own DSL/interpreter pair, not that
+# separate gap.
+RSpec.describe "a query's own group_by" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["group-by-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  GROUP_BY_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "ScoreboardGrowth" do
+      aggregate "Submission" do
+        identified_by { id.value }
+
+        value_object "SubmissionId" do
+          attribute :value, String
+        end
+
+        attribute :id,     SubmissionId
+        attribute :player, String
+        attribute :points, Integer
+
+        command "Submit" do
+          attribute :id,     SubmissionId
+          attribute :player, String
+          attribute :points, Integer
+          emits "Submitted"
+        end
+
+        query "PerPlayer" do
+          group_by :player
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_scoreboard
+    boot(GROUP_BY_SOURCE, "ScoreboardGrowth") do
+      ::ScoreboardGrowth::Submission.persisted_by("Memory")
+    end
+  end
+
+  it "tallies rows into one row per distinct group value, ordered by count then value" do
+    runtime = boot_scoreboard
+    runtime.dispatch("ScoreboardGrowth::Submission.Submit", id: { value: "s1" }, player: "Ada",   points: 10)
+    runtime.dispatch("ScoreboardGrowth::Submission.Submit", id: { value: "s2" }, player: "Ada",   points: 20)
+    runtime.dispatch("ScoreboardGrowth::Submission.Submit", id: { value: "s3" }, player: "Grace", points: 5)
+    runtime.dispatch("ScoreboardGrowth::Submission.Submit", id: { value: "s4" }, player: "Ada",   points: 1)
+
+    rows = runtime.query("ScoreboardGrowth::Submission.PerPlayer")
+
+    expect(rows).to eq([{ player: "Ada", count: 3 }, { player: "Grace", count: 1 }])
+  end
+
+  it "breaks a tie in count by the group value itself, so the order is deterministic" do
+    runtime = boot_scoreboard
+    runtime.dispatch("ScoreboardGrowth::Submission.Submit", id: { value: "s1" }, player: "Zed", points: 1)
+    runtime.dispatch("ScoreboardGrowth::Submission.Submit", id: { value: "s2" }, player: "Amy", points: 1)
+
+    rows = runtime.query("ScoreboardGrowth::Submission.PerPlayer")
+
+    expect(rows).to eq([{ player: "Amy", count: 1 }, { player: "Zed", count: 1 }])
+  end
+end


### PR DESCRIPTION
Adds `group_by :field` to Query: a real, third scalar-reduction shape riding the same where-clauses an ordinary query already applies, except it doesn't reduce to one scalar — it partitions the where-filtered set by `field`'s value and tallies each partition.

**Finding**: `docs/hecks-migration-findings.md` — matches what deciderate's own `PerPlayer`/leaderboard queries need ("the player leaderboard: submissions tallied per player"). Returns one row per distinct value, `field => value, count: N`, ordered by count descending (a leaderboard's own natural order) then by the group value for ties, so output is deterministic.

**Scope note**: the original commit this is split from (`28dd3fc`) actually bundled five distinct things (`count`, `median`, `group_by`, a `scope_to` no-op stub, and the unrelated `none_in_state` anti-join comparator) plus a sixth, completely unflagged entity-query bug fix — the original split plan only named two of these (`group_by` and `none_in_state`). This PR is `group_by` alone; `count`, `median`, `scope_to`, `none_in_state`, and the entity-query fix each land as their own PR, stacked after this one, per the corrected plan.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 5 failures at this point in the stack (up from 4 before this PR by exactly one expected new gap — `syntax_conformance_spec` now flags that `QueryBuilder#group_by` isn't yet a declared grammar word; that lands with the self-hosted-grammar-registration item later in this split, same pattern as the other deferred gaps already noted on PR #22). None of the 5 are regressions of anything that passed before this PR.

Split out of the original bundled PR #16 — stacks on #22.
