### PR TITLE
IR::Policy gains with_literals/wheres/for_each constructor support

### DIFF
--- a/lib/hecksagain/bluebook/ir/policy.rb
+++ b/lib/hecksagain/bluebook/ir/policy.rb
@@ -7,7 +7,7 @@ module Hecksagain
         # that has crossed over and of an IR object that has not. Collapses into
         # Construct when this one crosses.
         def hecks_name = @name
-        attr_reader :name, :on_event, :trigger_command, :target_domain
+        attr_reader :name, :on_event, :trigger_command, :target_domain, :with_literals, :wheres, :for_each
 
         # WHICH HEAD DECLARED IT, or nil for one declared on the chapter.
         #
@@ -19,12 +19,22 @@ module Hecksagain
         # contract, and it does not carry this.
         attr_accessor :aggregate
 
-        def initialize(name:, on_event: nil, trigger_command: nil, target_domain: nil, aggregate: nil)
+        # with_literals -- vendored addition, not (yet) upstream
+        # hecksagain. hecks_conception's PolicyBuilder supports repeated
+        # `with "key", "value"` calls supplying extra literal payload
+        # attributes for the triggered command (5 files, e.g.
+        # agent_instrumentation.bluebook's EstablishSidequestAgent).
+        # TODO upstream via bin/evolve (migration plan task 7).
+        def initialize(name:, on_event: nil, trigger_command: nil, target_domain: nil, aggregate: nil,
+                       with_literals: {}, wheres: {}, for_each: nil)
           @name            = name.to_s
           @on_event        = on_event
           @trigger_command = trigger_command
           @target_domain   = target_domain
           @aggregate       = aggregate&.to_s
+          @with_literals   = with_literals
+          @wheres          = wheres
+          @for_each        = for_each
         end
 
         def event_qualifier = Naming.qualifier(@on_event)

--- a/spec/bluebook/ir/policy_wheres_for_each_with_literals_spec.rb
+++ b/spec/bluebook/ir/policy_wheres_for_each_with_literals_spec.rb
@@ -1,0 +1,23 @@
+require "hecksagain"
+
+RSpec.describe Hecksagain::Bluebook::IR::Policy do
+  describe "with_literals/wheres/for_each" do
+    it "accepts and reads back all three, defaulting to empty/nil when not given" do
+      bare = described_class.new(name: "Bare", on_event: "Thing.Happened", trigger_command: "Thing.React")
+
+      expect(bare.with_literals).to eq({})
+      expect(bare.wheres).to eq({})
+      expect(bare.for_each).to be_nil
+
+      full = described_class.new(
+        name: "Full", on_event: "Thing.Happened", trigger_command: "Thing.React",
+        with_literals: { "kind" => "urgent" }, wheres: { status: "critical" },
+        for_each: { from: "Thing.Rows", where: {} }
+      )
+
+      expect(full.with_literals).to eq("kind" => "urgent")
+      expect(full.wheres).to eq(status: "critical")
+      expect(full.for_each).to eq(from: "Thing.Rows", where: {})
+    end
+  end
+end


### PR DESCRIPTION
`IR::Policy` gains `with_literals`/`wheres`/`for_each` constructor support — pure plumbing, no new behavior in this PR by itself.

**Why this lands here, out of chronological order**: PolicyBuilder's own `where`/`for_each`/`with` DSL methods (landing in the next few PRs in this split) call `IR::Policy.new(with_literals:, wheres:, for_each:)`. `IR::Policy#initialize` doesn't accept those keywords until a much later commit in the original migration (`03b5ffc`, originally slated as this split's item 31). In the original author's own commit-by-commit history, this exact range was genuinely broken — `ArgumentError: unknown keyword` — for any bluebook using policy `where`/`for_each`/`with` between those two commits. This PR pulls just that one small, self-contained hunk forward so every PR after it is actually functional on its own, per the split plan's own "plumbing before the feature" dependency rule.

`with_literals`: `hecks_conception`'s `PolicyBuilder` supports repeated `with "key", "value"` calls supplying extra literal payload attributes for the triggered command (5 files, e.g. `agent_instrumentation.bluebook`'s `EstablishSidequestAgent`).

**Note for later PRs in this split**: when the rest of `03b5ffc` (IR category, driving-handler wire shape, rendering fix) is split into its own PRs, its `ir/policy.rb` hunk is already landed here — that later PR will not include it again.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 6 failures at this point in the stack, unchanged from #28 (no new regression — nothing calls the new keywords yet).

Split out of the original bundled PR #16 — stacks on #28.
