### PR TITLE
sagas: mutable memory (remember/set/from_event)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/process_manager_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/process_manager_builder.rb
@@ -15,6 +15,12 @@ module Hecksagain
         def ends_on(event)       = @ends_on = event.to_s
         def state(name)          = @states << name.to_s
 
+        # `description` -- vendored addition, not (yet) upstream hecksagain
+        # (migration plan task 4): prose-only, matches PolicyBuilder's own
+        # accept-and-discard stub. A process manager's narrative belongs to
+        # the corpus author, not the IR.
+        def description(value) = nil
+
         def on(event_type, transition:, &block)
           from, to = single_transition(event_type, transition)
           handler  = HandlerBuilder.new
@@ -24,7 +30,9 @@ module Hecksagain
             event_type: event_type.to_s,
             from_state: from,
             to_state:   to,
-            dispatches: handler.dispatches
+            dispatches: handler.dispatches,
+            remembers:  handler.remembers,
+            guards:     handler.guards
           )
         end
 
@@ -97,9 +105,38 @@ module Hecksagain
         end
 
         class HandlerBuilder
-          attr_reader :dispatches
+          attr_reader :dispatches, :remembers, :guards
 
-          def initialize = @dispatches = []
+          def initialize
+            @dispatches = []
+            @remembers  = []
+            @guards     = []
+          end
+
+          # `remember key: from_event(...)` -- vendored addition, not
+          # (yet) upstream hecksagain (migration plan task 4). Writes
+          # into the saga instance's OWN carried memory (Runtime::
+          # SagaInterpreter's `instance[:memory]`) under `key`, for a
+          # LATER handler on the same instance to read back via
+          # `from_pm(:key)`. See IR::ProcessManagerHandler's own comment
+          # on why this exists -- `instance[:memory]` was write-once
+          # before this, so `from_pm` could only ever see the starting
+          # event, never anything a mid-saga handler decided.
+          def remember(**fields)
+            @remembers.concat(fields.to_a)
+          end
+
+          # `set :field, from_event(:field)` -- vendored addition, not
+          # (yet) upstream hecksagain (migration plan task 8, bin-buddy's
+          # SubscriptionLifecycle PM): the POSITIONAL-argument sibling of
+          # `remember key: from_event(...)` -- same accumulator, same
+          # saga-memory write, just written field-then-value instead of
+          # as a kwarg (bin-buddy's own corpus convention, found live
+          # rather than invented). Kept as a real alias, not a rename --
+          # `remember` stays the kwarg form other corpora already use.
+          def set(field, value)
+            @remembers << [field.to_sym, value]
+          end
 
           def dispatch(command_name, with: nil)
             @dispatches << IR::DispatchSpec.new(
@@ -107,6 +144,21 @@ module Hecksagain
               with_spec:    (with || {}).to_a
             )
           end
+
+          # Vendored addition, not (yet) upstream hecksagain: `with: {
+          # key: from_event(:field, default: "x") }` (miette's
+          # body/pulse_organs/bluebook and body/sleep/consolidation/
+          # bluebook) -- explicit sugar for "read :field from the
+          # triggering event's payload, falling back to default if
+          # absent". Returns the bare Symbol, relying on with_spec's
+          # EXISTING Symbol-means-argument-reference-resolved-at-
+          # dispatch-time mechanism to source it from the event payload
+          # the same way any other argument reference already does --
+          # the `default:` fallback is NOT threaded through (a real,
+          # documented gap: an absent field currently resolves to nil,
+          # not the declared default). TODO upstream via bin/evolve
+          # (migration plan task 7).
+          def from_event(field, default: nil) = field
         end
       end
     end

--- a/lib/hecksagain/bluebook/ir/process_manager.rb
+++ b/lib/hecksagain/bluebook/ir/process_manager.rb
@@ -10,14 +10,37 @@ module Hecksagain
         end
       end
 
+      # `remembers`, vendored addition not (yet) upstream hecksagain
+      # (migration plan task 4): named values this handler writes into
+      # the saga instance's OWN carried memory, for a LATER handler on
+      # the same instance to read back via `from_pm`. A real gap this
+      # closes: `instance[:memory]` (Runtime::SagaInterpreter) was set
+      # ONCE, from the STARTING event's payload, and never mutated again
+      # -- so `from_pm` (added earlier this session) could only ever see
+      # what the FIRST event carried, never anything a later handler
+      # decided along the way (miette's Lucidity PM: `MindSteered` sets
+      # the steering target ; the NEXT tick's handler needs to read it
+      # back, and neither the starts_on event nor the current tick's own
+      # event carries it). `remember key: from_event(...)` is the
+      # explicit, named write; see HandlerBuilder#remember and
+      # Runtime::SagaInterpreter#advance_saga's own comment for the read
+      # side.
+      # `guards`, vendored addition not (yet) upstream hecksagain
+      # (migration plan task 4): raw Procs, not rendered into `to_h` --
+      # same reason a command's `given`/`ensures` predicates aren't
+      # either (Proc isn't JSON-shaped); only their PRESENCE is exported,
+      # as a count, so the IR still says a guard exists without claiming
+      # to describe it. See DSL::ProcessManagerBuilder::HandlerBuilder#given.
       ProcessManagerHandler = Struct.new(:event_type, :from_state, :to_state,
-                                         :dispatches, keyword_init: true) do
+                                         :dispatches, :remembers, :guards, keyword_init: true) do
         def to_h
           {
             event_type: event_type.to_s,
             from_state: from_state.to_s,
             to_state:   to_state.to_s,
-            dispatches: dispatches.map(&:to_h)
+            dispatches: dispatches.map(&:to_h),
+            remembers:  (remembers || []).map { |k, v| [k.to_s, IR.render_value(v)] },
+            guard_count: (guards || []).size
           }
         end
       end

--- a/lib/hecksagain/runtime/saga_interpreter.rb
+++ b/lib/hecksagain/runtime/saga_interpreter.rb
@@ -72,8 +72,30 @@ module Hecksagain
         instance[:state] = handler.to_state
         @registry.saga_log << record.merge(advanced: true, from: handler.from_state, to: handler.to_state)
 
+        remember_into_instance(handler, event, instance, correlation)
+
         handler.dispatches.each do |spec|
           deliver_saga_dispatch(pm, spec, event, instance, correlation, domain)
+        end
+      end
+
+      # Vendored addition, not (yet) upstream hecksagain (migration plan
+      # task 4): resolves `handler.remembers` (from HandlerBuilder#remember)
+      # against THIS firing's event/instance and merges them into
+      # `instance[:memory]` -- BEFORE this handler's own dispatches run,
+      # so a `remember key: from_event(:x)` and a same-handler `dispatch
+      # ..., with: { y: from_pm(:key) }` compose in the natural written
+      # order. No `row:` context -- remembers fire once per handler
+      # firing, never once per for_each iteration.
+      def remember_into_instance(handler, event, instance, correlation)
+        return if (handler.remembers || []).empty?
+
+        handler.remembers.each do |key, value|
+          resolved = if !value.is_a?(Symbol) then value
+                     elsif value == correlation then correlation
+                     else resolve_with_value(value, event, instance)
+                     end
+          instance[:memory][key.to_sym] = resolved
         end
       end
 
@@ -171,6 +193,42 @@ module Hecksagain
           # without being the same domain object.
           [key.to_sym, Value.materialize(resolved)]
         end
+      end
+
+      # A DOTTED SOURCE READS THE ONE SCALAR, the same "a path names a
+      # field, not a whole value object" idiom `identified_by`/
+      # `correlates_by` already hold every other declaration to —
+      # `with: { item_id: :"id.value" }` reaches into a VO-wrapped
+      # payload field (Item.Add's own `id: ItemId`) for the bare scalar
+      # a reference-typed target argument (Place's own `item_id`)
+      # actually needs, rather than handing it the whole `{value: "..."}`
+      # shape a plain top-level key would. A bare (undotted) source is
+      # unchanged from before this existed — reads the field whole,
+      # exactly as every existing `with:` mapping in the corpus already
+      # does.
+      # `row:`, vendored addition not (yet) upstream hecksagain (migration
+      # plan task 4, i225): a for_each dispatch's iteration record, tried
+      # FIRST -- `from_iter`/`from_event` are indistinguishable at the IR
+      # level (both HandlerBuilder methods just return the bare field
+      # Symbol, see process_manager_builder.rb's own comment), so this is
+      # a runtime-side, not parse-side, resolution: when a row is present
+      # (a for_each dispatch) and carries the field, it wins over the
+      # event/instance fallback every other dispatch already used. Written
+      # complete here (item 10, `remember`'s own landing) even though
+      # `row:` has no real caller yet -- the saga `for_each` fan-out that
+      # exercises it lands in a later PR in this split.
+      def resolve_with_value(value, event, instance, row: nil)
+        head, *rest = value.to_s.split(".").map(&:to_sym)
+        base = if row && row.key?(head)
+                 row[head]
+               elsif event.payload.key?(head)
+                 event.payload[head]
+               else
+                 instance[:memory][head]
+               end
+        return base if rest.empty?
+
+        rest.reduce(Value.materialize(base)) { |held, segment| held.is_a?(Hash) ? held[segment] : held }
       end
 
       def qualified(command_name, domain)

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -5422,6 +5422,10 @@
           ],
           "event_type": "TransferRequested",
           "from_state": "requested",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "requested"
         },
         {
@@ -5459,6 +5463,10 @@
           ],
           "event_type": "AccountDebited",
           "from_state": "requested",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "awaiting_credit"
         },
         {
@@ -5475,6 +5483,10 @@
           ],
           "event_type": "AccountCredited",
           "from_state": "awaiting_credit",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "awaiting_credit"
         },
         {
@@ -5491,6 +5503,10 @@
           ],
           "event_type": "TransferCredited",
           "from_state": "awaiting_credit",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "settled"
         },
         {
@@ -5524,6 +5540,10 @@
           ],
           "event_type": "refused",
           "from_state": "awaiting_credit",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "reversed"
         }
       ],
@@ -5554,6 +5574,10 @@
           ],
           "event_type": "ExternalTransferRequested",
           "from_state": "requested",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "requested"
         },
         {
@@ -5570,6 +5594,10 @@
           ],
           "event_type": "refused",
           "from_state": "requested",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "returned"
         }
       ],
@@ -5611,6 +5639,10 @@
           ],
           "event_type": "OnboardingCleared",
           "from_state": "screening",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "cleared"
         },
         {
@@ -5619,6 +5651,10 @@
           ],
           "event_type": "OnboardingDeclined",
           "from_state": "screening",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "declined"
         }
       ],

--- a/spec/golden/ir/Wire.json
+++ b/spec/golden/ir/Wire.json
@@ -609,6 +609,10 @@
           ],
           "event_type": "WireAsked",
           "from_state": "asked",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "asked"
         },
         {
@@ -642,6 +646,10 @@
           ],
           "event_type": "Taken",
           "from_state": "asked",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "carrying"
         },
         {
@@ -658,6 +666,10 @@
           ],
           "event_type": "PutIn",
           "from_state": "carrying",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "landed"
         },
         {
@@ -691,6 +703,10 @@
           ],
           "event_type": "refused",
           "from_state": "carrying",
+          "guard_count": 0,
+          "remembers": [
+
+          ],
           "to_state": "returned"
         }
       ],

--- a/spec/saga_remember_growth_spec.rb
+++ b/spec/saga_remember_growth_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for saga mutable memory (`remember`/`set`):
+# SagaInterpreter's instance[:memory] was write-once before this PR --
+# set from the starting event's payload at saga creation, never mutated
+# again. A mid-saga handler can now hand a LATER tick something it
+# decided, written into the saga instance's own carried memory. (The
+# `from_pm` sugar to READ it back inside a later handler's own `with:`
+# lands with a separate, later item in this split -- this coverage
+# confirms the WRITE side directly.)
+RSpec.describe "saga mutable memory via remember" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["saga-remember-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  SAGA_REMEMBER_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "RememberGrowth" do
+      aggregate "GrowthOrder" do
+        identified_by { id.value }
+
+        value_object "GrowthOrderId" do
+          attribute :value, String
+        end
+
+        attribute :id, GrowthOrderId
+
+        command "Place" do
+          attribute :id,      GrowthOrderId
+          attribute :courier, String
+          emits "Placed"
+        end
+      end
+
+      process_manager "RememberSaga" do
+        correlates_by :"id.value"
+        starts_on "Placed"
+        ends_on "Shipped"
+
+        state "started"
+        state "remembered"
+
+        on "Placed", transition: { "started" => "remembered" } do
+          remember chosen_courier: from_event(:courier)
+        end
+      end
+    end
+  BLUEBOOK
+
+  it "carries a remembered value forward in the saga's own instance memory" do
+    runtime = boot(SAGA_REMEMBER_SOURCE, "RememberGrowth") { ::RememberGrowth::GrowthOrder.persisted_by("Memory") }
+    runtime.dispatch("RememberGrowth::GrowthOrder.Place", id: { value: "o1" }, courier: "SwiftPost")
+
+    instance = runtime.registry.saga_instances["RememberSaga"]["o1"]
+
+    expect(instance[:memory][:chosen_courier]).to eq("SwiftPost")
+  end
+end


### PR DESCRIPTION
`SagaInterpreter`'s `instance[:memory]` was write-once — set from the starting event's payload at saga creation, never mutated again. A mid-saga handler could never hand a later tick anything it decided.

**Finding**: `docs/hecks-migration-findings.md`. Adds `HandlerBuilder#remember` (writes into `instance[:memory]` after the transition, before that handler's own dispatches), its `set` positional alias (bin-buddy's own corpus convention, found live), and `from_event` sugar.

`instance[:memory]` was set ONCE, from the STARTING event's payload, and never mutated again — so `from_pm` could only ever see what the FIRST event carried, never anything a later handler decided along the way (miette's Lucidity PM: `MindSteered` sets the steering target; the NEXT tick's handler needs to read it back, and neither the `starts_on` event nor the current tick's own event carries it).

`IR::ProcessManagerHandler` gains `remembers` (named values a handler writes into the saga's own carried memory) and `guards` (raw Procs, not rendered into `to_h` — only their presence is exported, as a count; `given`, the guards' own producer, lands in the next PR in this split — `guards` stays empty until then).

`SagaInterpreter#resolve_with_value` is written complete here, including its `row:` kwarg — the saga `for_each` fan-out that exercises `row:` for real lands in a later PR in this split; introducing the complete, correct function now avoids reshaping its signature twice (same "plumbing ready before its second consumer" pattern as PR #29).

Also carries `ProcessManagerBuilder#description`, a trivial no-op prose-only stub matching `PolicyBuilder`'s own precedent — one orphan line from the same original commit, too small for its own PR.

Includes the golden IR fixture regeneration this IR shape change requires.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 11 failures at this point in the stack (up from 7 by 4 expected new gaps: two `syntax_conformance_spec` grammar-registration gaps, and `round_trip_spec` flags Wire/Banking's Handler `remembers`/`guard_count` not surviving the self-hosted grammar's own Judge round-trip yet — the EXACT gap the plan's item 36, "Handler remembers/guard_count self-hosted round-trip," closes later in this split). None of the 11 are regressions.

Split out of the original bundled PR #16 — stacks on #32.
