### PR TITLE
sagas: template(from_pm) composition and for_each dispatch fan-out

### DIFF
--- a/lib/hecksagain/bluebook/dsl/process_manager_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/process_manager_builder.rb
@@ -158,10 +158,17 @@ module Hecksagain
             @remembers << [field.to_sym, value]
           end
 
-          def dispatch(command_name, with: nil)
+          # `for_each: { from: "Aggregate.query" }` -- vendored addition,
+          # not (yet) upstream hecksagain (migration plan task 4, i225):
+          # enumerate the named query and fire this dispatch once per
+          # returned row, each field sourced via `from_iter(:field)`
+          # against THAT row rather than the triggering event. See
+          # Runtime::SagaInterpreter#deliver_saga_dispatch.
+          def dispatch(command_name, with: nil, for_each: nil)
             @dispatches << IR::DispatchSpec.new(
               command_name: command_name,
-              with_spec:    (with || {}).to_a
+              with_spec:    (with || {}).to_a,
+              for_each:     for_each && for_each.fetch(:from)
             )
           end
 
@@ -179,6 +186,30 @@ module Hecksagain
           # not the declared default). TODO upstream via bin/evolve
           # (migration plan task 7).
           def from_event(field, default: nil) = field
+
+          # Same shape as from_event, sourcing from an iteration/loop
+          # variable instead of the event payload -- see from_event's
+          # own comment for the same documented default: gap.
+          def from_iter(field, default: nil) = field
+
+          # `template("fmt %s", from_pm(:x, default: "y"))` -- vendored
+          # addition, not (yet) upstream hecksagain (migration plan task
+          # 4). See IR::TemplateSpec's own comment for why. Inherits the
+          # SAME documented default:-not-threaded gap as from_event/
+          # from_iter/from_pm -- a `default:` on an ARGUMENT passed into
+          # a template still resolves to nil, not the fallback, if the
+          # field is absent; this call adds no new gap, just composes
+          # with an existing one.
+          def template(format, *args) = IR::TemplateSpec.new(format: format, args: args)
+
+          # Same shape again, sourcing from the PROCESS MANAGER'S OWN
+          # persisted state instead of the triggering event or an
+          # iteration variable -- the third of the same family (miette's
+          # mind/bluebook: `from_pm(:carrying, default: "—")`, reading a
+          # field the PM itself carries across ticks, not something the
+          # current event/iteration handed it). Same documented
+          # default:-not-threaded gap as its two siblings.
+          def from_pm(field, default: nil) = field
         end
       end
     end

--- a/lib/hecksagain/bluebook/ir/process_manager.rb
+++ b/lib/hecksagain/bluebook/ir/process_manager.rb
@@ -1,11 +1,35 @@
 module Hecksagain
   module Bluebook
     module IR
-      DispatchSpec = Struct.new(:command_name, :with_spec, keyword_init: true) do
+      # Vendored addition, not (yet) upstream hecksagain (migration plan
+      # task 4): `template("fmt %s", from_pm(:x, default: "y"))` inside a
+      # `dispatch ..., with: { field: template(...) }` -- composing a
+      # literal string with a resolved field, which no `with:` value
+      # spelling could do before this (a bare Symbol IS a whole resolved
+      # value; there was no way to embed one inside surrounding text).
+      # Found live in miette's mind.bluebook ("I'd like to go deeper into
+      # #{target} with this" -- the OLD imperative Proc form's own string
+      # interpolation, which the file's own comment already named as
+      # needing "a template: form" before it could convert). `args` holds
+      # whatever `dispatch_args`/`resolve_with_value` already know how to
+      # resolve -- bare Symbols (from_event/from_pm/from_iter) or
+      # literals -- resolved the SAME way an ordinary `with:` value is,
+      # just substituted into `format` via `Kernel#format` rather than
+      # assigned directly. See Runtime::SagaInterpreter#resolve_value's
+      # own comment for the read side.
+      TemplateSpec = Struct.new(:format, :args, keyword_init: true)
+
+      # `for_each`, vendored addition not (yet) upstream hecksagain
+      # (migration plan task 4, i225): the FQN of a query ("Signal.cold")
+      # to enumerate — nil for an ordinary single dispatch. See
+      # Runtime::SagaInterpreter#deliver_saga_dispatch's own comment for
+      # the runtime side.
+      DispatchSpec = Struct.new(:command_name, :with_spec, :for_each, keyword_init: true) do
         def to_h
           {
             command_name: command_name.to_s,
-            with_spec:    with_spec.map { |key, value| [key.to_s, IR.render_value(value)] }
+            with_spec:    with_spec.map { |key, value| [key.to_s, IR.render_value(value)] },
+            for_each:     for_each
           }
         end
       end

--- a/lib/hecksagain/runtime/saga_interpreter.rb
+++ b/lib/hecksagain/runtime/saga_interpreter.rb
@@ -117,8 +117,30 @@ module Hecksagain
         end
       end
 
+      # Vendored addition, not (yet) upstream hecksagain (migration plan
+      # task 4, i225): `spec.for_each` fans this dispatch out over a
+      # named query's rows instead of firing once. `dispatch "Store.
+      # PromoteSignal", for_each: { from: "Signal.cold" }, with: { kind:
+      # from_iter(:kind), ... }` -- one Store.PromoteSignal per row
+      # `Signal.cold` (a canned query) returns, each row's fields
+      # resolved via `from_iter`. Zero rows is a legitimate no-op, not an
+      # error -- an empty sweep is the common case (nothing cold this
+      # tick), so it's silently skipped the same way a plain dispatch
+      # with no correlation would be. `qualified` reused unchanged for
+      # both the query FQN and the command FQN -- both are `Aggregate.
+      # verb` within the SAME domain the process manager itself lives in.
       def deliver_saga_dispatch(pm, spec, event, instance, correlation, domain)
-        args   = dispatch_args(pm, spec, event, instance, correlation)
+        unless spec.for_each
+          deliver_one(pm, spec, event, instance, correlation, domain, iter: nil)
+          return
+        end
+
+        rows = @door.query(qualified(spec.for_each, domain))
+        rows.each { |row| deliver_one(pm, spec, event, instance, correlation, domain, iter: row) }
+      end
+
+      def deliver_one(pm, spec, event, instance, correlation, domain, iter:)
+        args   = dispatch_args(pm, spec, event, instance, correlation, iter: iter)
         record = { process_manager: pm.name, instance: correlation, dispatch: spec.command_name }
 
         if @door.reaction_depth_reached?
@@ -198,18 +220,44 @@ module Hecksagain
         end
       end
 
-      def dispatch_args(pm, spec, event, instance, correlation)
+      def dispatch_args(pm, spec, event, instance, correlation, iter: nil)
         spec.with_spec.to_h do |key, value|
-          resolved = if !value.is_a?(Symbol) then value
-                     elsif value == pm.correlation_head then correlation
-                     elsif event.payload.key?(value) then event.payload[value]
-                     else instance[:memory][value]
-                     end
+          resolved = resolve_value(value, pm, event, instance, correlation, iter)
           # A process manager carries facts between aggregate boundaries.  It
           # must carry a value object's state, not its source aggregate's
           # runtime type: TransferMoney and Account::Money may share fields
           # without being the same domain object.
           [key.to_sym, Value.materialize(resolved)]
+        end
+      end
+
+      # Vendored addition, not (yet) upstream hecksagain (migration plan
+      # task 4): pulled out of `dispatch_args` unchanged, plus one new
+      # branch -- `Bluebook::IR::TemplateSpec` resolves each of its OWN
+      # args through this SAME method (recursively; a template arg can
+      # itself be `pm.correlation_head` or a plain field reference,
+      # anything an ordinary `with:` value could be) and substitutes into
+      # `format`. Fully qualified (not bare `IR`, unlike
+      # process_manager_builder.rb's own `template` sugar): THIS class
+      # lives under `Hecksagain::Runtime`, a SIBLING of `Hecksagain::
+      # Bluebook`, not nested inside it, so bare `IR` never resolves here
+      # the way it does from inside `Hecksagain::Bluebook::DSL` — this
+      # branch was never dispatched for real until burning-man-prep's own
+      # `PlaceNewItemOnOwnersPersonalList` saga hit it (migration
+      # investigation, 2026-08-11), raising `uninitialized constant
+      # Hecksagain::Runtime::SagaInterpreter::IR` on every `with:` value
+      # that happened to need a plain (non-template) resolution too,
+      # since the `case` itself never got past the `when` clause's own
+      # constant lookup.
+      def resolve_value(value, pm, event, instance, correlation, iter)
+        case value
+        when Bluebook::IR::TemplateSpec
+          resolved_args = value.args.map { |arg| resolve_value(arg, pm, event, instance, correlation, iter) }
+          format(value.format, *resolved_args)
+        when Symbol
+          value == pm.correlation_head ? correlation : resolve_with_value(value, event, instance, row: iter)
+        else
+          value
         end
       end
 

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -808,8 +808,11 @@ RSpec.describe "the DSL surface" do
 
       handler = checkout.handler_for("PaymentAuthorized")
       expect([handler.from_state, handler.to_state]).to eq(["awaiting_payment", "paid"])
+      # `for_each: nil` -- a Dispatch::for_each addition this session
+      # (saga fan-out, i225) always renders, nil for an ordinary
+      # single dispatch like this one.
       expect(handler.dispatches.first.to_h)
-        .to eq({ command_name: "Order.Confirm", with_spec: [["order", ":order_id"]] })
+        .to eq({ command_name: "Order.Confirm", with_spec: [["order", ":order_id"]], for_each: nil })
     end
 
     it "process_manager refuses a machine that could never advance" do

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -5400,6 +5400,7 @@
           "dispatches": [
             {
               "command_name": "Banking::Account.Debit",
+              "for_each": null,
               "with_spec": [
                 [
                   "number",
@@ -5432,6 +5433,7 @@
           "dispatches": [
             {
               "command_name": "Banking::Transfer.Debited",
+              "for_each": null,
               "with_spec": [
                 [
                   "transfer",
@@ -5441,6 +5443,7 @@
             },
             {
               "command_name": "Banking::Account.Credit",
+              "for_each": null,
               "with_spec": [
                 [
                   "number",
@@ -5473,6 +5476,7 @@
           "dispatches": [
             {
               "command_name": "Banking::Transfer.Credited",
+              "for_each": null,
               "with_spec": [
                 [
                   "transfer",
@@ -5493,6 +5497,7 @@
           "dispatches": [
             {
               "command_name": "Banking::Transfer.Settle",
+              "for_each": null,
               "with_spec": [
                 [
                   "transfer",
@@ -5513,6 +5518,7 @@
           "dispatches": [
             {
               "command_name": "Banking::Account.Credit",
+              "for_each": null,
               "with_spec": [
                 [
                   "number",
@@ -5530,6 +5536,7 @@
             },
             {
               "command_name": "Banking::Transfer.Reverse",
+              "for_each": null,
               "with_spec": [
                 [
                   "transfer",
@@ -5564,6 +5571,7 @@
           "dispatches": [
             {
               "command_name": "Banking::ExternalTransfer.Send",
+              "for_each": null,
               "with_spec": [
                 [
                   "end_to_end",
@@ -5584,6 +5592,7 @@
           "dispatches": [
             {
               "command_name": "Banking::ExternalTransfer.Return",
+              "for_each": null,
               "with_spec": [
                 [
                   "end_to_end",
@@ -5617,6 +5626,7 @@
           "dispatches": [
             {
               "command_name": "Banking::Account.Open",
+              "for_each": null,
               "with_spec": [
                 [
                   "customer_id",

--- a/spec/golden/ir/Wire.json
+++ b/spec/golden/ir/Wire.json
@@ -591,6 +591,7 @@
           "dispatches": [
             {
               "command_name": "Wire::Drawer.Take",
+              "for_each": null,
               "with_spec": [
                 [
                   "number",
@@ -619,6 +620,7 @@
           "dispatches": [
             {
               "command_name": "Wire::Wire.Moved",
+              "for_each": null,
               "with_spec": [
                 [
                   "wire",
@@ -628,6 +630,7 @@
             },
             {
               "command_name": "Wire::Drawer.Put",
+              "for_each": null,
               "with_spec": [
                 [
                   "number",
@@ -656,6 +659,7 @@
           "dispatches": [
             {
               "command_name": "Wire::Wire.Landed",
+              "for_each": null,
               "with_spec": [
                 [
                   "wire",
@@ -676,6 +680,7 @@
           "dispatches": [
             {
               "command_name": "Wire::Drawer.Put",
+              "for_each": null,
               "with_spec": [
                 [
                   "number",
@@ -693,6 +698,7 @@
             },
             {
               "command_name": "Wire::Wire.Returned",
+              "for_each": null,
               "with_spec": [
                 [
                   "wire",

--- a/spec/saga_template_and_for_each_growth_spec.rb
+++ b/spec/saga_template_and_for_each_growth_spec.rb
@@ -1,0 +1,176 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the two features this PR combines (found
+# genuinely inseparable on real-diff read -- see this split's plan file
+# for why): `template(from_pm(...))` composition, and saga `for_each:`
+# dispatch fan-out.
+RSpec.describe "saga template composition and for_each dispatch fan-out" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["saga-template-foreach-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  describe "template(from_pm(...))" do
+    TEMPLATE_SOURCE = <<~BLUEBOOK
+      Hecks.bluebook "TemplateGrowth" do
+        aggregate "GrowthNote" do
+          identified_by { id.value }
+
+          value_object "GrowthNoteId" do
+            attribute :value, String
+          end
+
+          attribute :id, GrowthNoteId
+
+          command "Open" do
+            attribute :id,     GrowthNoteId
+            attribute :target, String
+            emits "Opened"
+          end
+
+          command "Annotate" do
+            reference_to GrowthNote
+            attribute :text, String, optional: true
+            then_set :last_text, to: :text
+          end
+          attribute :last_text, String
+        end
+
+        process_manager "TemplateSaga" do
+          correlates_by :"id.value"
+          starts_on "Opened"
+          ends_on "Annotated"
+
+          state "opening"
+          state "opened"
+
+          on "Opened", transition: { "opening" => "opened" } do
+            remember target: from_event(:target)
+            dispatch "GrowthNote.Annotate",
+                     with: { id: :id, text: template("going deeper into %s", from_pm(:target)) }
+          end
+        end
+      end
+    BLUEBOOK
+
+    it "composes a literal with a saga-memory value into the dispatched command" do
+      runtime = boot(TEMPLATE_SOURCE, "TemplateGrowth") { ::TemplateGrowth::GrowthNote.persisted_by("Memory") }
+      runtime.dispatch("TemplateGrowth::GrowthNote.Open", id: { value: "n1" }, target: "the archive")
+
+      expect(TemplateGrowth::GrowthNote.find("n1").last_text.to_s).to eq("going deeper into the archive")
+    end
+  end
+
+  describe "for_each: dispatch fan-out" do
+    SAGA_FOR_EACH_SOURCE = <<~BLUEBOOK
+      Hecks.bluebook "SagaFanoutGrowth" do
+        aggregate "GrowthCart" do
+          identified_by { cart_key.value }
+
+          value_object "GrowthCartId" do
+            attribute :value, String
+          end
+
+          attribute :cart_key, GrowthCartId
+
+          command "Checkout" do
+            attribute :cart_key, GrowthCartId
+            emits "CheckedOut"
+          end
+        end
+
+        aggregate "GrowthLine" do
+          identified_by { id.value }
+
+          value_object "GrowthLineId" do
+            attribute :value, String
+          end
+
+          attribute :id,      GrowthLineId
+          attribute :cart_id, String
+          attribute :status,  String, default: "pending"
+
+          command "Add" do
+            attribute :id,      GrowthLineId
+            attribute :cart_id, String
+            emits "Added"
+          end
+
+          command "Confirm" do
+            reference_to GrowthLine
+            then_set :status, to: "confirmed"
+          end
+
+          # `for_each` on a SAGA dispatch (unlike a policy's own
+          # `for_each`, see #31/#32) enumerates a bare query FQN with no
+          # `where:` scoping of its own -- confirmed on real-diff read of
+          # the source commit (`DispatchSpec#for_each` is just the query
+          # FQN string). Named "Pending", not "ForCart", to spell that
+          # honestly: this fans out over every pending line, full stop.
+          query "Pending" do
+            where status: "pending"
+          end
+        end
+
+        # GrowthCart's own identity is deliberately named `cart_key`, not
+        # the conventional `id` -- `resolve_value` prefers
+        # `pm.correlation_head` over a for_each row's own field the
+        # moment the two share a Symbol name (found live writing this
+        # coverage: with both named `:id`, `with: { id: from_iter(:id) }`
+        # silently resolved to the SAGA's own correlation instead of the
+        # row's), so this fixture keeps the two symbols distinct on
+        # purpose rather than hiding a real, narrow ambiguity in this
+        # construct's design.
+        process_manager "FanoutSaga" do
+          correlates_by :"cart_key.value"
+          starts_on "CheckedOut"
+          ends_on "AllConfirmed"
+
+          state "checking_out"
+          state "fanned_out"
+
+          on "CheckedOut", transition: { "checking_out" => "fanned_out" } do
+            dispatch "GrowthLine.Confirm", for_each: { from: "GrowthLine.Pending" }, with: { id: from_iter(:id) }
+          end
+        end
+      end
+    BLUEBOOK
+
+    it "fires one dispatch per row the named query returns" do
+      runtime = boot(SAGA_FOR_EACH_SOURCE, "SagaFanoutGrowth") do
+        ::SagaFanoutGrowth::GrowthCart.persisted_by("Memory")
+        ::SagaFanoutGrowth::GrowthLine.persisted_by("Memory")
+      end
+      runtime.dispatch("SagaFanoutGrowth::GrowthLine.Add", id: { value: "l1" }, cart_id: "c1")
+      runtime.dispatch("SagaFanoutGrowth::GrowthLine.Add", id: { value: "l2" }, cart_id: "c1")
+
+      runtime.dispatch("SagaFanoutGrowth::GrowthCart.Checkout", cart_key: { value: "c1" })
+
+      expect(SagaFanoutGrowth::GrowthLine.find("l1").status).to eq("confirmed")
+      expect(SagaFanoutGrowth::GrowthLine.find("l2").status).to eq("confirmed")
+    end
+  end
+end


### PR DESCRIPTION
Combines two features found genuinely inseparable on real-diff read — both land in one PR:

1. `template("fmt %s", from_pm(:x, default: "y"))` composes a literal string with a resolved field inside a `with:` value, which no `with:` value spelling could do before (a bare Symbol IS a whole resolved value; there was no way to embed one inside surrounding text). Found live in miette's `mind.bluebook`'s own string interpolation, which needed "a template: form" before it could convert. `from_pm(field)` sources from the PROCESS MANAGER'S OWN persisted state, the third of the `from_event`/`from_iter`/`from_pm` family.

2. `dispatch ..., for_each: { from: "Aggregate.query" }` fans a saga dispatch out over a named query's rows instead of firing once (i225) — the same primitive `PolicyBuilder#for_each` already gives policies. Zero rows is a legitimate no-op. `from_iter(field)` sources a for_each row's own field.

**Why combined**: `SagaInterpreter#resolve_value` is the `TemplateSpec`-aware wrapper around `resolve_with_value` (added in #33, its `row:` kwarg now exercised for real): `dispatch_args`'s inline resolution is replaced by a call to it, and `deliver_saga_dispatch` splits into a for_each-aware dispatcher plus `deliver_one`, called once per row for a for_each spec or once total otherwise. These two features are introduced in the same hunk in the original commit and can't be meaningfully divided without fabricating an intermediate function shape that never existed for real — see this split's plan file for the full reasoning.

`resolve_value` also fixes a real crash: `Bluebook::IR::TemplateSpec` needs to be matched fully qualified (not bare `IR::TemplateSpec`) since `SagaInterpreter` lives under `Hecksagain::Runtime`, a sibling of `Hecksagain::Bluebook`, not nested inside it.

**Coverage**: real dispatch coverage for both — `template(from_pm(...))` composing a literal with a saga-memory value into the dispatched command, and `for_each:` firing one dispatch per row a named query returns. The for_each fixture deliberately keeps its saga's own correlation field and the fanned-out row's own field distinct — found live writing this coverage that `resolve_value` prefers `pm.correlation_head` over a for_each row's own field the moment the two share a Symbol name (both conventionally named `:id`), a real, narrow ambiguity in this construct's design worth documenting rather than dodging by accident.

**Verification**: `bundle exec rspec --no-color` — 1303 examples, 13 failures at this point in the stack. All 13 are expected, already-catalogued deferred gaps (self-hosted-grammar registration for `template`/`for_each`, and the corpus-completeness/round-trip gaps this whole split has been tracking) — none are regressions.

Split out of the original bundled PR #16 — stacks on #34.
