### PR TITLE
DSL: then_set gains remove:/multiply:/clamp: (+ UNSET sentinel, from:, positional to:)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/command_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/command_builder.rb
@@ -4,6 +4,21 @@ module Hecksagain
       class CommandBuilder
         include AttributeCollector
 
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4): a sentinel for "this keyword was never passed", distinct
+        # from Ruby's own nil/false. `then_set`'s ORIGINAL default (`to:
+        # nil`) could not tell "not given" apart from "given, and the
+        # value IS false" — `to || from` silently treats `to: false` the
+        # same as an absent `to:` and falls through to `from` (also
+        # absent), so `then_set :accepted, to: false` raised "names no
+        # operation" for the one value most likely to be written that way
+        # (a boolean flip). Confirmed real, live: miette's
+        # dream_interpretation.bluebook (`then_set :accepted, to: false`)
+        # and transparency.bluebook (`then_set :always, to: false`). TODO
+        # upstream via bin/evolve.
+        UNSET = Object.new.freeze
+        private_constant :UNSET
+
         def initialize(name, owner: nil)
           @name      = name
           @owner     = owner
@@ -115,16 +130,68 @@ module Hecksagain
         # bluebook was written under (Syntax::Keyword carries the rename as
         # `was:`), and it stays answered here forever — a renamed word's old
         # era keeps booting, which is the whole point of the rename column.
-        def then_set(target, to: nil, append: nil, increment: nil, decrement: nil)
+        #
+        # Vendored addition, not (yet) upstream hecksagain: `then_set
+        # :target, from: :source_field` (hecks_conception/miette, found
+        # live in body/doctor/bluebook/doctor.bluebook) -- semantically
+        # identical to `to:` (copy this argument/field into the target),
+        # different word. TODO upstream via bin/evolve (migration plan
+        # task 7): decide whether `from:` or `to:` becomes the canonical
+        # spelling.
+        #
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4, i106 in-DSL math): `multiply:`/`clamp:` -- per-tick organ
+        # math (miette's body/organs/bluebook: strength decays ×0.98,
+        # weight/strength clamp to [0, 1]) that used to be shell-side awk
+        # and moved into the bluebook itself. `multiply:` mirrors
+        # increment/decrement's shape exactly (a Numeric amount, applied
+        # by CommandRules::Arithmetic -- see that file's own comment on
+        # the matching Float-support widening this required). `clamp:`
+        # is a genuinely different shape -- its source is always a literal
+        # `[min, max]` pair, never an argument reference, and it bounds
+        # the CURRENT value rather than combining it with an amount -- so
+        # it does not reuse `arithmetic`/`arithmetic_value_object` at all;
+        # see MutationApplier#apply's own `:clamp` branch.
+        #
+        # `remove:` -- vendored addition, not (yet) upstream hecksagain
+        # (migration plan task 4): the list-removal counterpart to
+        # `append:` (plan.bluebook's own RemoveDependency/DeactivateSprint
+        # commands: "the runtime list-remove primitive (then_set remove:)
+        # drops it from the list element-wise, with no read-modify-write
+        # -- so a concurrent Add can never be lost"). Matches an element
+        # by VALUE equality against `mutation.source` (resolved and
+        # Value-coerced the same way increment/decrement/multiply already
+        # coerce their own amount -- see MutationApplier#removed).
+        #
+        # `then_set :field, true` -- vendored addition, not (yet) upstream
+        # hecksagain (migration plan task 8): a bare positional literal
+        # instead of `to:` -- 14 occurrences across hecks_nursury
+        # (oceanography.bluebook/volcanology.bluebook and others),
+        # always a boolean shorthand (`then_set :deployed, true`, never
+        # a string/number positional -- checked directly, zero non-
+        # boolean occurrences of the bare-positional-second-arg shape
+        # anywhere in the corpus). Folded into `to:` itself rather than
+        # given its own mutation op -- semantically identical, same
+        # UNSET-sentinel discipline the `to: false` fix already
+        # established (a positional `false` must read as "set to
+        # false," not "absent," same as the keyword form). Only applied
+        # when `to:` itself was NOT also given, so an explicit `to:`
+        # keyword always wins over a stray positional.
+        def then_set(target, positional_to = UNSET, to: UNSET, from: UNSET, append: UNSET,
+                     increment: UNSET, decrement: UNSET, multiply: UNSET, clamp: UNSET, remove: UNSET)
           # moved to the language: given "a mutation names a target", on Verb.Change
 
-          named = { set: to, append: append, increment: increment, decrement: decrement }
-                  .reject { |_, source| source.nil? }
+          to = positional_to if to.equal?(UNSET) && !positional_to.equal?(UNSET)
+          set_source = to.equal?(UNSET) ? from : to
+
+          named = { set: set_source, append: append, increment: increment, decrement: decrement,
+                    multiply: multiply, clamp: clamp, remove: remove }
+              .reject { |_, source| source.equal?(UNSET) }
 
           if named.empty?
             raise Malformed,
                   "#{@name}'s then_set :#{target} names no operation — " \
-                  "give it to:, append:, increment:, or decrement:"
+                  "give it to:, append:, increment:, decrement:, multiply:, clamp:, or remove:"
           end
 
           if named.size > 1

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1947,6 +1947,50 @@ RSpec.describe "the DSL surface" do
       expect(mutation.to_h[:source]).to eq(kind: "literal", value: "sold")
     end
 
+    # Real coverage for item 12e's plumbing (migration plan task 4/7/8):
+    # then_set's UNSET-sentinel rewrite -- to: false no longer reads as
+    # absent, from: is a to:-equivalent alias, and a bare positional second
+    # argument is boolean shorthand for to:. remove:/multiply:/clamp: are
+    # covered by their own items' dispatch-level specs (13/15/16); this file
+    # only proves the DSL surface itself parses and records the right op.
+    it "then_set to: false is a real mutation, not an absent to:" do
+      mutation = build_command("CmdSetToFalse") { then_set :status, to: false }.mutations.first
+
+      expect(mutation.op).to eq(:set)
+      expect(mutation.to_h[:source]).to eq(kind: "literal", value: false)
+    end
+
+    it "then_set from: is a to:-equivalent alias" do
+      mutation = build_command("CmdSetFrom") { then_set :status, from: :status }.mutations.first
+
+      expect(mutation.op).to eq(:set)
+      expect(mutation.to_h[:source]).to eq(kind: "argument", name: "status")
+    end
+
+    it "then_set :field, true reads as to: true — a bare positional boolean shorthand" do
+      mutation = build_command("CmdSetPositional") { then_set :status, true }.mutations.first
+
+      expect(mutation.op).to eq(:set)
+      expect(mutation.to_h[:source]).to eq(kind: "literal", value: true)
+    end
+
+    it "then_set :field, true defers to an explicit to: when both are given" do
+      mutation = build_command("CmdSetPositionalLoses") { then_set :status, true, to: "explicit" }.mutations.first
+
+      expect(mutation.to_h[:source]).to eq(kind: "literal", value: "explicit")
+    end
+
+    it "then_set still refuses two operations at once with the new keyword list named" do
+      expect { build_command("CmdSetTornNew") { then_set :status, to: "a", remove: :b } }
+        .to raise_error(Hecksagain::Bluebook::DSL::Malformed, /tries to set and remove/)
+    end
+
+    it "then_set still refuses no operation, naming every keyword including the new ones" do
+      expect { build_command("CmdSetNoneNew") { then_set :status } }
+        .to raise_error(Hecksagain::Bluebook::DSL::Malformed,
+                         /give it to:, append:, increment:, decrement:, multiply:, clamp:, or remove:/)
+    end
+
     it "then_set append: pushes a built value object onto a list" do
       mutation = build_command("CmdAppend") { then_set :parts, append: { size: :size } }.mutations.first
 


### PR DESCRIPTION
**Migration findings doc**: task 4/7/8 (hecks-hecksagain-migration) — real out-of-order plumbing dependency, pulled forward from `1855be0` (originally items ~17-23 of the split plan).

`6df3840`'s runtime support for the `:remove`/`:multiply`/`:clamp` mutation ops (items 13/15/16 of the split plan) has no way to be dispatched from an actual bluebook without a DSL surface — there is no `then_remove`/`then_multiply`/`then_clamp` word, only `then_set`'s own keyword args. Reading `1855be0`'s real diff, `then_set`'s entire method signature is rewritten in one hunk that bundles **seven** things inseparably (same method, same line — matching item 12's own documented "genuinely inseparable" precedent):

- `UNSET`, a sentinel distinct from `nil`/`false`. `then_set`'s original default (`to: nil`) couldn't tell "not given" apart from "given, and the value IS `false`" — `then_set :accepted, to: false` raised "names no operation" for the value most likely to be written that way.
- `from:` — a `to:`-equivalent alias (semantically identical, different word).
- `multiply:`/`clamp:` — the DSL halves of items 15/16.
- `remove:` — the DSL half of item 13.
- A bare positional second argument (`then_set :field, true`) as boolean shorthand for `to:` — folded into `to:` itself, not a separate op. Only applied when `to:` itself wasn't also given (explicit `to:` always wins).

**What this PR does**
- Pulls the whole `then_set` rewrite forward, with `UNSET` sentinel.
- Adds real spec coverage in `spec/dsl_spec.rb`: `to: false` is a real mutation and not an absent `to:`, `from:` parses as a `to:`-equivalent, a bare positional boolean parses as `to:`, an explicit `to:` still wins over a stray positional, and both "too many operations" / "no operation" refusals still fire and now name every new keyword.

`remove:`/`multiply:`/`clamp:` themselves get their own dispatch-level coverage in items 13/15/16 (stacked after this one) — this PR only proves the DSL surface parses and records the right op.

**Verification**: `bundle exec rspec` — 1313 examples, 13 failures, same pre-existing failure set as this stack's previous item (all tracked in `.pr-split-plan.md`; none are regressions).

**Note for future items**: when `1855be0` is split later (originally items 17-23), this hunk is ALREADY LANDED here — item 20 (UNSET sentinel) becomes a no-op/renumbering note, and the `from:`/positional-`to:` pieces (not in the original plan at all) fold into this PR's own record rather than being duplicated.
