### PR TITLE
self-hosted grammar: Dispatch identity gains position.value

### DIFF
--- a/lib/hecksagain/language/bluebook/reaction.bluebook
+++ b/lib/hecksagain/language/bluebook/reaction.bluebook
@@ -242,9 +242,23 @@ Hecks.bluebook "Bluebook" do
 
     # THE HANDLER IT IS IN, AND THE COMMAND IT SENDS — keyed by position before,
     # for the same want of a way to say this.
+    #
+    # Vendored correction (migration plan task 4): (handler_id, command_name)
+    # alone collides on a real, legitimate pattern — one handler fanning the
+    # SAME command out several times with different `with:` bindings each
+    # time (miette's body/pulse_organs/bluebook: one BodyPulse handler
+    # dispatching "Signal.FireSignal" once per organ, same command name,
+    # different args). Unlike Handler's from_state (a real business value),
+    # position here is not a stand-in for missing meaning — it names WHICH
+    # send this is, and each Dispatch is declared once, at load time, never
+    # re-addressed by identity afterward (the "way back" is always
+    # DeclaredIn + order_by :position, never a Dispatch looked up by its own
+    # id). So folding position into identity is safe exactly where it was
+    # unsafe for Handler's legs. TODO upstream via bin/evolve.
     identified_by do
       handler_id
       command_name.value
+      position.value
     end
 
     attribute :handler,      DispatchText

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -5925,7 +5925,8 @@
       ],
       "identified_by": [
         "handler_id",
-        "command_name.value"
+        "command_name.value",
+        "position.value"
       ],
       "lifecycle": null,
       "name": "Dispatch",

--- a/spec/saga_dispatch_position_identity_growth_spec.rb
+++ b/spec/saga_dispatch_position_identity_growth_spec.rb
@@ -1,0 +1,94 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for the self-hosted grammar identity fix on `Dispatch`:
+# `identified_by { handler_id; command_name.value }` alone collapses two
+# dispatches of the SAME command, with different `with:` bindings, inside
+# one handler into one meta-domain identity -- a real, legitimate fan-out
+# pattern (one handler sending the same command several times, once per
+# argument set). Before `position.value` joined the identity, the
+# self-hosted grammar's own Judge crashed with `AlreadyExists` the instant
+# a handler dispatched the same command name twice.
+RSpec.describe "saga Dispatch identity includes position" do
+  DISPATCH_IDENTITY_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "DispatchIdentityGrowth" do
+      aggregate "Organ" do
+        identified_by { id.value }
+        value_object "OrganId" do
+          attribute :value, String
+        end
+        attribute :id, OrganId
+
+        command "Open" do
+          attribute :id, OrganId
+          emits "Opened"
+        end
+        command "Fire" do
+          reference_to Organ
+          attribute :label, OrganId
+          emits "Fired"
+        end
+      end
+
+      process_manager "FanOutSaga" do
+        correlates_by :"id.value"
+        starts_on "Opened"
+        ends_on "Fired"
+
+        state "opening"
+        state "opened"
+
+        # ONE HANDLER, THE SAME COMMAND DISPATCHED TWICE with different
+        # with: bindings -- the exact shape that collided into one
+        # identity before this fix.
+        on "Opened", transition: { "opening" => "opened" } do
+          dispatch "DispatchIdentityGrowth::Organ.Fire", with: { id: :id, label: :id }
+          dispatch "DispatchIdentityGrowth::Organ.Fire", with: { id: :id, label: :id }
+        end
+      end
+    end
+  BLUEBOOK
+
+  def judged_dispatch_identity_growth
+    file = Tempfile.new(["dispatch-identity-growth-", ".bluebook"])
+    file.write(DISPATCH_IDENTITY_SOURCE)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    bluebook = nil
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      bluebook = Kernel.eval(DISPATCH_IDENTITY_SOURCE, TOPLEVEL_BINDING, file.path, 1)
+    end
+
+    judge = Hecksagain::Bluebook::MetaValidator::Judge.new(bluebook)
+    [judge, Hecksagain::Bluebook::MetaValidator::Reconstruction.of(judge.runtime, bluebook.hecks_name)]
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  it "judges both dispatches without raising AlreadyExists" do
+    expect { judged_dispatch_identity_growth }.not_to raise_error
+  end
+
+  it "keeps both same-command dispatches as distinct records, in declared order" do
+    judge, reconstruction = judged_dispatch_identity_growth
+
+    expect(judge.refusals).to be_empty
+
+    process_manager = reconstruction[:process_managers].find { |pm| pm[:name] == "FanOutSaga" }
+    handler = process_manager[:handlers].first
+
+    expect(handler[:dispatches].size).to eq(2)
+    expect(handler[:dispatches].map { |d| d[:command_name] }).to eq(
+      ["DispatchIdentityGrowth::Organ.Fire", "DispatchIdentityGrowth::Organ.Fire"]
+    )
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 4 (hecks-hecksagain-migration) — real bug fix bundled into `25cf543`, not called out in that commit's own message.

`Dispatch` (`reaction.bluebook`) was `identified_by { handler_id; command_name.value }` alone — collides on a real, legitimate pattern: one handler fanning the SAME command out several times with different `with:` bindings each time (e.g. one `BodyPulse` handler dispatching `"Signal.FireSignal"` once per organ, same command name, different args). Without `position` in the identity, the self-hosted grammar's own Judge **raised `AlreadyExists`** the instant a handler dispatched the same command name twice — an uncaught crash, not a refusal.

Unlike Handler's `from_state` (item #43/12c — a real business value), `position` here is not standing in for missing meaning: it names WHICH send this is, and each `Dispatch` is declared once, at load time, never re-addressed by identity afterward (the way back is always `DeclaredIn` + `order_by :position`, never a `Dispatch` looked up by its own id). So folding position into identity is safe exactly where it was unsafe for Handler's legs.

**What this PR does**
- Adds `position.value` to `Dispatch`'s `identified_by` block.
- Regenerates `spec/golden/ir/Bluebook.json` for the new identity path (only file whose content actually changed).
- Adds `spec/saga_dispatch_position_identity_growth_spec.rb`: builds a handler dispatching the same command twice with different `with:` bindings, confirms Judge no longer raises `AlreadyExists`, and confirms both dispatches survive as distinct records in declared order.

**Verification**: `bundle exec rspec` — 1307 examples, 13 failures, same pre-existing failure set as this stack's previous item (all tracked in `.pr-split-plan.md`; none are regressions). Confirmed via before/after: reverting just this hunk reproduces the `AlreadyExists` crash in the new spec.

Split out of `25cf543` (item 12 of the PR-split plan) as its own item, 12d, stacked after 12c — a genuinely separate hunk in the same file, distinct rationale from 12c's fix.
