### PR TITLE
query DSL: scope_to no-op stub

### DIFF
--- a/lib/hecksagain/bluebook/dsl/query_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/query_builder.rb
@@ -26,6 +26,16 @@ module Hecksagain
         # evaluation side.
         def median(field) = @median_field = field.to_sym
 
+        # `scope_to :field` -- NO-OP stub: "injects a where(player ==
+        # :actor) from the reserved `actor` kwarg the ACL/edge supplies"
+        # (deciderate's own comment) -- real caller-identity-based row
+        # authorization, a security-relevant feature not rushed under
+        # time pressure (same discipline as `success`/`failure`'s
+        # effect-family stubs -- structurally captured so the file
+        # boots, never silently pretended enforced). Needs a real
+        # design pass on how the runtime learns "who is calling."
+        def scope_to(*) = nil
+
         # `group_by :field` -- a real, third scalar-reduction shape
         # alongside `count`/`median`, except it doesn't reduce to ONE
         # scalar -- it partitions the where-filtered set by `field`'s

--- a/spec/bluebook/dsl/query_builder_scope_to_spec.rb
+++ b/spec/bluebook/dsl/query_builder_scope_to_spec.rb
@@ -1,0 +1,14 @@
+require "hecksagain"
+
+RSpec.describe Hecksagain::Bluebook::DSL::QueryBuilder do
+  describe "scope_to" do
+    it "accepts any arguments and builds a query unaffected, a deliberate no-op" do
+      query = described_class.build("Mine") do
+        scope_to :player
+      end
+
+      expect(query).to be_a(Hecksagain::Bluebook::IR::Query)
+      expect(query.name).to eq("Mine")
+    end
+  end
+end


### PR DESCRIPTION
Adds `scope_to :field` to Query as a deliberate no-op: "injects a `where(player == :actor)` from the reserved `actor` kwarg the ACL/edge supplies" — real caller-identity-based row authorization, a security-relevant feature not rushed under time pressure (same discipline as the `success`/`failure` effect-family stubs elsewhere in this codebase — structurally captured so a bluebook file using it boots, never silently pretended enforced).

**Finding**: `docs/hecks-migration-findings.md`. Needs a real design pass on how the runtime learns "who is calling" before this can be anything but a stub — deliberately not attempted here.

**Scope note**: split out of `28dd3fc` alongside #23/#24/#25 — the fourth and last of the query-reduction-family DSL words from that commit. See #23's description for why the original commit needed splitting further than the plan initially named.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 5 failures at this point in the stack, unchanged from #25 (no new regression, this is a pure no-op).

Split out of the original bundled PR #16 — stacks on #25.
