### PR TITLE
sagas: handler-level given

### DIFF
--- a/lib/hecksagain/bluebook/dsl/process_manager_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/process_manager_builder.rb
@@ -126,6 +126,26 @@ module Hecksagain
             @remembers.concat(fields.to_a)
           end
 
+          # `given { |ctx| ... }` -- vendored addition, not (yet) upstream
+          # hecksagain (migration plan task 4): a handler-level
+          # precondition on its DISPATCHES, not on the transition itself
+          # -- the transition + any `remember`s always happen when the
+          # event fires in the right from_state; `given` only decides
+          # whether this handler's `dispatch`es actually fire. Real need,
+          # not speculative: miette's Lucidity PM enters `rejoined` on
+          # `LucidRemEntered` regardless of whether Mind is present (the
+          # bridge's Body-half alone is enough to transition), but only
+          # dispatches `LucidDream.BecomeLucid` when Mind actually is —
+          # the OLD imperative Proc form did `next({commands: []}) unless
+          # mind_present` after the transition had already been decided
+          # by the enclosing framework, same split. `ctx` is a merged
+          # Hash of the triggering event's payload + the saga instance's
+          # own remembered fields — see Runtime::SagaInterpreter#
+          # advance_saga's own comment for how it's built and evaluated.
+          def given(&predicate)
+            @guards << predicate
+          end
+
           # `set :field, from_event(:field)` -- vendored addition, not
           # (yet) upstream hecksagain (migration plan task 8, bin-buddy's
           # SubscriptionLifecycle PM): the POSITIONAL-argument sibling of

--- a/lib/hecksagain/runtime/saga_interpreter.rb
+++ b/lib/hecksagain/runtime/saga_interpreter.rb
@@ -74,9 +74,27 @@ module Hecksagain
 
         remember_into_instance(handler, event, instance, correlation)
 
+        unless guards_pass?(handler, event, instance)
+          @registry.saga_log << record.merge(dispatched: false, reason: "given clause did not hold")
+          return
+        end
+
         handler.dispatches.each do |spec|
           deliver_saga_dispatch(pm, spec, event, instance, correlation, domain)
         end
+      end
+
+      # Vendored addition, not (yet) upstream hecksagain (migration plan
+      # task 4) — see HandlerBuilder#given's own comment. `ctx` merges the
+      # triggering event's payload UNDER the instance's remembered
+      # fields, so a `remember`ed value (this same firing's, per above,
+      # since remember runs first) wins on key collision — the more
+      # specific, more recently-decided fact.
+      def guards_pass?(handler, event, instance)
+        return true if (handler.guards || []).empty?
+
+        ctx = event.payload.merge(instance[:memory])
+        handler.guards.all? { |predicate| predicate.call(ctx) }
       end
 
       # Vendored addition, not (yet) upstream hecksagain (migration plan

--- a/spec/saga_given_growth_spec.rb
+++ b/spec/saga_given_growth_spec.rb
@@ -1,0 +1,94 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for saga handler-level `given`: a precondition
+# on its DISPATCHES, not on the transition itself -- the transition
+# always happens when the event fires in the right from_state; `given`
+# only decides whether this handler's dispatches actually fire.
+RSpec.describe "saga handler-level given" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["saga-given-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  SAGA_GIVEN_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "GivenGrowth" do
+      aggregate "GrowthAccount" do
+        identified_by { id.value }
+
+        value_object "GrowthAccountId" do
+          attribute :value, String
+        end
+
+        attribute :id, GrowthAccountId
+
+        command "Open" do
+          attribute :id,      GrowthAccountId
+          attribute :verified, String
+          emits "Opened"
+        end
+
+        command "Activate" do
+          reference_to GrowthAccount
+          emits "Activated"
+        end
+      end
+
+      process_manager "GivenSaga" do
+        correlates_by :"id.value"
+        starts_on "Opened"
+        ends_on "Activated"
+
+        state "opening"
+        state "opened"
+
+        on "Opened", transition: { "opening" => "opened" } do
+          given { |ctx| ctx[:verified] == "yes" }
+          dispatch "GrowthAccount.Activate", with: { id: :id }
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_given
+    boot(SAGA_GIVEN_SOURCE, "GivenGrowth") { ::GivenGrowth::GrowthAccount.persisted_by("Memory") }
+  end
+
+  it "fires the dispatch when the given clause holds" do
+    runtime = boot_given
+    runtime.dispatch("GivenGrowth::GrowthAccount.Open", id: { value: "a1" }, verified: "yes")
+
+    expect(runtime.registry.saga_log.any? { |entry| entry[:delivered] == true }).to be(true)
+  end
+
+  it "skips the dispatch -- and only the dispatch -- when the given clause does not hold" do
+    runtime = boot_given
+    runtime.dispatch("GivenGrowth::GrowthAccount.Open", id: { value: "a2" }, verified: "no")
+
+    instance = runtime.registry.saga_instances["GivenSaga"]["a2"]
+    expect(instance[:state]).to eq("opened")
+    expect(runtime.registry.saga_log.last).to include(dispatched: false, reason: "given clause did not hold")
+  end
+end


### PR DESCRIPTION
Adds `HandlerBuilder#given` to Process Managers: a handler-level precondition on its DISPATCHES, not on the transition itself — the transition and any `remember`s always happen when the event fires in the right `from_state`; `given` only decides whether this handler's dispatches actually fire.

**Finding**: `docs/hecks-migration-findings.md`. Real need, not speculative: miette's Lucidity PM enters `rejoined` on `LucidRemEntered` regardless of whether Mind is present (the bridge's Body-half alone is enough to transition), but only dispatches `LucidDream.BecomeLucid` when Mind actually is — the OLD imperative Proc form did `next({commands: []}) unless mind_present` after the transition had already been decided by the enclosing framework, same split.

`SagaInterpreter#guards_pass?` evaluates the handler's guards against a merged context — the triggering event's payload UNDER the instance's remembered fields, so a `remember` from THIS same firing wins on key collision, the more specific, more recently-decided fact.

**Verification**: `bundle exec rspec --no-color` — 1267 examples, 11 failures at this point in the stack, unchanged from #33 (no new regression).

Split out of the original bundled PR #16 — stacks on #33.
