### PR TITLE
policy DSL: for_each fan-out dispatch

### DIFF
--- a/lib/hecksagain/bluebook/dsl/policy_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/policy_builder.rb
@@ -26,13 +26,38 @@ module Hecksagain
           (@wheres ||= {}).merge!(conditions.transform_keys(&:to_sym))
         end
 
+        # `for_each from: "Aggregate.query_name", where: { field:
+        # from_event(:x) }` -- vendored addition, not (yet) upstream
+        # hecksagain (migration plan task 8): a policy-level fan-out,
+        # the SAME shape as `dispatch ..., for_each:` already built for
+        # saga handlers, except a policy has no saga instance to source
+        # from -- every `where:` value resolves against the triggering
+        # EVENT's payload only. deciderate's own SettleVotesOnPop names
+        # it exactly : "a pop settles the bubble's live votes" -- one
+        # Vote.Settle per row `Vote.ForBubble` returns, not one dispatch
+        # total. See Runtime::PolicyInterpreter#deliver's own comment
+        # for the evaluation side.
+        def for_each(from:, where: {})
+          @for_each = { from: from.to_s, where: where }
+        end
+
+        # `from_event(:field)` -- vendored addition, not (yet) upstream
+        # hecksagain (migration plan task 8): the SAME trivial sugar as
+        # HandlerBuilder's own `from_event` (a PM handler's sibling) --
+        # returns the bare Symbol, relying on `for_each`'s `where:` hash
+        # resolving a Symbol value against the triggering event's
+        # payload at delivery time, exactly like a `with:` spec already
+        # does for `dispatch`.
+        def from_event(field, default: nil) = field
+
         def build
           IR::Policy.new(
             name:            @name,
             on_event:        @on_event,
             trigger_command: @trigger_command,
             target_domain:   @target_domain,
-            wheres:          @wheres || {}
+            wheres:          @wheres || {},
+            for_each:        @for_each
           )
         end
 

--- a/lib/hecksagain/runtime/policy_interpreter.rb
+++ b/lib/hecksagain/runtime/policy_interpreter.rb
@@ -1,5 +1,6 @@
 require_relative "../naming"
 require_relative "errors"
+require_relative "query_interpreter"
 
 
 module Hecksagain
@@ -14,7 +15,14 @@ module Hecksagain
 
       def react(event, domain)
         policies_for(event, domain).each do |policy|
-          @registry.reaction_log << deliver(policy, event, domain)
+          # `deliver` returns one record ordinarily, or an ARRAY of
+          # records for a `for_each` policy (vendored addition -- see
+          # PolicyBuilder#for_each's own comment) -- one dispatch per
+          # matched row, so one reaction-log entry per row too. NOT
+          # `Array(result)` -- that turns a plain record Hash into its
+          # own `[[key, value], ...]` pairs instead of wrapping it.
+          result = deliver(policy, event, domain)
+          (result.is_a?(Array) ? result : [result]).each { |record| @registry.reaction_log << record }
         end
       end
 
@@ -49,6 +57,8 @@ module Hecksagain
       end
 
       def deliver(policy, event, domain)
+        return deliver_for_each(policy, event, domain) if policy.for_each
+
         target = "#{policy.target_domain || domain}::#{policy.trigger_command}"
         record = { policy: policy.name, on: event.name, trigger: target }
 
@@ -93,6 +103,44 @@ module Hecksagain
         warn "[hecksagain] defect in reaction — policy #{policy.name} on #{event.name} " \
              "firing #{target}: #{error.class}: #{error.message}"
         record.merge(delivered: false, reason: error.message, defect: true, error_class: error.class.name)
+      end
+
+      # `for_each from: "Aggregate.query_name", where: {...}` -- vendored
+      # addition, not (yet) upstream hecksagain (migration plan task 8):
+      # see PolicyBuilder#for_each's own comment. Runs the named query
+      # (within the POLICY's OWN domain -- `trigger`'s own
+      # target_domain-or-domain convention, mirrored here since a
+      # for_each source and its trigger are the same saga step) with
+      # `where:`'s Symbol values resolved against the triggering event's
+      # payload, then dispatches the trigger command ONCE PER ROW using
+      # the universal `id=<value>` self-ref fallback every aggregate's
+      # own self-referencing command already accepts -- no need to know
+      # the target command's exact reference-argument name.
+      def deliver_for_each(policy, event, domain)
+        spec = policy.for_each
+        aggregate_name, query_name = spec[:from].split(".", 2)
+        payload = event.payload.transform_keys(&:to_sym)
+        resolved_where = (spec[:where] || {}).transform_values do |v|
+          v.is_a?(Symbol) ? payload[v] : v
+        end
+
+        rows = QueryInterpreter.new(@registry).call(domain, aggregate_name, query_name, resolved_where)
+        target = "#{policy.target_domain || domain}::#{policy.trigger_command}"
+
+        Array(rows).map do |row|
+          record = { policy: policy.name, on: event.name, trigger: target, for_row: row[:id] }
+          if @door.reaction_depth_reached?
+            next record.merge(delivered: false,
+                              reason: "reaction depth #{@door.max_reaction_depth} reached")
+          end
+
+          begin
+            @door.reenter(target, id: row[:id])
+            record.merge(delivered: true)
+          rescue *DOMAIN_REFUSALS => error
+            record.merge(delivered: false, reason: error.message)
+          end
+        end
       end
     end
   end

--- a/spec/policy_for_each_growth_spec.rb
+++ b/spec/policy_for_each_growth_spec.rb
@@ -1,0 +1,131 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for policy `for_each from:, where:` + `from_event` --
+# finding #12: a policy-level fan-out, the same shape as `dispatch ...,
+# for_each:` already built for saga handlers.
+#
+# The DSL side alone (`PolicyBuilder.build`) needs no boot at all, and
+# proves the BUILDER half of this PR parses `for_each`/`from_event` into
+# the shape `PolicyInterpreter#deliver_for_each` reads, independent of
+# whether a real dispatch can reach that shape at all.
+#
+# A REAL dispatch finds two further, separate, genuine runtime gaps,
+# both fixed by a later-landing item in this split:
+# `PolicyInterpreter#deliver_for_each` hands `QueryInterpreter#call` the
+# bare aggregate NAME it split out of `from:`, never resolved to the
+# aggregate object `#call` needs (`Dispatcher#resolve_aggregate` always
+# does this resolution first for an ordinary query) -- that alone raises
+# a plain `NoMethodError: undefined method 'query' for a String`. But
+# `deliver`'s own `return deliver_for_each(...) if policy.for_each` runs
+# BEFORE `record` (the reaction-log entry both of `deliver`'s own rescue
+# clauses call `.merge` on) is assigned, so the SAME method's own defect
+# handling then raises a SECOND, different `NoMethodError: undefined
+# method 'merge' for nil` trying to record the first one -- the one this
+# example actually observes and pins, since Ruby's own exception-in-
+# rescue replaces the original. Pinned here as the current, real
+# behaviour -- the later fix should turn this red, which is the point:
+# it is the signal to replace this example with the positive one (one
+# dispatch per matching row) this construct is actually meant to prove.
+RSpec.describe "a policy's own for_each fan-out" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["policy-for-each-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  it "parses for_each + from_event into the fan-out shape the interpreter reads" do
+    policy = Hecksagain::Bluebook::DSL::PolicyBuilder.build("PingGrowthTicketsOnOpen") do
+      on "Opened"
+      for_each from: "GrowthTicket.ForBoard", where: { board_id: from_event(:id) }
+      trigger "GrowthTicket.Ping"
+    end
+
+    expect(policy.for_each).to eq(from: "GrowthTicket.ForBoard", where: { board_id: :id })
+  end
+
+  FOR_EACH_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "FanoutGrowth" do
+      aggregate "GrowthBoard" do
+        identified_by { id.value }
+
+        value_object "GrowthBoardId" do
+          attribute :value, String
+        end
+
+        attribute :id, GrowthBoardId
+
+        command "Open" do
+          attribute :id, GrowthBoardId
+          emits "Opened"
+        end
+      end
+
+      aggregate "GrowthTicket" do
+        identified_by { id.value }
+
+        value_object "GrowthTicketId" do
+          attribute :value, String
+        end
+
+        attribute :id,       GrowthTicketId
+        attribute :board_id, String
+        attribute :status,   String, default: "open"
+
+        command "Create" do
+          attribute :id,       GrowthTicketId
+          attribute :board_id, String
+          emits "Created"
+        end
+
+        command "Ping" do
+          reference_to GrowthTicket
+          then_set :status, to: "pinged"
+        end
+
+        query "ForBoard" do
+          attribute :board_id, String
+          where board_id: :board_id
+        end
+      end
+
+      policy "PingGrowthTicketsOnOpen" do
+        on "Opened"
+        for_each from: "GrowthTicket.ForBoard", where: { board_id: from_event(:id) }
+        trigger "GrowthTicket.Ping"
+      end
+    end
+  BLUEBOOK
+
+  it "currently crashes on dispatch -- deliver_for_each never resolves the aggregate it queries" do
+    runtime = boot(FOR_EACH_SOURCE, "FanoutGrowth") do
+      ::FanoutGrowth::GrowthBoard.persisted_by("Memory")
+      ::FanoutGrowth::GrowthTicket.persisted_by("Memory")
+    end
+    runtime.dispatch("FanoutGrowth::GrowthTicket.Create", id: { value: "t1" }, board_id: "b1")
+
+    expect { runtime.dispatch("FanoutGrowth::GrowthBoard.Open", id: { value: "b1" }) }
+      .to raise_error(NoMethodError, /undefined method [`']merge['`]? for nil/)
+  end
+end


### PR DESCRIPTION
Adds `for_each from: "Aggregate.query_name", where: {...}` and its `from_event(:field)` sugar to Policy: fans a policy's reaction out once per row of a query's result set, rather than once per event (i225).

**Finding**: `docs/hecks-migration-findings.md`. The SAME shape as `dispatch ..., for_each:` already built for saga handlers, except a policy has no saga instance to source from — every `where:` value resolves against the triggering event's payload only. deciderate's own `SettleVotesOnPop` names it exactly: "a pop settles the bubble's live votes" — one `Vote.Settle` per row `Vote.ForBubble` returns, not one dispatch total.

Runs the named query with `where:`'s Symbol values resolved against the triggering event's payload, then dispatches the trigger command ONCE PER ROW using the universal `id=<value>` self-ref fallback every aggregate's own self-referencing command already accepts — no need to know the target command's exact reference-argument name.

`PolicyInterpreter#react` now unwraps the array `deliver()` returns for a `for_each` policy into one reaction-log entry per row, instead of logging the array itself.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 7 failures at this point in the stack, unchanged from #30 (no new regression).

Split out of the original bundled PR #16 — stacks on #30, the second of two real features from `62917a8`. A catch-all PR for the same commit's minor DSL stubs (`with`/`map`/`condition`/`cross_domain`/a `description` alias) follows next.
