### PR TITLE
mutations: multiply op

### DIFF
--- a/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
+++ b/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
@@ -42,6 +42,18 @@ module Hecksagain
           # never be lost").
           when :remove
             instance[mutation.target] = removed(instance, aggregate, mutation, args)
+          # Vendored addition, not (yet) upstream hecksagain (migration
+          # plan task 4, i106): multiply -- the scale counterpart to
+          # increment/decrement's add/subtract -- see
+          # CommandRules::Arithmetic#multiply's own comment. Same
+          # amount-wrapping shape increment/decrement already use above
+          # (the shared Value-wrap asymmetry across all three is item 17's
+          # own fix, not repeated here).
+          when :multiply
+            amount = @rules.resolve_source(mutation.source, args)
+            attribute = aggregate.attribute(mutation.target)
+            amount = Value.for_attribute(aggregate, attribute, amount) if attribute
+            instance[mutation.target] = @rules.multiply(instance[mutation.target], amount, mutation.target)
           end
         end
 

--- a/lib/hecksagain/runtime/command_rules/arithmetic.rb
+++ b/lib/hecksagain/runtime/command_rules/arithmetic.rb
@@ -21,7 +21,12 @@ module Hecksagain
           MutationOp.new(name: "set",       sign: nil),
           MutationOp.new(name: "append",    sign: nil),
           MutationOp.new(name: "increment", sign: 1),
-          MutationOp.new(name: "decrement", sign: -1)
+          MutationOp.new(name: "decrement", sign: -1),
+          # Vendored addition, not (yet) upstream hecksagain (migration
+          # plan task 4, i106): multiply carries no sign -- like
+          # set/append, it does no add-or-subtract arithmetic (multiply
+          # scales). See #multiply below.
+          MutationOp.new(name: "multiply",  sign: nil)
         ].freeze
 
         # A mutation's source is either the NAME OF AN ARGUMENT or a LITERAL, and
@@ -94,6 +99,46 @@ module Hecksagain
         end
 
         def sign_of(op) = MUTATION_OPS.find { |candidate| candidate.name == op.to_s }&.sign || -1
+
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4, i106): `current * amount` -- the scaling counterpart to
+        # increment/decrement's add/subtract. Same raw-vs-value-object
+        # branch shape as #arithmetic/#arithmetic_value_object, reused
+        # rather than duplicated verb-for-verb (a `Proc` picks the actual
+        # arithmetic; everything else -- the Value unwrap/rewrap, the
+        # TypeMismatch refusals -- is identical to the additive pair).
+        def multiply(current, amount, target)
+          current ||= 0
+
+          if current.is_a?(Value) && amount.is_a?(Value)
+            return combine_value_object(current, amount, target, "multiply") { |c, a| c * a }
+          end
+
+          unless amount.is_a?(Numeric) && current.is_a?(Numeric)
+            raise TypeMismatch, RefusalWording.render("TypeMismatch", "arithmetic_amount",
+                                                       op: "multiply", target: target,
+                                                       offered: Rendering.describe(current.is_a?(Numeric) ? amount : current))
+          end
+
+          current * amount
+        end
+
+        private
+
+        def combine_value_object(current, amount, target, op)
+          current_fields = current.to_h
+          amount_fields  = amount.to_h
+          shared_numeric = current_fields.keys.select do |field|
+            current_fields[field].is_a?(Numeric) && amount_fields[field].is_a?(Numeric)
+          end
+          unless shared_numeric.size == 1
+            raise TypeMismatch,
+                  RefusalWording.render("TypeMismatch", "arithmetic_shared_field", op: op, target: target)
+          end
+
+          field = shared_numeric.first
+          current.with(field, yield(current[field], amount[field]))
+        end
       end
     end
   end

--- a/spec/mutation_multiply_growth_spec.rb
+++ b/spec/mutation_multiply_growth_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the `multiply` mutation op: `current * amount`,
+# the scaling counterpart to increment/decrement's add/subtract (i106).
+RSpec.describe "mutation op multiply" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["mutation-multiply-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  MUTATION_MULTIPLY_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "MutationMultiplyGrowth" do
+      aggregate "Organ" do
+        identified_by { id.value }
+
+        value_object "OrganId" do
+          attribute :value, String
+        end
+
+        value_object "Strength" do
+          attribute :value, Float
+        end
+
+        attribute :id,       OrganId
+        attribute :strength, Strength
+
+        command "Open" do
+          attribute :id, OrganId
+          attribute :strength, Strength
+          emits "OrganOpened"
+        end
+
+        command "Decay" do
+          reference_to Organ
+          attribute :factor, Strength
+
+          then_set :strength, multiply: :factor
+          emits "OrganDecayed"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime)
+    aggregate = runtime.registry.bluebook("MutationMultiplyGrowth").aggregate("Organ")
+    runtime.registry.repository("MutationMultiplyGrowth", aggregate)
+  end
+
+  def boot_mutation_multiply
+    boot(MUTATION_MULTIPLY_SOURCE, "MutationMultiplyGrowth") do
+      ::MutationMultiplyGrowth::Organ.persisted_by("Memory")
+    end
+  end
+
+  it "scales a value-object field by the given factor" do
+    runtime = boot_mutation_multiply
+    runtime.dispatch("MutationMultiplyGrowth::Organ.Open", id: { value: "o1" }, strength: { value: 1.0 })
+    runtime.dispatch("MutationMultiplyGrowth::Organ.Decay", id: "o1", factor: { value: 0.98 })
+
+    organ = repository_for(runtime).find("o1")
+    expect(organ[:strength][:value]).to be_within(0.0001).of(0.98)
+  end
+
+  it "raises a TypeMismatch scaling a non-numeric current value" do
+    runtime = boot_mutation_multiply
+    runtime.dispatch("MutationMultiplyGrowth::Organ.Open", id: { value: "o2" }, strength: { value: 1.0 })
+
+    expect do
+      runtime.dispatch("MutationMultiplyGrowth::Organ.Decay", id: "o2", factor: "not-a-number")
+    end.to raise_error(Hecksagain::Runtime::TypeMismatch)
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 4, i106 (hecks-hecksagain-migration). Item 15 of the PR-split plan (renumbered from the original 14/15 — see `.pr-split-plan.md` for `6df3840`'s full corrected 10-piece breakdown).

The `multiply` mutation op: `current * amount`, the scaling counterpart to increment/decrement's add/subtract. Own method + a new `combine_value_object` shared private helper (not used by anything else in this PR). Same raw-vs-value-object branch shape as `#arithmetic`/`#arithmetic_value_object`, reused rather than duplicated verb-for-verb.

`MutationApplier#apply`'s `:multiply` branch wraps `amount` the same way `increment`/`decrement` currently do (unconditionally, when the target attribute exists) — the shared Value-wrap asymmetry bug across all three ops is item 17's own fix, deliberately not repeated here.

**What this PR does**
- Adds `multiply` to `MUTATION_OPS`, `#multiply`, and `#combine_value_object`.
- Adds the `:multiply` branch to `MutationApplier#apply`.
- Adds `spec/mutation_multiply_growth_spec.rb`: scales a value-object field by a given factor, and raises `TypeMismatch` scaling against a non-numeric amount.

**Verification**: `bundle exec rspec` — 1319 examples, 14 failures. The +1 vs. this stack's previous item is an **expected gap** (`vocabulary_conformance_spec`'s `MutationOp` sign table doesn't yet register `"multiply"` in the self-hosted grammar — closed by a later grammar-registration item), matching the exact pattern every new DSL word in this split has shown (e.g. items 06/08/09). Confirmed via before/after: reverting this hunk turns `multiply` into a silent no-op.

Stacks after #47 (item 14) and #45 (item 12e, `then_set`'s `multiply:` DSL surface).
