### PR TITLE
query DSL: median aggregation

### DIFF
--- a/lib/hecksagain/bluebook/dsl/query_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/query_builder.rb
@@ -16,6 +16,16 @@ module Hecksagain
         # `count` -- see IR::Query's own comment.
         def count = @count = true
 
+        # `median :field` -- the SAME shape as `count` (a scalar
+        # reduction over the filtered set, riding the where-clauses
+        # that already apply), one field further -- deciderate's own
+        # vision names this explicitly ("proves the grown query DSL
+        # (aggregation)"; Consensus.median :estimate -- "the ESTIMATION
+        # answer: the median estimate across a decision's submissions").
+        # See Runtime::QueryInterpreter#call's own comment for the
+        # evaluation side.
+        def median(field) = @median_field = field.to_sym
+
         # `group_by :field` -- a real, third scalar-reduction shape
         # alongside `count`/`median`, except it doesn't reduce to ONE
         # scalar -- it partitions the where-filtered set by `field`'s
@@ -56,6 +66,7 @@ module Hecksagain
             inspection: @inspection,
             index_hints: @index_hints || [],
             count: @count || false,
+            median_field: @median_field,
             group_by_field: @group_by_field
           )
         end

--- a/lib/hecksagain/bluebook/ir/query.rb
+++ b/lib/hecksagain/bluebook/ir/query.rb
@@ -21,7 +21,7 @@ module Hecksagain
       class Query < QuerySpecification::Common::Options
         include Construct
 
-        attr_reader :name, :description, :attributes, :count, :group_by_field
+        attr_reader :name, :description, :attributes, :count, :median_field, :group_by_field
 
         # `count:`, vendored addition not (yet) upstream hecksagain
         # (migration plan task 4): `query "Count" do count end`
@@ -30,6 +30,11 @@ module Hecksagain
         # Runtime::QueryInterpreter#call's own comment for the
         # evaluation side (returns an Integer instead of an Array).
         #
+        # `median_field:`, vendored addition not (yet) upstream
+        # hecksagain (migration plan task 8): `median :field` -- the
+        # same scalar-reduction shape as `count`, one field further. See
+        # QueryBuilder#median's own comment.
+        #
         # `group_by_field:`, vendored addition not (yet) upstream
         # hecksagain (migration plan task 8): `group_by :field` -- a
         # third aggregation shape, partition-and-tally rather than
@@ -37,7 +42,8 @@ module Hecksagain
         def initialize(name:, description: nil, attributes: [], wheres: [],
                        order_by: nil, limit: nil, offset: nil, cursor: nil,
                        consistency: nil, freshness: nil, authorization: nil, null_semantics: nil,
-                       inspection: nil, index_hints: [], count: false, group_by_field: nil)
+                       inspection: nil, index_hints: [], count: false, median_field: nil,
+                       group_by_field: nil)
           null_semantics ||= QuerySpecification::Common::NullSemantics.default
           super(wheres: wheres, order_by: order_by, limit: limit, offset: offset, cursor: cursor,
                 consistency: consistency, freshness: freshness, authorization: authorization,
@@ -47,6 +53,7 @@ module Hecksagain
           @description = description
           @attributes  = attributes
           @count       = count
+          @median_field = median_field
           @group_by_field = group_by_field
         end
 

--- a/lib/hecksagain/runtime/query_interpreter.rb
+++ b/lib/hecksagain/runtime/query_interpreter.rb
@@ -46,6 +46,27 @@ module Hecksagain
         return interpret(repository.all, declared, args).size if declared.count
 
         # Vendored addition, not (yet) upstream hecksagain (migration
+        # plan task 8): `median :field` -- the SAME filtered-then-reduce
+        # shape as `count` just above, one field further (deciderate's
+        # own Consensus query: "the median estimate across a decision's
+        # submissions" -- a where-filtered set folded to one number).
+        # Standard median (sorted middle value ; average of the two
+        # middle values on an even count) over whichever scalars the
+        # field actually holds -- `comparable` unwraps a Value/Hash field
+        # the same way ordering/comparison already do elsewhere in this
+        # file, so a VO-wrapped numeric field reduces the same as a bare
+        # one. An empty filtered set has no median -- nil, not a crash.
+        if declared.median_field
+          values = interpret(repository.all, declared, args)
+                     .map { |row| comparable(row[declared.median_field]) }
+                     .compact.sort
+          return nil if values.empty?
+
+          mid = values.size / 2
+          return values.size.odd? ? values[mid] : (values[mid - 1] + values[mid]) / 2.0
+        end
+
+        # Vendored addition, not (yet) upstream hecksagain (migration
         # plan task 8): `group_by :field` -- the SAME filtered-set
         # starting point as an ordinary query, partitioned by `field`'s
         # value instead of returned as a flat list (deciderate's own

--- a/spec/query_median_growth_spec.rb
+++ b/spec/query_median_growth_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for `median :field` -- the same filtered-then-
+# reduce shape as `count`, one field further.
+#
+# `meta_validation: false` for the same reason as this split's other
+# query-reduction coverage.
+RSpec.describe "a query's own median" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["median-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  MEDIAN_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "ConsensusGrowth" do
+      aggregate "Estimate" do
+        identified_by { id.value }
+
+        value_object "EstimateId" do
+          attribute :value, String
+        end
+
+        attribute :id,    EstimateId
+        attribute :points, Integer
+
+        command "Submit" do
+          attribute :id,     EstimateId
+          attribute :points, Integer
+          emits "Submitted"
+        end
+
+        query "MedianPoints" do
+          median :points
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_consensus
+    boot(MEDIAN_SOURCE, "ConsensusGrowth") { ::ConsensusGrowth::Estimate.persisted_by("Memory") }
+  end
+
+  it "reduces an odd-count filtered set to its sorted middle value" do
+    runtime = boot_consensus
+    [3, 8, 5].each_with_index do |points, i|
+      runtime.dispatch("ConsensusGrowth::Estimate.Submit", id: { value: "e#{i}" }, points: points)
+    end
+
+    expect(runtime.query("ConsensusGrowth::Estimate.MedianPoints")).to eq(5)
+  end
+
+  it "averages the two middle values on an even-count filtered set" do
+    runtime = boot_consensus
+    [3, 8, 5, 13].each_with_index do |points, i|
+      runtime.dispatch("ConsensusGrowth::Estimate.Submit", id: { value: "e#{i}" }, points: points)
+    end
+
+    expect(runtime.query("ConsensusGrowth::Estimate.MedianPoints")).to eq(6.5)
+  end
+end


### PR DESCRIPTION
Adds `median :field` to Query: the same shape as `count` (a scalar reduction over the filtered set, riding the where-clauses that already apply), one field further — deciderate's `Consensus.median :estimate` ("the ESTIMATION answer: the median estimate across a decision's submissions").

**Finding**: `docs/hecks-migration-findings.md`. Standard median (sorted middle value; average of the two middle values on an even count) over whichever scalars the field actually holds — `comparable` unwraps a Value/Hash field the same way ordering/comparison already do elsewhere in this file, so a VO-wrapped numeric field reduces the same as a bare one. An empty filtered set has no median — `nil`, not a crash.

**Scope note**: split out of `28dd3fc` alongside #23/#24 — see #23's description for why the original commit needed splitting further than the plan initially named.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 5 failures at this point in the stack, unchanged from #24 (no new regression).

Split out of the original bundled PR #16 — stacks on #24.
