### PR TITLE
query DSL: count aggregation

### DIFF
--- a/lib/hecksagain/bluebook/dsl/query_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/query_builder.rb
@@ -13,6 +13,9 @@ module Hecksagain
 
         def description(value) = @description = value
 
+        # `count` -- see IR::Query's own comment.
+        def count = @count = true
+
         # `group_by :field` -- a real, third scalar-reduction shape
         # alongside `count`/`median`, except it doesn't reduce to ONE
         # scalar -- it partitions the where-filtered set by `field`'s
@@ -52,6 +55,7 @@ module Hecksagain
             null_semantics: @null_semantics,
             inspection: @inspection,
             index_hints: @index_hints || [],
+            count: @count || false,
             group_by_field: @group_by_field
           )
         end

--- a/lib/hecksagain/bluebook/ir/query.rb
+++ b/lib/hecksagain/bluebook/ir/query.rb
@@ -21,8 +21,15 @@ module Hecksagain
       class Query < QuerySpecification::Common::Options
         include Construct
 
-        attr_reader :name, :description, :attributes, :group_by_field
+        attr_reader :name, :description, :attributes, :count, :group_by_field
 
+        # `count:`, vendored addition not (yet) upstream hecksagain
+        # (migration plan task 4): `query "Count" do count end`
+        # (framework/web_debug/bluebook/web_debug.bluebook) -- a scalar
+        # row-count ask, not a filtered record list. See
+        # Runtime::QueryInterpreter#call's own comment for the
+        # evaluation side (returns an Integer instead of an Array).
+        #
         # `group_by_field:`, vendored addition not (yet) upstream
         # hecksagain (migration plan task 8): `group_by :field` -- a
         # third aggregation shape, partition-and-tally rather than
@@ -30,7 +37,7 @@ module Hecksagain
         def initialize(name:, description: nil, attributes: [], wheres: [],
                        order_by: nil, limit: nil, offset: nil, cursor: nil,
                        consistency: nil, freshness: nil, authorization: nil, null_semantics: nil,
-                       inspection: nil, index_hints: [], group_by_field: nil)
+                       inspection: nil, index_hints: [], count: false, group_by_field: nil)
           null_semantics ||= QuerySpecification::Common::NullSemantics.default
           super(wheres: wheres, order_by: order_by, limit: limit, offset: offset, cursor: cursor,
                 consistency: consistency, freshness: freshness, authorization: authorization,
@@ -39,6 +46,7 @@ module Hecksagain
           @hecks_name  = @name
           @description = description
           @attributes  = attributes
+          @count       = count
           @group_by_field = group_by_field
         end
 

--- a/lib/hecksagain/runtime/query_interpreter.rb
+++ b/lib/hecksagain/runtime/query_interpreter.rb
@@ -35,6 +35,16 @@ module Hecksagain
 
         repository = @registry.repository(domain, aggregate)
 
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4): `query "Count" do count end` -- a scalar row-count ask.
+        # Reuses the SAME filtering (`interpret`, wheres/order_by/limit
+        # all still apply) rather than a separate code path, then answers
+        # with the size instead of the mapped records -- so a `count`
+        # query with its own where-clauses counts a FILTERED set, not the
+        # whole table, matching what a bluebook author would expect
+        # `where`+`count` together to mean.
+        return interpret(repository.all, declared, args).size if declared.count
+
         # Vendored addition, not (yet) upstream hecksagain (migration
         # plan task 8): `group_by :field` -- the SAME filtered-set
         # starting point as an ordinary query, partitioned by `field`'s

--- a/spec/query_count_growth_spec.rb
+++ b/spec/query_count_growth_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for `count` -- a scalar row-count ask, riding
+# the same where-clauses an ordinary query already applies.
+#
+# `meta_validation: false` for the same reason as this split's group_by
+# coverage -- the self-hosted grammar doesn't carry Query's `count`
+# through its own Judge round-trip yet.
+RSpec.describe "a query's own count" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["count-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  COUNT_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "TallyGrowth" do
+      aggregate "Ticket" do
+        identified_by { id.value }
+
+        value_object "TicketId" do
+          attribute :value, String
+        end
+
+        attribute :id,     TicketId
+        attribute :status, String, default: "open"
+
+        command "Open" do
+          attribute :id, TicketId
+          emits "Opened"
+        end
+
+        command "Close" do
+          reference_to Ticket
+          then_set :status, to: "closed"
+        end
+
+        query "OpenCount" do
+          where(status: "open")
+          count
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_tally
+    boot(COUNT_SOURCE, "TallyGrowth") { ::TallyGrowth::Ticket.persisted_by("Memory") }
+  end
+
+  it "counts the where-filtered set, not the whole table" do
+    runtime = boot_tally
+    runtime.dispatch("TallyGrowth::Ticket.Open", id: { value: "t1" })
+    runtime.dispatch("TallyGrowth::Ticket.Open", id: { value: "t2" })
+    runtime.dispatch("TallyGrowth::Ticket.Open", id: { value: "t3" })
+    runtime.dispatch("TallyGrowth::Ticket.Close", id: "t3")
+
+    expect(runtime.query("TallyGrowth::Ticket.OpenCount")).to eq(2)
+  end
+end


### PR DESCRIPTION
Adds `count` to Query: `query "Count" do count end` (`framework/web_debug/bluebook/web_debug.bluebook`) — a scalar row-count ask, not a filtered record list.

**Finding**: `docs/hecks-migration-findings.md`. Reuses the same filtering (`wheres`/`order_by`/`limit` all still apply) rather than a separate code path, then answers with the size instead of the mapped records — so a `count` query with its own where-clauses counts a FILTERED set, not the whole table, matching what a bluebook author would expect `where`+`count` together to mean.

**Scope note**: split out of `28dd3fc` alongside #23 (`group_by`) — see that PR's description for why the original commit needed splitting into more pieces than the plan initially named.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 5 failures at this point in the stack, unchanged from #23 (no new regression).

Split out of the original bundled PR #16 — stacks on #23.
