### PR TITLE
policy DSL: with_literals wiring, and description/condition/cross_domain stubs

### DIFF
--- a/lib/hecksagain/bluebook/dsl/policy_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/policy_builder.rb
@@ -6,6 +6,10 @@ module Hecksagain
           @name = name
         end
 
+        # Vendored alias, not (yet) upstream hecksagain -- see
+        # CommandBuilder's identical `description`/`goal` alias comment.
+        def description(value) = nil
+
         def on(event_name) = @on_event = event_name.to_s
 
         def trigger(command_name) = @trigger_command = command_name.to_s
@@ -50,12 +54,73 @@ module Hecksagain
         # does for `dispatch`.
         def from_event(field, default: nil) = field
 
+        # Vendored addition, not (yet) upstream hecksagain -- see
+        # IR::Policy#with_literals's own comment.
+        def with(key, value)
+          (@with_literals ||= {})[key.to_s] = value
+        end
+
+        # Vendored addition, not (yet) upstream hecksagain: `map target:
+        # :event_field` renames/selects an event-payload field for the
+        # triggered command's argument -- structurally accepted here
+        # (folded into the same with_literals merge, sourced from a
+        # `:event_field` symbol marker the interpreter could resolve
+        # against the actual event payload) so the corpus boots; exact
+        # select-vs-merge runtime semantics need review before this is
+        # trusted for a live dispatch. TODO upstream via bin/evolve
+        # (migration plan task 7); TODO verify runtime semantics before
+        # any file relying on `map` goes live.
+        def map(**pairs)
+          (@with_literals ||= {}).merge!(pairs.transform_keys(&:to_s))
+        end
+
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): `condition { |event| event.field > x }` -- found
+        # 15 times across hecks_nursury, always a comparison/boolean
+        # expression over the triggering event's own payload via a
+        # block PARAMETER (`event.severity == "critical"`, `.abs > 3`,
+        # `!event.within_limit`), never a bare-name predicate the way
+        # `given`'s `Ports::Extraction.canonical` already handles. This
+        # is a REAL gap, not equivalent to the already-built `where
+        # field: value` sibling just above -- `where` is equality-only
+        # on a literal hash ; `condition` needs the canonical
+        # expression evaluator's comparison/`!`/arithmetic grammar
+        # (confirmed present for `given`/`expects`, per this session's
+        # bin-buddy findings) wired to a NAMED block param instead of
+        # bare-attribute resolution, which nothing here does yet.
+        # Accepted so the file boots, block body NOT evaluated --
+        # meaning any policy using `condition` currently fires
+        # UNCONDITIONALLY on its `on:` event, not gated as its own
+        # bluebook declares. Deliberately not rushed : precisely
+        # diagnosed and documented rather than silently treated as
+        # equivalent to a real implementation. TODO upstream via
+        # bin/evolve (migration plan task 7): give `condition` real
+        # semantics, reusing `given`'s canonical-extraction machinery
+        # once it can resolve a block param's dotted event-payload
+        # access, not just bare names.
+        def condition(&) = nil
+
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): `cross_domain true` -- 3 occurrences, 2 files
+        # (universal_domain_pattern.bluebook, causal_combinatorics.bluebook
+        # -- both in hecks_nursury's meta-domain cluster, about Bluebook-
+        # the-language itself rather than business modeling, per this
+        # migration's own inventory). A bare boolean flag, distinct from
+        # the already-real `across "DomainName"` (`@target_domain`) --
+        # this names NO target domain at all, just marks the policy as
+        # crossing a boundary conceptually. Accepted so the file boots ;
+        # not wired to `@target_domain` or anything else, since there is
+        # no domain name here to wire it TO. TODO upstream via bin/evolve
+        # (migration plan task 7).
+        def cross_domain(*) = nil
+
         def build
           IR::Policy.new(
             name:            @name,
             on_event:        @on_event,
             trigger_command: @trigger_command,
             target_domain:   @target_domain,
+            with_literals:   @with_literals || {},
             wheres:          @wheres || {},
             for_each:        @for_each
           )

--- a/lib/hecksagain/runtime/policy_interpreter.rb
+++ b/lib/hecksagain/runtime/policy_interpreter.rb
@@ -67,7 +67,13 @@ module Hecksagain
                               reason: "reaction depth #{@door.max_reaction_depth} reached")
         end
 
-        @door.reenter(target, **event.payload.transform_keys(&:to_sym))
+        # with_literals (vendored addition -- see IR::Policy's own
+        # comment) merges in AFTER the event payload, so a policy's own
+        # explicit `with "key", "value"` always wins over a same-named
+        # payload field -- the literal was written to be authoritative,
+        # not a fallback.
+        args = event.payload.transform_keys(&:to_sym).merge((policy.with_literals || {}).transform_keys(&:to_sym))
+        @door.reenter(target, **args)
         record.merge(delivered: true)
       rescue *DOMAIN_REFUSALS => error
         # The target refused — a fact about the domain, recorded and not
@@ -126,6 +132,7 @@ module Hecksagain
 
         rows = QueryInterpreter.new(@registry).call(domain, aggregate_name, query_name, resolved_where)
         target = "#{policy.target_domain || domain}::#{policy.trigger_command}"
+        literals = (policy.with_literals || {}).transform_keys(&:to_sym)
 
         Array(rows).map do |row|
           record = { policy: policy.name, on: event.name, trigger: target, for_row: row[:id] }
@@ -135,7 +142,7 @@ module Hecksagain
           end
 
           begin
-            @door.reenter(target, id: row[:id])
+            @door.reenter(target, id: row[:id], **literals)
             record.merge(delivered: true)
           rescue *DOMAIN_REFUSALS => error
             record.merge(delivered: false, reason: error.message)

--- a/spec/bluebook/dsl/policy_builder_catchall_spec.rb
+++ b/spec/bluebook/dsl/policy_builder_catchall_spec.rb
@@ -1,0 +1,41 @@
+require "hecksagain"
+
+RSpec.describe Hecksagain::Bluebook::DSL::PolicyBuilder do
+  describe "with_literals wiring" do
+    it "carries repeated with(key, value) calls into IR::Policy#with_literals" do
+      policy = described_class.build("Grants") do
+        on "Thing.Happened"
+        trigger "Thing.React"
+        with "kind", "urgent"
+        with "source", "growth"
+      end
+
+      expect(policy.with_literals).to eq("kind" => "urgent", "source" => "growth")
+    end
+
+    it "folds map's field selections into the same with_literals accumulator" do
+      policy = described_class.build("Mapped") do
+        on "Thing.Happened"
+        trigger "Thing.React"
+        map target: :event_field
+      end
+
+      expect(policy.with_literals).to eq("target" => :event_field)
+    end
+  end
+
+  describe "description/condition/cross_domain stubs" do
+    it "accepts each and builds a policy unaffected, deliberate no-ops" do
+      policy = described_class.build("Stubbed") do
+        description "prose only"
+        on "Thing.Happened"
+        trigger "Thing.React"
+        condition { |event| event.severity == "critical" }
+        cross_domain true
+      end
+
+      expect(policy).to be_a(Hecksagain::Bluebook::IR::Policy)
+      expect(policy.name).to eq("Stubbed")
+    end
+  end
+end


### PR DESCRIPTION
Wires `PolicyBuilder#with`/`#map` into `IR::Policy#with_literals` (merged into a triggered command's args AFTER the event payload, so an explicit `with "key", "value"` always wins over a same-named payload field), plus three low-risk catch-all additions from the same original commit:

- `description` — vendored no-op alias, same precedent as `CommandBuilder`'s own `description`/`goal` alias.
- `condition { |event| ... }` — vendored NO-OP stub. Found 15 times across hecks_nursury, always a comparison/boolean expression over the triggering event's own payload via a block PARAMETER, which nothing in this grammar resolves yet (distinct from `where`, #30, which is equality-only on a literal hash). Accepted so the file boots, block body NOT evaluated — any policy using `condition` currently fires unconditionally, precisely diagnosed rather than silently faked.
- `cross_domain true` — vendored NO-OP stub, a bare boolean flag distinct from the real `across "DomainName"`. Accepted so the file boots; not wired to anything, since there is no domain name here to wire it to.

`map`'s exact select-vs-merge runtime semantics are explicitly TODO/unverified per the source comment — accepted structurally, not trusted for a live dispatch yet.

**Scope note**: grouped as one PR per the split plan's own "true one-liner no-op stubs" allowance (the precedent already set for item 23) — each of these four is independently tiny and low-risk; splitting them further would not meaningfully aid review. Completes the split of `62917a8` — reconstructing `policy_builder.rb`/`policy_interpreter.rb` across #30/#31/this PR is byte-identical to that commit's own final tree.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 7 failures at this point in the stack, unchanged from #31 (no new regression).

Split out of the original bundled PR #16 — stacks on #31.
