### PR TITLE
mutations: remove op

### DIFF
--- a/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
+++ b/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
@@ -35,24 +35,38 @@ module Hecksagain
               mutation.target,
               @rules.sign_of(mutation.op)
             )
+          # Vendored addition, not (yet) upstream hecksagain (migration
+          # plan task 4): remove -- the list-removal counterpart to
+          # append, matching an element by value (plan.bluebook's
+          # RemoveDependency/DeactivateSprint: "a concurrent Add can
+          # never be lost").
+          when :remove
+            instance[mutation.target] = removed(instance, aggregate, mutation, args)
           end
         end
 
-        # A symbol source names a COMMAND ARGUMENT first (append: cards,
-        # assignee_id: :assignee_id — the ordinary case), falling back to
-        # the AGGREGATE'S OWN CURRENT FIELD when it isn't one — a caller
-        # appending at the end without computing or supplying a position
-        # (`position: :next_position`, a field the command never declares
-        # as an argument at all). `args.key?`, not a truthiness check on
-        # the value — an explicitly-nil argument still counts as "the
-        # caller named it," same distinction `assign_creation_attributes`
+        # A CALLER-SUPPLIED ARG, FIRST -- an append's own field can also
+        # name something the SUBJECT ALREADY KNOWS about itself, falling
+        # back to the AGGREGATE'S OWN CURRENT FIELD when it isn't one — a
+        # caller appending at the end without computing or supplying a
+        # position (`position: :next_position`, a field the command never
+        # declares as an argument at all). `args.key?`, not a truthiness
+        # check on the value — an explicitly-nil argument still counts as
+        # "the caller named it," same distinction `assign_creation_attributes`
         # already draws.
-        def appended(instance, aggregate, mutation, args)
-          fields       = mutation.source.transform_values do |source|
-            next source unless source.is_a?(Symbol)
+        #
+        # Extracted to its own method (pure refactor, ternary -> early
+        # return, no behavior change) alongside `remove`'s own addition
+        # below, purely for readability at this point in the file.
+        def resolve_append_source(source, instance, args)
+          return source unless source.is_a?(Symbol)
+          return args[source] if args.key?(source)
 
-            args.key?(source) ? args[source] : instance[source]
-          end
+          instance[source]
+        end
+
+        def appended(instance, aggregate, mutation, args)
+          fields       = mutation.source.transform_values { |source| resolve_append_source(source, instance, args) }
           element_type = aggregate.attribute(mutation.target)&.type
           value_object = aggregate.value_object(element_type)
           if value_object
@@ -63,6 +77,22 @@ module Hecksagain
           element      = value_object ? Value.build(value_object, fields) : entity_element(aggregate, element_type, instance[mutation.target], fields)
 
           Array(instance[mutation.target]) + [element]
+        end
+
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4): the removal counterpart to #appended -- matches by
+        # VALUE EQUALITY, element-wise, no read-modify-write (plan.
+        # bluebook's own words: "so a concurrent Add can never be lost").
+        # `mutation.source` is a single field reference (`:dependency`),
+        # unlike append's field-map -- resolved and Value-coerced the
+        # SAME way increment/decrement already coerce their own amount,
+        # so the comparison is against a like-shaped Value, not a raw
+        # scalar against a wrapped one.
+        def removed(instance, aggregate, mutation, args)
+          value     = @rules.resolve_source(mutation.source, args)
+          attribute = aggregate.attribute(mutation.target)
+          value     = Value.for_attribute(aggregate, attribute, value) if attribute
+          Array(instance[mutation.target]).reject { |element| element == value }
         end
 
         def entity_element(aggregate, element_type, current, fields)

--- a/spec/mutation_remove_growth_spec.rb
+++ b/spec/mutation_remove_growth_spec.rb
@@ -1,0 +1,109 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the `remove` mutation op: the list-removal
+# counterpart to `append`, matching an element by value equality, no
+# read-modify-write (plan.bluebook's RemoveDependency/DeactivateSprint --
+# "a concurrent Add can never be lost").
+RSpec.describe "mutation op remove" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["mutation-remove-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  MUTATION_REMOVE_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "MutationRemoveGrowth" do
+      aggregate "Sprint" do
+        identified_by { id.value }
+
+        value_object "SprintId" do
+          attribute :value, String
+        end
+
+        value_object "Dependency" do
+          attribute :value, String
+        end
+
+        attribute :id,           SprintId
+        attribute :dependencies, list_of(Dependency)
+
+        command "Open" do
+          attribute :id, SprintId
+          emits "SprintOpened"
+        end
+
+        command "AddDependency" do
+          reference_to Sprint
+          attribute :dependency, Dependency
+
+          then_set :dependencies, append: { value: :dependency }
+          emits "DependencyAdded"
+        end
+
+        command "RemoveDependency" do
+          reference_to Sprint
+          attribute :dependency, Dependency
+
+          then_set :dependencies, remove: :dependency
+          emits "DependencyRemoved"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def sprint_repository(runtime)
+    aggregate = runtime.registry.bluebook("MutationRemoveGrowth").aggregate("Sprint")
+    runtime.registry.repository("MutationRemoveGrowth", aggregate)
+  end
+
+  def boot_mutation_remove
+    boot(MUTATION_REMOVE_SOURCE, "MutationRemoveGrowth") do
+      ::MutationRemoveGrowth::Sprint.persisted_by("Memory")
+    end
+  end
+
+  it "removes a matching element by value equality" do
+    runtime = boot_mutation_remove
+    runtime.dispatch("MutationRemoveGrowth::Sprint.Open", id: { value: "s1" })
+    runtime.dispatch("MutationRemoveGrowth::Sprint.AddDependency", id: "s1", dependency: { value: "db" })
+    runtime.dispatch("MutationRemoveGrowth::Sprint.AddDependency", id: "s1", dependency: { value: "api" })
+
+    runtime.dispatch("MutationRemoveGrowth::Sprint.RemoveDependency", id: "s1", dependency: { value: "db" })
+
+    sprint = sprint_repository(runtime).find("s1")
+    expect(sprint[:dependencies].map { |d| d[:value] }).to eq(["api"])
+  end
+
+  it "is a no-op, not an error, removing a value that was never added" do
+    runtime = boot_mutation_remove
+    runtime.dispatch("MutationRemoveGrowth::Sprint.Open", id: { value: "s2" })
+    runtime.dispatch("MutationRemoveGrowth::Sprint.AddDependency", id: "s2", dependency: { value: "db" })
+
+    runtime.dispatch("MutationRemoveGrowth::Sprint.RemoveDependency", id: "s2", dependency: { value: "nope" })
+
+    sprint = sprint_repository(runtime).find("s2")
+    expect(sprint[:dependencies].map { |d| d[:value] }).to eq(["db"])
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 4 (hecks-hecksagain-migration), item 13 of the PR-split plan (corrected — see below).

The `remove` mutation op: the list-removal counterpart to `append`, matching an element by value equality, no read-modify-write (`plan.bluebook`'s own `RemoveDependency`/`DeactivateSprint`: "so a concurrent Add can never be lost"). `mutation.source` is a single field reference, resolved and Value-coerced the same way `increment`/`decrement` already coerce their own amount, so the comparison is against a like-shaped `Value`, not a raw scalar against a wrapped one.

Also extracts `#appended`'s inline source-resolution ternary into its own `resolve_append_source` method — a **pure refactor** (ternary → early-return, zero behavior change, confirmed by diffing against `6df3840^`'s own prior source), done alongside `remove`'s own addition purely for readability at this point in the file. Not a second finding — nothing to write coverage for because nothing changed.

**What this PR does**
- Adds the `:remove` branch to `MutationApplier#apply` + the `removed` method.
- Adds `spec/mutation_remove_growth_spec.rb`: removes a matching element by value equality, and confirms removing a value that was never added is a no-op rather than an error.

**Verification**: `bundle exec rspec` — 1315 examples, 13 failures, same pre-existing failure set as this stack's previous item (all tracked in `.pr-split-plan.md`; none are regressions). Confirmed via before/after: reverting just this hunk turns `remove` into a silent no-op (the runtime's `case` statement previously had no `:remove` branch).

**Scope correction**: real-diff read of `6df3840` (originally plan items 13-16, guessed as 4 pieces) found **10** real, independently-splittable pieces. See `.pr-split-plan.md`'s notes on items 13 through 17e for the full breakdown (Float/Numeric widening for existing ops, `multiply`, `clamp`, the Value-wrap asymmetry fix, an `IR::Attribute#logged` field, a `Value.scalar` lifecycle-transition bug fix, and two `Value::Coercion` fixes — all unrelated to `remove` and each getting its own PR).

Stacks after #45 (`then_set`'s `remove:`/`multiply:`/`clamp:` DSL surface, pulled forward from `1855be0` as required plumbing — item 12e).
