### PR TITLE
self-hosted grammar: Handler identity gains from_state.value

### DIFF
--- a/lib/hecksagain/language/bluebook/reaction.bluebook
+++ b/lib/hecksagain/language/bluebook/reaction.bluebook
@@ -157,13 +157,26 @@ Hecks.bluebook "Bluebook" do
 
     reference_to ProcessManager
 
-    # THE PROCESS MANAGER IT IS IN, AND THE EVENT IT ANSWERS. A saga answers each
-    # event once, so the event names the leg. The judge keyed this by POSITION
+    # THE PROCESS MANAGER IT IS IN, THE EVENT IT ANSWERS, AND THE STATE IT
+    # ANSWERS FROM. The judge keyed this by POSITION
     # ("#{parent}##{index}"), which is a mint : insert a leg above and every leg
     # below is renamed. The event does not move.
+    #
+    # Vendored correction (migration plan task 4, hecks-hecksagain-migration):
+    # (process_manager_id, event_type) ALONE is not one leg — a state machine
+    # legitimately answers the SAME event differently depending on which state
+    # it is currently in (miette's own BodyCycle PM: "BodyPulse" while
+    # attentive moves attentive->attentive, "BodyPulse" while sleeping_light
+    # moves sleeping_light->sleeping_light — six real, distinct legs, one
+    # event name). Excluding from_state collapsed all six into one identity,
+    # so the second-declared leg for the same event read as a duplicate
+    # Declare of the first. from_state doesn't move for the same reason
+    # event_type doesn't: it's a value, not a position. TODO upstream via
+    # bin/evolve.
     identified_by do
       process_manager_id
       event_type.value
+      from_state.value
     end
 
     # No `saga` field. It named the old word for a process manager, held nothing —

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -5677,7 +5677,8 @@
       ],
       "identified_by": [
         "process_manager_id",
-        "event_type.value"
+        "event_type.value",
+        "from_state.value"
       ],
       "lifecycle": null,
       "name": "Handler",

--- a/spec/saga_handler_from_state_identity_growth_spec.rb
+++ b/spec/saga_handler_from_state_identity_growth_spec.rb
@@ -1,0 +1,101 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for the self-hosted grammar identity fix on `Handler`:
+# `identified_by { process_manager_id; event_type.value }` alone collapses
+# two legs answering the SAME event from two DIFFERENT states into one
+# meta-domain identity. Before `from_state.value` joined the identity, the
+# self-hosted grammar's own Judge crashed with `AlreadyExists` the moment a
+# process manager declared a second leg for an event it already answered
+# from a different state -- a legitimate, common shape (a state machine
+# answering the same event differently depending on where it currently is).
+RSpec.describe "saga Handler identity includes from_state" do
+  HANDLER_IDENTITY_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "HandlerIdentityGrowth" do
+      aggregate "Widget" do
+        identified_by { id.value }
+        value_object "WidgetId" do
+          attribute :value, String
+        end
+        attribute :id, WidgetId
+
+        command "Open" do
+          attribute :id, WidgetId
+          emits "Opened"
+        end
+        command "Foo" do
+          reference_to Widget
+          emits "Fooed"
+        end
+        command "Bar" do
+          reference_to Widget
+          emits "Barred"
+        end
+      end
+
+      process_manager "TwoLegSaga" do
+        correlates_by :"id.value"
+        starts_on "Opened"
+        ends_on "Barred"
+
+        state "a"
+        state "b"
+        state "c"
+
+        # SAME EVENT, TWO DIFFERENT from_states -- the exact shape that
+        # collided into one identity before this fix.
+        on "Ping", transition: { "a" => "b" } do
+          dispatch "HandlerIdentityGrowth::Widget.Foo", with: { id: :id }
+        end
+
+        on "Ping", transition: { "b" => "c" } do
+          dispatch "HandlerIdentityGrowth::Widget.Bar", with: { id: :id }
+        end
+      end
+    end
+  BLUEBOOK
+
+  def judged_handler_identity_growth
+    file = Tempfile.new(["handler-identity-growth-", ".bluebook"])
+    file.write(HANDLER_IDENTITY_SOURCE)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    bluebook = nil
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      bluebook = Kernel.eval(HANDLER_IDENTITY_SOURCE, TOPLEVEL_BINDING, file.path, 1)
+    end
+
+    judge = Hecksagain::Bluebook::MetaValidator::Judge.new(bluebook)
+    [judge, Hecksagain::Bluebook::MetaValidator::Reconstruction.of(judge.runtime, bluebook.hecks_name)]
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  it "judges both legs without raising AlreadyExists" do
+    expect { judged_handler_identity_growth }.not_to raise_error
+  end
+
+  it "keeps both legs as distinct handler records" do
+    judge, reconstruction = judged_handler_identity_growth
+
+    expect(judge.refusals).to be_empty
+
+    process_manager = reconstruction[:process_managers].find { |pm| pm[:name] == "TwoLegSaga" }
+    expect(process_manager[:handlers].size).to eq(2)
+
+    legs = process_manager[:handlers].map { |h| h.values_at(:event_type, :from_state, :to_state) }
+    expect(legs).to contain_exactly(
+      %w[Ping a b],
+      %w[Ping b c]
+    )
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 4 (hecks-hecksagain-migration) — real bug fix bundled into `25cf543`, not called out in that commit's own message.

`Handler` (`reaction.bluebook`) was `identified_by { process_manager_id; event_type.value }` alone. A state machine legitimately answers the SAME event differently depending on which state it currently is in — one event name, several distinct legs (e.g. a `BodyPulse` handler that moves `attentive -> attentive` and, separately, `sleeping_light -> sleeping_light`). Without `from_state` in the identity, every such leg collapsed into one meta-domain identity: the self-hosted grammar's own Judge **raised `AlreadyExists`** ("creating_duplicate") the instant a process manager declared a second leg for an event it already answered from a different state — not a refusal caught and reported, an uncaught crash, so no bluebook with this common, legitimate shape could be judged at all.

`from_state` doesn't move for the same reason `event_type` doesn't: it's a value, not a position.

**What this PR does**
- Adds `from_state.value` to `Handler`'s `identified_by` block.
- Regenerates `spec/golden/ir/Bluebook.json` for the new identity path (only file whose content actually changed under `GOLDEN=rewrite`).
- Adds `spec/saga_handler_from_state_identity_growth_spec.rb`: builds a process manager with two legs answering the same event from two different states, confirms Judge no longer raises `AlreadyExists`, and confirms both legs survive as distinct handler records with their own `from_state`/`to_state`.

**Verification**: `bundle exec rspec` — 1305 examples, 13 failures, same failure set as this stack's previous item (all pre-existing, expected/deferred gaps tracked in `.pr-split-plan.md`; none are regressions). Confirmed via before/after diff: reverting just this hunk reproduces the `AlreadyExists` crash in the new spec.

Split out of `25cf543` (item 12 of the PR-split plan) as its own item, 12c — distinct rationale from item 12d (`Dispatch.position.value`), which stacks after this one.
