### PR TITLE
policy DSL: conditional where clauses

### DIFF
--- a/lib/hecksagain/bluebook/dsl/policy_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/policy_builder.rb
@@ -12,12 +12,27 @@ module Hecksagain
 
         def across(domain_name) = @target_domain = domain_name.to_s
 
+        # `where field: value` -- vendored addition, not (yet) upstream
+        # hecksagain (migration plan task 8): a conditional policy
+        # trigger, gating whether the policy fires on the triggering
+        # EVENT'S OWN PAYLOAD (not a stored-record query the way an
+        # aggregate query's `where` is) -- deciderate's own comment
+        # names it exactly : "the where-guard IS the 'round complete'
+        # condition -- the saga," AdvanceRound firing only when
+        # `games_remaining: 0` rides the ResolutionRecorded event. See
+        # Runtime::PolicyInterpreter#policies_for's own comment for the
+        # evaluation side.
+        def where(**conditions)
+          (@wheres ||= {}).merge!(conditions.transform_keys(&:to_sym))
+        end
+
         def build
           IR::Policy.new(
             name:            @name,
             on_event:        @on_event,
             trigger_command: @trigger_command,
-            target_domain:   @target_domain
+            target_domain:   @target_domain,
+            wheres:          @wheres || {}
           )
         end
 

--- a/lib/hecksagain/runtime/policy_interpreter.rb
+++ b/lib/hecksagain/runtime/policy_interpreter.rb
@@ -28,8 +28,24 @@ module Hecksagain
 
         bluebook.policies.select do |policy|
           policy.event_name == event.name &&
-            (policy.event_qualifier.nil? || policy.event_qualifier == emitting)
+            (policy.event_qualifier.nil? || policy.event_qualifier == emitting) &&
+            wheres_match?(policy, event)
         end
+      end
+
+      # `where field: value` -- vendored addition, not (yet) upstream
+      # hecksagain (migration plan task 8): see PolicyBuilder#where's own
+      # comment. A wheres-mismatch is NOT a refusal -- it means this
+      # policy simply doesn't apply to this particular event, the same
+      # as `policy.event_qualifier` not matching just above. Compared
+      # against the RAW event payload (symbolized), not a stored record
+      # -- a policy's where clause reads what the triggering event
+      # itself carried, not the aggregate's current state.
+      def wheres_match?(policy, event)
+        return true if policy.wheres.nil? || policy.wheres.empty?
+
+        payload = event.payload.transform_keys(&:to_sym)
+        policy.wheres.all? { |field, expected| payload[field] == expected }
       end
 
       def deliver(policy, event, domain)

--- a/spec/policy_where_growth_spec.rb
+++ b/spec/policy_where_growth_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for policy `where field: value` -- finding #11:
+# a policy only reacts when the triggering event's own payload matches;
+# a mismatch isn't a refusal, the policy just doesn't apply to this
+# event.
+#
+# `meta_validation: false` -- the self-hosted grammar's own Policy
+# contract doesn't carry `wheres` through its own Judge round-trip yet
+# (a separate, later-landing item in this split); turned off here so
+# what's under test is this PR's own DSL/interpreter pair.
+RSpec.describe "a policy's own where clause" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["policy-where-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  POLICY_WHERE_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "AlarmGrowth" do
+      aggregate "GrowthSensor" do
+        identified_by { id.value }
+
+        value_object "GrowthSensorId" do
+          attribute :value, String
+        end
+
+        value_object "GrowthStatus" do
+          attribute :value, String, default: "quiet"
+        end
+
+        attribute :id,     GrowthSensorId
+        attribute :status, GrowthStatus
+
+        # `severity` is deliberately NOT an aggregate field — a bare
+        # command argument the policy's where-clause reads straight off
+        # the emitted event's own payload, avoiding this stack point's
+        # separate (later-landing) bare-scalar-to-single-field-VO
+        # coercion gap entirely.
+        command "Report" do
+          attribute :id,       GrowthSensorId
+          attribute :severity, String
+          emits "Reported"
+        end
+
+        command "Alert" do
+          reference_to GrowthSensor
+          attribute :severity, String, optional: true
+          then_set :status, to: { value: "alerted" }
+        end
+
+        policy "AlertOnCritical" do
+          on "Reported"
+          where severity: "critical"
+          trigger "GrowthSensor.Alert"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_alarm
+    boot(POLICY_WHERE_SOURCE, "AlarmGrowth") { ::AlarmGrowth::GrowthSensor.persisted_by("Memory") }
+  end
+
+  it "fires the trigger when the triggering event's own payload matches the where clause" do
+    runtime = boot_alarm
+    runtime.dispatch("AlarmGrowth::GrowthSensor.Report", id: { value: "s1" }, severity: "critical")
+
+    expect(runtime.reactions).to contain_exactly(
+      hash_including(policy: "AlertOnCritical", on: "Reported",
+                     trigger: "AlarmGrowth::GrowthSensor.Alert", delivered: true)
+    )
+    expect(AlarmGrowth::GrowthSensor.find("s1").status.to_h).to eq(value: "alerted")
+  end
+
+  it "does not fire -- and is not a refusal -- when the payload doesn't match" do
+    runtime = boot_alarm
+    runtime.dispatch("AlarmGrowth::GrowthSensor.Report", id: { value: "s2" }, severity: "normal")
+
+    expect(runtime.reactions).to be_empty
+    expect(AlarmGrowth::GrowthSensor.find("s2").status.to_h).to eq(value: "quiet")
+  end
+end


### PR DESCRIPTION
Adds `where field: value` to Policy: a conditional policy trigger, gating whether the policy fires on the triggering EVENT'S OWN PAYLOAD (not a stored-record query the way an aggregate query's `where` is).

**Finding**: `docs/hecks-migration-findings.md` — deciderate's own comment names it exactly: "the where-guard IS the 'round complete' condition — the saga," `AdvanceRound` firing only when `games_remaining: 0` rides the `ResolutionRecorded` event.

A policy only reacts when the triggering event's own payload matches; a mismatch isn't a refusal, the policy just doesn't apply to this event (same as an `event_qualifier` miss). Compared against the RAW event payload (symbolized), not a stored record — a policy's where clause reads what the triggering event itself carried, not the aggregate's current state.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 7 failures at this point in the stack (up 1 expected gap from #29: `syntax_conformance_spec` wants `PolicyBuilder#where` registered as a grammar word, landing with the self-hosted-grammar-registration item later in this split). None of the 7 are regressions.

Split out of the original bundled PR #16 — stacks on #29. `for_each`/`from_event` (the other half of the original `62917a8` commit) follows as its own PR next.
