### PR TITLE
query DSL: none_in_state cross-aggregate anti-join comparator

### DIFF
--- a/lib/hecksagain/query_specification/common/comparators.rb
+++ b/lib/hecksagain/query_specification/common/comparators.rb
@@ -3,7 +3,16 @@ require_relative "../../literal"
 module Hecksagain
   module QuerySpecification
     module Common
-      COMPARATORS = %i[eq ne gt gte lt lte in contains].freeze
+      # `none_in_state`, vendored addition not (yet) upstream hecksagain
+      # (migration plan task 4): a CROSS-AGGREGATE ANTI-JOIN comparator --
+      # `where ref: { none_in_state: "Claim:held" }` holds true when NO
+      # record in the named aggregate, keyed by this record's own field
+      # value, is currently in the named state. plan.bluebook's own
+      # description: "a keyed point lookup (HashMap hit), never a scan" --
+      # a real, deliberate, pre-existing feature (WhereOp::NoneInState in
+      # the old Rust runtime), not invented here -- see Runtime::
+      # QueryInterpreter#holds?'s own comment for the evaluation side.
+      COMPARATORS = %i[eq ne gt gte lt lte in contains none_in_state].freeze
     end
 
     # The specification structs' own name for the one wire spelling — see

--- a/lib/hecksagain/runtime/query_interpreter.rb
+++ b/lib/hecksagain/runtime/query_interpreter.rb
@@ -43,7 +43,7 @@ module Hecksagain
         # query with its own where-clauses counts a FILTERED set, not the
         # whole table, matching what a bluebook author would expect
         # `where`+`count` together to mean.
-        return interpret(repository.all, declared, args).size if declared.count
+        return interpret(repository.all, declared, args, domain: domain).size if declared.count
 
         # Vendored addition, not (yet) upstream hecksagain (migration
         # plan task 8): `median :field` -- the SAME filtered-then-reduce
@@ -57,7 +57,7 @@ module Hecksagain
         # file, so a VO-wrapped numeric field reduces the same as a bare
         # one. An empty filtered set has no median -- nil, not a crash.
         if declared.median_field
-          values = interpret(repository.all, declared, args)
+          values = interpret(repository.all, declared, args, domain: domain)
                      .map { |row| comparable(row[declared.median_field]) }
                      .compact.sort
           return nil if values.empty?
@@ -78,7 +78,7 @@ module Hecksagain
         # way `ordered` already does.
         if declared.group_by_field
           field = declared.group_by_field
-          groups = interpret(repository.all, declared, args)
+          groups = interpret(repository.all, declared, args, domain: domain)
                      .group_by { |row| comparable(row[field]) }
           return groups.map { |value, rows| { field => value, count: rows.size } }
                        .sort_by { |row| [-row[:count], row[field].to_s] }
@@ -96,7 +96,7 @@ module Hecksagain
           return records.map { |record| record.state.merge(id: record.id) }
         end
 
-        interpret(repository.all, declared, args)
+        interpret(repository.all, declared, args, domain: domain)
       end
 
       # The REFERENCE answer — this interpreter's own evaluation, never an
@@ -132,8 +132,8 @@ module Hecksagain
                                                     aggregate: aggregate.hecks_name, query: query_name.inspect))
       end
 
-      def interpret(records, declared, args)
-        matched = records.select { |r| declared.wheres.all? { |w| where_holds?(w, r, args) } }
+      def interpret(records, declared, args, domain: nil)
+        matched = records.select { |r| declared.wheres.all? { |w| where_holds?(w, r, args, domain: domain) } }
         ordered = ordered(matched, declared.order_by, declared.null_semantics)
         capped  = declared.limit ? ordered.first(resolve_query_value(declared.limit.value, args).to_i) : ordered
 
@@ -239,11 +239,11 @@ module Hecksagain
         ) { |row| comparable(QuerySpecification::FieldPath.dig(row, field)) }
       end
 
-      def where_holds?(clause, record, args)
-        holds?(clause, QuerySpecification::FieldPath.dig(record, clause.field), args)
+      def where_holds?(clause, record, args, domain: nil)
+        holds?(clause, QuerySpecification::FieldPath.dig(record, clause.field), args, record: record, domain: domain)
       end
 
-      def holds?(clause, held, args)
+      def holds?(clause, held, args, record: nil, domain: nil)
         held = comparable(held)
         want = comparable(resolve_query_value(clause.value, args))
 
@@ -256,8 +256,43 @@ module Hecksagain
         when "gte"      then ordered?(held, want) && held >= want
         when "in"       then members(want).include?(held.to_s)
         when "contains" then contains?(held, want)
+        when "none_in_state" then none_in_state?(held, want)
         else                 held == want
         end
+      end
+
+      # Vendored addition, not (yet) upstream hecksagain (migration plan
+      # task 4) -- see comparators.rb's own comment on `none_in_state`
+      # itself. `want` is "Aggregate:state" (a literal, never resolved
+      # through `resolve_query_value`'s Symbol path -- the target names a
+      # TYPE, not an argument). `held` is THIS record's own field value,
+      # already unwrapped by `comparable` -- the point-lookup key. No
+      # `domain:` qualifier on "Aggregate" because the corpus's own usage
+      # never gives one (plan.bluebook's Story reaching Conductor's Claim)
+      # -- searched by bare name across every loaded domain, the same
+      # single free-text lookup `HecksagainRuntime.state` already does for
+      # a caller-supplied aggregate FQN. Ambiguous (two domains declaring
+      # the same aggregate name) is a real, theoretical gap -- picks the
+      # first match rather than refusing, since a where-clause never
+      # raises (see `ordered?`'s own comment on the same contract).
+      def none_in_state?(held, want)
+        aggregate_name, state = want.to_s.split(":", 2)
+        target = find_aggregate_by_name(aggregate_name)
+        return true unless target
+
+        target_domain, target_ir = target
+        record = @registry.repository(target_domain, target_ir).find(held)
+        return true unless record
+
+        comparable(record.state[:state]) != state
+      end
+
+      def find_aggregate_by_name(name)
+        @registry.bluebooks.each do |domain, bluebook|
+          aggregate = bluebook.aggregates.find { |a| a.hecks_name == name }
+          return [domain, aggregate] if aggregate
+        end
+        nil
       end
 
       # gt/gte/lt/lte are numeric-only and silently false otherwise — a

--- a/spec/query_none_in_state_growth_spec.rb
+++ b/spec/query_none_in_state_growth_spec.rb
@@ -1,0 +1,131 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for `none_in_state` -- finding #13, a
+# cross-aggregate anti-join comparator: `where field: { none_in_state:
+# "Aggregate:state" }` holds when the record `field`'s value points at
+# is NOT currently in that state (including when it points at no record
+# at all). Exercised on an ENTITY query -- the equivalent AGGREGATE-level
+# query has a separate, later-landing gap in `Ports::Query::InMemory`
+# this coverage does not exercise.
+#
+# `meta_validation: false` -- the self-hosted grammar's own
+# Vocabulary::QueryComparator doesn't admit `none_in_state` yet (a
+# separate, later-landing item in this split registers the new
+# comparator word); turned off here so what's under test is this PR's
+# own comparator/interpreter pair, not that separate gap.
+RSpec.describe "none_in_state, a cross-aggregate anti-join" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["anti-join-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  NONE_IN_STATE_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "AntiJoinGrowth" do
+      aggregate "Claim" do
+        identified_by { id.value }
+
+        value_object "ClaimId" do
+          attribute :value, String
+        end
+
+        value_object "ClaimState" do
+          attribute :value, String, default: "held"
+        end
+
+        attribute :id,    ClaimId
+        attribute :state, ClaimState
+
+        command "File" do
+          attribute :id, ClaimId
+          emits "Filed"
+        end
+
+        command "Release" do
+          reference_to Claim
+          then_set :state, to: { value: "released" }
+        end
+      end
+
+      aggregate "Board" do
+        identified_by { id.value }
+
+        value_object "BoardId" do
+          attribute :value, String
+        end
+
+        attribute :id,          BoardId
+        attribute :assignments, list_of(Assignment)
+
+        entity "Assignment" do
+          identified_by { claim_id.value }
+
+          attribute :claim_id, String
+
+          query "Unclaimed" do
+            where claim_id: { none_in_state: "Claim:held" }
+          end
+        end
+
+        command "Open" do
+          attribute :id, BoardId
+          emits "Opened"
+        end
+
+        command "Assign" do
+          reference_to Board
+          attribute :claim_id, String
+          then_set :assignments, append: { claim_id: :claim_id }
+          emits "Assigned"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_anti_join
+    boot(NONE_IN_STATE_SOURCE, "AntiJoinGrowth") do
+      ::AntiJoinGrowth::Claim.persisted_by("Memory")
+      ::AntiJoinGrowth::Board.persisted_by("Memory")
+    end
+  end
+
+  it "excludes an assignment whose claim IS in the named state, and keeps the rest" do
+    runtime = boot_anti_join
+    runtime.dispatch("AntiJoinGrowth::Claim.File", id: { value: "c1" })  # stays "held"
+    runtime.dispatch("AntiJoinGrowth::Claim.File", id: { value: "c2" })
+    runtime.dispatch("AntiJoinGrowth::Claim.Release", id: "c2")          # no longer "held"
+
+    runtime.dispatch("AntiJoinGrowth::Board.Open", id: { value: "b1" })
+    runtime.dispatch("AntiJoinGrowth::Board.Assign", id: "b1", claim_id: "c1")
+    runtime.dispatch("AntiJoinGrowth::Board.Assign", id: "b1", claim_id: "c2")
+    # A claim that was never filed at all — "no record in that state" reads
+    # the same as "a record, but not in that state".
+    runtime.dispatch("AntiJoinGrowth::Board.Assign", id: "b1", claim_id: "nonexistent")
+
+    rows = runtime.query("AntiJoinGrowth::Board.Assignment.Unclaimed")
+
+    expect(rows.map { |row| row[:claim_id] }).to contain_exactly("c2", "nonexistent")
+  end
+end


### PR DESCRIPTION
Adds `none_in_state` to the where-clause comparator vocabulary: a CROSS-AGGREGATE ANTI-JOIN comparator — `where ref: { none_in_state: "Claim:held" }` holds true when NO record in the named aggregate, keyed by this record's own field value, is currently in the named state.

**Finding**: `docs/hecks-migration-findings.md`. `plan.bluebook`'s own description: "a keyed point lookup (HashMap hit), never a scan" — a real, deliberate, pre-existing feature (`WhereOp::NoneInState` in the old Rust runtime), not invented here.

Threads `domain:` through `QueryInterpreter#interpret`/`where_holds?`/`holds?` and adds a registry-wide by-bare-name aggregate lookup (`find_aggregate_by_name`) so `none_in_state` resolves as a real keyed point-lookup. `want` is `"Aggregate:state"` (a literal, never resolved through the Symbol/argument path — the target names a TYPE). No `domain:` qualifier on `"Aggregate"` because the corpus's own usage never gives one — searched by bare name across every loaded domain, the same single free-text lookup `HecksagainRuntime.state` already does for a caller-supplied aggregate FQN. Ambiguous names (two domains declaring the same aggregate) pick the first match rather than refusing, since a where-clause never raises.

**Scope note**: split out of `28dd3fc` — the sixth and last DSL/comparator piece of that commit (after `group_by` #23, `count` #24, `median` #25, `scope_to` #26). The `domain:` threading is bundled here rather than split further since the commit message ties it specifically to this feature, even though `none_in_state?` itself doesn't consume `domain` yet. A seventh, completely unflagged item from the same original commit — an entity-query scoping bug fix — follows as its own PR next.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 6 failures at this point in the stack (up 1 expected gap from #26: `vocabulary_conformance_spec` wants `none_in_state` registered in the self-hosted grammar's vocabulary, landing with the grammar-registration item later in this split). None of the 6 are regressions.

Split out of the original bundled PR #16 — stacks on #26.
