### PR TITLE
mutations: clamp op

### DIFF
--- a/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
+++ b/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
@@ -54,6 +54,14 @@ module Hecksagain
             attribute = aggregate.attribute(mutation.target)
             amount = Value.for_attribute(aggregate, attribute, amount) if attribute
             instance[mutation.target] = @rules.multiply(instance[mutation.target], amount, mutation.target)
+          # Vendored addition, not (yet) upstream hecksagain (migration
+          # plan task 4, i106): clamp -- bounds the current value into
+          # [min, max]. mutation.source is always a literal [min, max]
+          # pair, never an argument reference -- resolve_source would be
+          # a no-op for an Array (it only special-cases Symbol), so it's
+          # read straight.
+          when :clamp
+            instance[mutation.target] = @rules.clamp(instance[mutation.target], mutation.source, mutation.target)
           end
         end
 

--- a/lib/hecksagain/runtime/command_rules/arithmetic.rb
+++ b/lib/hecksagain/runtime/command_rules/arithmetic.rb
@@ -23,10 +23,11 @@ module Hecksagain
           MutationOp.new(name: "increment", sign: 1),
           MutationOp.new(name: "decrement", sign: -1),
           # Vendored addition, not (yet) upstream hecksagain (migration
-          # plan task 4, i106): multiply carries no sign -- like
-          # set/append, it does no add-or-subtract arithmetic (multiply
-          # scales). See #multiply below.
-          MutationOp.new(name: "multiply",  sign: nil)
+          # plan task 4, i106): multiply/clamp carry no sign -- like
+          # set/append, they do no add-or-subtract arithmetic (multiply
+          # scales, clamp bounds). See #multiply/#clamp below.
+          MutationOp.new(name: "multiply",  sign: nil),
+          MutationOp.new(name: "clamp",     sign: nil)
         ].freeze
 
         # A mutation's source is either the NAME OF AN ARGUMENT or a LITERAL, and
@@ -121,6 +122,31 @@ module Hecksagain
           end
 
           current * amount
+        end
+
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4, i106): bound the CURRENT value into `[min, max]` -- no
+        # "amount" to combine, so it does not go through
+        # #arithmetic/#multiply's shared-numeric-field matching at all;
+        # it clamps whichever single numeric field the wrapping value
+        # object carries (a synthesised wrapper always carries exactly
+        # one, per Part 3a's auto-synthesis).
+        def clamp(current, bounds, target)
+          min, max = bounds
+          if current.is_a?(Value)
+            fields = current.to_h
+            field  = fields.keys.find { |f| fields[f].is_a?(Numeric) } or
+              raise TypeMismatch, RefusalWording.render("TypeMismatch", "arithmetic_current",
+                                                         op: "clamp", target: target, offered: Rendering.describe(current))
+            return current.with(field, fields[field].clamp(min, max))
+          end
+
+          unless current.is_a?(Numeric)
+            raise TypeMismatch, RefusalWording.render("TypeMismatch", "arithmetic_current",
+                                                       op: "clamp", target: target, offered: Rendering.describe(current))
+          end
+
+          current.clamp(min, max)
         end
 
         private

--- a/spec/mutation_clamp_growth_spec.rb
+++ b/spec/mutation_clamp_growth_spec.rb
@@ -1,0 +1,104 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the `clamp` mutation op: bounds the current
+# value into [min, max] -- no "amount" to combine, a genuinely different
+# shape from multiply/increment/decrement (i106).
+RSpec.describe "mutation op clamp" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["mutation-clamp-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  MUTATION_CLAMP_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "MutationClampGrowth" do
+      aggregate "Organ" do
+        identified_by { id.value }
+
+        value_object "OrganId" do
+          attribute :value, String
+        end
+
+        value_object "Strength" do
+          attribute :value, Float
+        end
+
+        attribute :id,       OrganId
+        attribute :strength, Strength
+
+        command "Open" do
+          attribute :id, OrganId
+          attribute :strength, Strength
+          emits "OrganOpened"
+        end
+
+        command "Bound" do
+          reference_to Organ
+
+          then_set :strength, clamp: [0.0, 1.0]
+          emits "OrganBounded"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime)
+    aggregate = runtime.registry.bluebook("MutationClampGrowth").aggregate("Organ")
+    runtime.registry.repository("MutationClampGrowth", aggregate)
+  end
+
+  def boot_mutation_clamp
+    boot(MUTATION_CLAMP_SOURCE, "MutationClampGrowth") do
+      ::MutationClampGrowth::Organ.persisted_by("Memory")
+    end
+  end
+
+  it "bounds a value ABOVE the max down to the max" do
+    runtime = boot_mutation_clamp
+    runtime.dispatch("MutationClampGrowth::Organ.Open", id: { value: "o1" }, strength: { value: 1.4 })
+    runtime.dispatch("MutationClampGrowth::Organ.Bound", id: "o1")
+
+    organ = repository_for(runtime).find("o1")
+    expect(organ[:strength][:value]).to eq(1.0)
+  end
+
+  it "bounds a value BELOW the min up to the min" do
+    runtime = boot_mutation_clamp
+    runtime.dispatch("MutationClampGrowth::Organ.Open", id: { value: "o2" }, strength: { value: -0.3 })
+    runtime.dispatch("MutationClampGrowth::Organ.Bound", id: "o2")
+
+    organ = repository_for(runtime).find("o2")
+    expect(organ[:strength][:value]).to eq(0.0)
+  end
+
+  it "leaves an in-range value untouched" do
+    runtime = boot_mutation_clamp
+    runtime.dispatch("MutationClampGrowth::Organ.Open", id: { value: "o3" }, strength: { value: 0.42 })
+    runtime.dispatch("MutationClampGrowth::Organ.Bound", id: "o3")
+
+    organ = repository_for(runtime).find("o3")
+    expect(organ[:strength][:value]).to eq(0.42)
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 4, i106 (hecks-hecksagain-migration). Item 16 of the PR-split plan (renumbered from the original 15 — see `.pr-split-plan.md` for `6df3840`'s full corrected 10-piece breakdown).

The `clamp` mutation op: bounds the current value into `[min, max]` — no "amount" to combine, a genuinely different shape from `multiply`/`increment`/`decrement`. It does not go through `#arithmetic`/`#multiply`'s shared-numeric-field matching at all; it clamps whichever single numeric field the wrapping value object carries. `mutation.source` is always a literal `[min, max]` pair, never an argument reference, so `MutationApplier` reads it straight rather than through `resolve_source`.

**What this PR does**
- Adds `clamp` to `MUTATION_OPS` and `#clamp`.
- Adds the `:clamp` branch to `MutationApplier#apply`.
- Adds `spec/mutation_clamp_growth_spec.rb`: bounds a value above the max down to the max, bounds a value below the min up to the min, and leaves an in-range value untouched.

**Verification**: `bundle exec rspec` — 1322 examples, 14 failures — same 14 as the previous item in this stack (the one expected `vocabulary_conformance_spec` gap now names both `"multiply"` and `"clamp"` as missing from the self-hosted grammar's `MutationOp` table; no new failure, not a regression). Confirmed via before/after: reverting this hunk turns `clamp` into a silent no-op.

Fully standalone from `multiply`'s own `combine_value_object` helper. Stacks after #48 (item 15, `multiply`) and #45 (item 12e, `then_set`'s `clamp:` DSL surface).
