### PR TITLE
runtime: entity queries scope to their own named parent, not every parent

### DIFF
--- a/lib/hecksagain/runtime/query_interpreter.rb
+++ b/lib/hecksagain/runtime/query_interpreter.rb
@@ -189,13 +189,17 @@ module Hecksagain
         declared = entity.query(query_name) ||
                    raise(UnknownVerb, RefusalWording.render("UnknownVerb", "entity_query_missing",
                                                              entity: entity_name, query: query_name.inspect))
+        args = normalize_args(aggregate, declared, args)
         declared = TenantScope.apply(declared, args)
         list_attr = aggregate.attributes.find { |a| a.list? && a.type.to_s == entity_name } ||
                     raise(UnknownVerb, RefusalWording.render("UnknownVerb", "entity_holds_no_list",
                                                               aggregate: aggregate.hecks_name, entity: entity_name))
 
-        parent_key = Naming.reference_key(aggregate.hecks_name)
-        rows = @registry.repository(domain, aggregate).all.flat_map do |record|
+        parent_key     = Naming.reference_key(aggregate.hecks_name)
+        repository     = @registry.repository(domain, aggregate)
+        parent_records = scoped_parents(aggregate, declared, args, repository)
+
+        rows = parent_records.flat_map do |record|
           Array(record[list_attr.name])
             .select { |el| declared.wheres.all? { |w| element_where_holds?(w, el, args) } }
             .map    { |el| { parent_key => record.id }.merge(el) }
@@ -204,6 +208,26 @@ module Hecksagain
         ordered = ordered_elements(rows, declared.order_by, declared.null_semantics,
                                    parent_key, entity.identity_heads)
         declared.limit ? ordered.first(resolve_query_value(declared.limit.value, args).to_i) : ordered
+      end
+
+      # ONE PARENT, NOT EVERY PARENT — an entity query that declares
+      # `reference_to <ItsOwnAggregate>` (PersonalList.Item.OnList's own
+      # `reference_to PersonalList`, say) is asking to be scoped the
+      # same way an ordinary query's `where(field: :arg)` already scopes
+      # a plain aggregate query — this is that same ask, one level down,
+      # answered by finding the ONE named record directly rather than
+      # flat-mapping every record's own list and filtering afterward.
+      # Absent the argument, or absent a matching reference_to on the
+      # query at all, every parent is still walked — unchanged from
+      # before this existed, and still how a query meant to span every
+      # list (an admin's "everything on every list," if one existed)
+      # keeps working.
+      def scoped_parents(aggregate, declared, args, repository)
+        parent_ref = declared.attributes.find { |a| a.reference? && a.type.target_name == aggregate.hecks_name }
+        return repository.all unless parent_ref && args.key?(parent_ref.name)
+
+        record = repository.find(args[parent_ref.name])
+        record ? [record] : []
       end
 
       def element_where_holds?(clause, element, args)

--- a/spec/entity_query_scoped_parents_spec.rb
+++ b/spec/entity_query_scoped_parents_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the entity-query "ONE PARENT, NOT EVERY
+# PARENT" fix: an entity query declaring `reference_to <ItsOwnAggregate>`
+# finds the one named parent record directly, rather than flat-mapping
+# every parent's own list and filtering afterward.
+#
+# Aggregate/entity names deliberately unique across this whole suite
+# (not "Item"/"PersonalList") -- generic fixture names have caused real,
+# order-dependent collisions elsewhere in this corpus (see dsl_spec.rb's
+# own comment on the "Widget" collision it hit and fixed the same way).
+RSpec.describe "an entity query scoped to its own named parent" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["scoped-parents-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    file&.close!
+  end
+
+  SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "ScopedParentsGrowth" do
+      aggregate "GrowthRoster" do
+        identified_by { id.value }
+
+        value_object "GrowthRosterId" do
+          attribute :value, String
+        end
+
+        attribute :id,      GrowthRosterId
+        attribute :entries, list_of(GrowthEntry)
+
+        entity "GrowthEntry" do
+          identified_by { entry_id.value }
+
+          attribute :entry_id, String
+
+          query "OnRoster" do
+            reference_to GrowthRoster
+          end
+        end
+
+        command "Open" do
+          attribute :id, GrowthRosterId
+          emits "Opened"
+        end
+
+        command "AddEntry" do
+          reference_to GrowthRoster
+          attribute :entry_id, String
+          then_set :entries, append: { entry_id: :entry_id }
+          emits "EntryAdded"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_rosters
+    boot(SOURCE, "ScopedParentsGrowth") { ::ScopedParentsGrowth::GrowthRoster.persisted_by("Memory") }
+  end
+
+  it "finds only the named parent's own entries, not every roster's" do
+    runtime = boot_rosters
+    runtime.dispatch("ScopedParentsGrowth::GrowthRoster.Open", id: { value: "roster1" })
+    runtime.dispatch("ScopedParentsGrowth::GrowthRoster.Open", id: { value: "roster2" })
+    runtime.dispatch("ScopedParentsGrowth::GrowthRoster.AddEntry", id: "roster1", entry_id: "a")
+    runtime.dispatch("ScopedParentsGrowth::GrowthRoster.AddEntry", id: "roster2", entry_id: "b")
+
+    rows = runtime.query("ScopedParentsGrowth::GrowthRoster.GrowthEntry.OnRoster", growth_roster_id: "roster1")
+
+    expect(rows.map { |row| row[:entry_id] }).to eq(["a"])
+  end
+end


### PR DESCRIPTION
`QueryInterpreter#entity_rows` walked EVERY parent record's own list and filtered afterward, even when the entity query declares `reference_to <ItsOwnAggregate>` (`PersonalList.Item.OnList`'s own `reference_to PersonalList`, say) naming exactly which parent it means.

An entity query that scopes to its own aggregate is asking to be scoped the same way an ordinary query's `where(field: :arg)` already scopes a plain aggregate query — this is that same ask, one level down, now answered by finding the ONE named record directly (`scoped_parents`) rather than flat-mapping every record's own list and filtering afterward. Absent the argument, or absent a matching `reference_to` on the query at all, every parent is still walked — unchanged from before this existed, and still how a query meant to span every list (an admin's "everything on every list," if one existed) keeps working.

**Scope note**: found on real-diff read of `28dd3fc` — a real, independent bug fixed alongside that commit's query-DSL-aggregation work, but functionally unrelated to `count`/`median`/`group_by`/`scope_to`/`none_in_state` (#23-#27). Not mentioned anywhere in that commit's own message; the original split plan didn't know to look for it. Gets its own PR here rather than being silently folded into one of the aggregation PRs.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 6 failures at this point in the stack, unchanged from #27 (no new regression). Diffing the reconstructed `query_interpreter.rb`/`query_builder.rb`/`ir/query.rb`/`comparators.rb` against `28dd3fc`'s own final tree at this point in the stack is byte-identical (net of two comment-wording differences from `group_by` landing before `count`/`median` in this split's own order) — confirms all seven real pieces of that commit (#23-#27 plus this PR) are accounted for.

Split out of the original bundled PR #16 — stacks on #27.
