### PR TITLE
mutations: Float/Numeric arithmetic for increment/decrement

### DIFF
--- a/lib/hecksagain/runtime/command_rules/arithmetic.rb
+++ b/lib/hecksagain/runtime/command_rules/arithmetic.rb
@@ -55,11 +55,16 @@ module Hecksagain
             return arithmetic_value_object(current, amount, target, sign, op)
           end
 
-          unless amount.is_a?(Integer)
+          # Widened from Integer to Numeric (migration plan task 4, i106):
+          # miette's organ math increments a Float (`increment: 0.02`) --
+          # the raw, non-value-object path only ever mattered for Integer
+          # counters before this corpus existed. Integer stays the common
+          # case; Float is now accepted the same way.
+          unless amount.is_a?(Numeric)
             raise TypeMismatch, RefusalWording.render("TypeMismatch", "arithmetic_amount",
                                                        op: op, target: target, offered: Rendering.describe(amount))
           end
-          unless current.is_a?(Integer)
+          unless current.is_a?(Numeric)
             raise TypeMismatch, RefusalWording.render("TypeMismatch", "arithmetic_current",
                                                        op: op, target: target, offered: Rendering.describe(current))
           end
@@ -70,8 +75,14 @@ module Hecksagain
         def arithmetic_value_object(current, amount, target, sign, op)
           current_fields = current.to_h
           amount_fields  = amount.to_h
+          # Widened from Integer to Numeric -- see #arithmetic's own
+          # comment. A synthesised value-object wrapper around a bare
+          # Float attribute (miette's Synapse#strength, auto-wrapped per
+          # Part 3a's "bare primitives forbidden" finding) lands here as
+          # a one-Float-field Value exactly the way a one-Integer-field
+          # Value already did.
           shared_numeric = current_fields.keys.select do |field|
-            current_fields[field].is_a?(Integer) && amount_fields[field].is_a?(Integer)
+            current_fields[field].is_a?(Numeric) && amount_fields[field].is_a?(Numeric)
           end
           unless shared_numeric.size == 1
             raise TypeMismatch,

--- a/spec/mutation_float_arithmetic_growth_spec.rb
+++ b/spec/mutation_float_arithmetic_growth_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for Float/Numeric arithmetic on the EXISTING
+# increment/decrement ops: CommandRules::Arithmetic#arithmetic/
+# #arithmetic_value_object were Integer-only before this fix, so any
+# Float-typed field (miette's own organ math, "increment: 0.02") raised
+# a TypeMismatch the caller never made. Widened from Integer to Numeric.
+# Independent of `multiply`/`clamp` landing -- those are brand-new ops
+# with their own Numeric checks from birth and never call #arithmetic/
+# #arithmetic_value_object at all; this fix is exclusively a value-add
+# to the two pre-existing ops.
+RSpec.describe "Float arithmetic on increment/decrement" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["mutation-float-arithmetic-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  FLOAT_ARITHMETIC_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "FloatArithmeticGrowth" do
+      aggregate "Organ" do
+        identified_by { id.value }
+
+        value_object "OrganId" do
+          attribute :value, String
+        end
+
+        value_object "Strength" do
+          attribute :value, Float
+        end
+
+        attribute :id,       OrganId
+        attribute :strength, Strength
+
+        command "Open" do
+          attribute :id, OrganId
+          attribute :strength, Strength
+          emits "OrganOpened"
+        end
+
+        command "Grow" do
+          reference_to Organ
+          attribute :amount, Strength
+
+          then_set :strength, increment: :amount
+          emits "OrganGrew"
+        end
+
+        command "Fatigue" do
+          reference_to Organ
+          attribute :amount, Strength
+
+          then_set :strength, decrement: :amount
+          emits "OrganFatigued"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime)
+    aggregate = runtime.registry.bluebook("FloatArithmeticGrowth").aggregate("Organ")
+    runtime.registry.repository("FloatArithmeticGrowth", aggregate)
+  end
+
+  def boot_float_arithmetic
+    boot(FLOAT_ARITHMETIC_SOURCE, "FloatArithmeticGrowth") do
+      ::FloatArithmeticGrowth::Organ.persisted_by("Memory")
+    end
+  end
+
+  it "increments a Float-typed value object field" do
+    runtime = boot_float_arithmetic
+    runtime.dispatch("FloatArithmeticGrowth::Organ.Open", id: { value: "o1" }, strength: { value: 0.5 })
+    runtime.dispatch("FloatArithmeticGrowth::Organ.Grow", id: "o1", amount: { value: 0.02 })
+
+    organ = repository_for(runtime).find("o1")
+    expect(organ[:strength][:value]).to be_within(0.0001).of(0.52)
+  end
+
+  it "decrements a Float-typed value object field" do
+    runtime = boot_float_arithmetic
+    runtime.dispatch("FloatArithmeticGrowth::Organ.Open", id: { value: "o2" }, strength: { value: 0.5 })
+    runtime.dispatch("FloatArithmeticGrowth::Organ.Fatigue", id: "o2", amount: { value: 0.1 })
+
+    organ = repository_for(runtime).find("o2")
+    expect(organ[:strength][:value]).to be_within(0.0001).of(0.4)
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 4, i106 (hecks-hecksagain-migration). Item 14 of the PR-split plan (corrected scope).

`CommandRules::Arithmetic#arithmetic`/`#arithmetic_value_object` were Integer-only. Widened to `Numeric` so Float fields (miette's own organ math, `increment: 0.02`) aren't rejected as a type mismatch.

**Real scope correction**: split out of the original plan's "item 14 — multiply + Float arithmetic support" bundle. Real-diff read of `6df3840` shows this widening touches only the two pre-existing ops' (`increment`/`decrement`) shared methods — `multiply` (item 15, next in the stack) is brand-new code with its own `Numeric` checks from birth and never calls `#arithmetic`/`#arithmetic_value_object` at all. So this is a genuinely separate finding, not entangled with `multiply` landing.

**What this PR does**
- Widens `#arithmetic`/`#arithmetic_value_object`'s type checks from `Integer` to `Numeric`.
- Adds `spec/mutation_float_arithmetic_growth_spec.rb`: increments and decrements a Float-typed value-object field.

**Verification**: `bundle exec rspec` — 1317 examples, 13 failures, same pre-existing failure set (tracked in `.pr-split-plan.md`; none are regressions). Confirmed via before/after: reverting this hunk raises `TypeMismatch` ("needs a value object with one shared Integer field") on both increment and decrement of a Float field.

Stacks after #46 (item 13, `remove`).
