### PR TITLE
mutations: Value-wrap asymmetry fix + bare-scalar mutation coercion

### DIFF
--- a/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
+++ b/lib/hecksagain/runtime/command_interpreter/mutation_applier.rb
@@ -28,13 +28,14 @@ module Hecksagain
           when :increment, :decrement
             amount = @rules.resolve_source(mutation.source, args)
             attribute = aggregate.attribute(mutation.target)
-            amount = Value.for_attribute(aggregate, attribute, amount) if attribute
-            instance[mutation.target] = @rules.arithmetic(
-              instance[mutation.target],
-              amount,
-              mutation.target,
-              @rules.sign_of(mutation.op)
-            )
+            current   = instance[mutation.target]
+            # Vendored fix, not (yet) upstream hecksagain (migration plan
+            # task 9): see #rewrap_arithmetic_result's own comment below
+            # -- `amount` is wrapped ONLY when `current` already is, not
+            # merely because the target attribute exists.
+            amount = Value.for_attribute(aggregate, attribute, amount) if attribute && current.is_a?(Value)
+            result = @rules.arithmetic(current, amount, mutation.target, @rules.sign_of(mutation.op))
+            instance[mutation.target] = rewrap_arithmetic_result(aggregate, attribute, current, result)
           # Vendored addition, not (yet) upstream hecksagain (migration
           # plan task 4): remove -- the list-removal counterpart to
           # append, matching an element by value (plan.bluebook's
@@ -43,17 +44,16 @@ module Hecksagain
           when :remove
             instance[mutation.target] = removed(instance, aggregate, mutation, args)
           # Vendored addition, not (yet) upstream hecksagain (migration
-          # plan task 4, i106): multiply -- the scale counterpart to
-          # increment/decrement's add/subtract -- see
-          # CommandRules::Arithmetic#multiply's own comment. Same
-          # amount-wrapping shape increment/decrement already use above
-          # (the shared Value-wrap asymmetry across all three is item 17's
-          # own fix, not repeated here).
+          # plan task 4, i106): multiply/clamp, the scale/bound pair
+          # alongside increment/decrement's add/subtract pair -- see
+          # CommandRules::Arithmetic#multiply/#clamp's own comments.
           when :multiply
             amount = @rules.resolve_source(mutation.source, args)
             attribute = aggregate.attribute(mutation.target)
-            amount = Value.for_attribute(aggregate, attribute, amount) if attribute
-            instance[mutation.target] = @rules.multiply(instance[mutation.target], amount, mutation.target)
+            current   = instance[mutation.target]
+            amount = Value.for_attribute(aggregate, attribute, amount) if attribute && current.is_a?(Value)
+            result = @rules.multiply(current, amount, mutation.target)
+            instance[mutation.target] = rewrap_arithmetic_result(aggregate, attribute, current, result)
           # Vendored addition, not (yet) upstream hecksagain (migration
           # plan task 4, i106): clamp -- bounds the current value into
           # [min, max]. mutation.source is always a literal [min, max]
@@ -113,6 +113,49 @@ module Hecksagain
           attribute = aggregate.attribute(mutation.target)
           value     = Value.for_attribute(aggregate, attribute, value) if attribute
           Array(instance[mutation.target]).reject { |element| element == value }
+        end
+
+        # Vendored fix, not (yet) upstream hecksagain (migration plan
+        # task 9): #apply's `:increment`/`:decrement`/`:multiply`
+        # branches used to wrap `amount` into a `Value` unconditionally
+        # whenever the target attribute existed, never checking whether
+        # `current` (the field's OWN existing value, read straight off
+        # `instance[mutation.target]`) was ALSO wrapped -- the two sides
+        # of the same arithmetic call could disagree on Value-ness. On a
+        # PHANTOM-CREATED field this is the common case, not an edge
+        # one: `Instance.defaults`/`#default_for` leaves a VO-typed
+        # attribute with no declared `default:` genuinely absent (nil),
+        # and `CommandRules::Arithmetic#arithmetic`/`#multiply`'s own
+        # `current ||= 0` then turns that nil into a RAW, unwrapped
+        # Integer `0` -- so `current.is_a?(Value) && amount.is_a?(Value)`
+        # read false even though `amount` (correctly wrapped by the old
+        # unconditional line) genuinely held a valid, correctly-typed
+        # number, and the primitive path's `unless amount.is_a?(Numeric)`
+        # guard refused it as a TYPE MISMATCH the caller never made --
+        # an artifact of this method's own asymmetric wrapping, not bad
+        # input.
+        #
+        # Fixed at the call site (above) by wrapping `amount` ONLY when
+        # `current` is ALREADY a `Value` -- so an established VO-typed
+        # field (a multi-field Money balance, say, already hydrated from
+        # a prior save) keeps going through
+        # `Arithmetic#arithmetic_value_object` exactly as before (the
+        # "already-Value-wrapped field still mutates correctly" case
+        # this fix must not regress), while a phantom field's raw
+        # `current` and raw `amount` both take the plain-Numeric path
+        # together. This method closes the other half: the plain-Numeric
+        # path returns a bare Ruby number, and if the attribute is
+        # itself VO-typed (the norm), that raw result needs the SAME
+        # wrap `:set` already gives its own resolved value (`Value.for`)
+        # before it's stored, so a field's stored shape doesn't depend
+        # on which dispatch happened to mutate it first. A no-op
+        # whenever `current` was already a Value (the VO branch already
+        # returns one) or the mutation targets no declared attribute at
+        # all.
+        def rewrap_arithmetic_result(aggregate, attribute, current, result)
+          return result if current.is_a?(Value) || attribute.nil? || result.is_a?(Value)
+
+          Value.for_attribute(aggregate, attribute, result)
         end
 
         def entity_element(aggregate, element_type, current, fields)

--- a/lib/hecksagain/runtime/value/coercion.rb
+++ b/lib/hecksagain/runtime/value/coercion.rb
@@ -85,6 +85,27 @@ module Hecksagain
           # supply an object rather than a scalar.
           return value.to_h if value.is_a?(self)
 
+          # Vendored addition, not (yet) upstream hecksagain (migration
+          # plan task 5): a bare scalar auto-wraps into a single-field
+          # value object's sole attribute -- the SAME shape
+          # #from_identifier already establishes for identity coercion
+          # (`build(value_object, { fields.first.name => identifier }) if
+          # fields.size == 1`), made consistent here for MUTATION
+          # coercion too. Real, corpus-wide gap: a synthesised single-
+          # field wrapper (Part 3a's bare-primitive auto-synthesis, the
+          # norm for a VO-typed aggregate field) is exactly the shape
+          # #rewrap_arithmetic_result hands back a raw scalar RESULT to
+          # -- without this, every phantom-field increment/multiply on a
+          # single-field-wrapped attribute refused with "pass its fields
+          # as an object, not <scalar>" the instant it tried to re-wrap
+          # its own correctly-computed result. Multi-field VOs still
+          # refuse below, unchanged -- only the genuinely unambiguous
+          # single-field case auto-wraps, matching from_identifier's own
+          # precedent exactly.
+          if value_object.attributes.size == 1
+            return { value_object.attributes.first.name => value }
+          end
+
           raise TypeMismatch,
                 RefusalWording.render("TypeMismatch", "value_object_shape",
                                       name: name, type: value_object.hecks_name,

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -553,7 +553,15 @@ RSpec.describe "the DSL surface" do
         .to raise_error(Hecksagain::Runtime::InvariantViolation, /current or savings/)
     end
 
-    it "refuses a scalar for every value object" do
+    # NOT for every value object any more. `Value::Coercion#fields_for` was
+    # deliberately widened (migration plan task 5, this split's own item 17)
+    # to auto-wrap a bare scalar into a SINGLE-field value object's sole
+    # attribute — `Kind` here has exactly one field, so `kind: "current"`
+    # now auto-wraps to `{ name: "current" }` rather than refusing. The
+    # refusal survives only for a genuinely MULTI-field value object, where
+    # the scalar cannot say which field it means — `Amount` (cents +
+    # currency) is that case here.
+    it "refuses a scalar for every multi-field value object" do
       registry = account_domain
       runtime  = Hecksagain::Runtime::Loader.bind_runtime(
         Hecksagain::Runtime::Dispatcher.new(registry.tap(&:verify!))
@@ -561,7 +569,7 @@ RSpec.describe "the DSL surface" do
 
       expect {
         runtime.dispatch("Coerced::Holding.Open", id: "h3",
-                         kind: "current", amount: { cents: 100, currency: "GBP" })
+                         kind: { name: "current" }, amount: "a lot")
       }
         .to raise_error(Hecksagain::Runtime::TypeMismatch, /pass its fields as an object/)
     end

--- a/spec/mutation_value_wrap_asymmetry_growth_spec.rb
+++ b/spec/mutation_value_wrap_asymmetry_growth_spec.rb
@@ -1,0 +1,130 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the Value-wrap asymmetry bug fix across
+# increment/decrement/multiply: #apply used to wrap `amount` into a Value
+# whenever the target attribute existed, never checking whether `current`
+# (the field's own existing value) was ALSO wrapped. On a PHANTOM-CREATED
+# field -- a VO-typed attribute with no declared default, genuinely nil
+# until first touched -- `current` came back as a raw, unwrapped 0, so the
+# two sides of the same arithmetic call disagreed on Value-ness and the
+# primitive path refused a correctly-typed number as a type mismatch the
+# caller never made.
+#
+# Uses a LITERAL amount (`increment: 1`, not `increment: :amount`)
+# deliberately: a Symbol source naming a COMMAND ARGUMENT arrives already
+# Value-wrapped by normalize_args/coerce_declared_arguments (a separate,
+# earlier coercion pass, unaffected by this fix either way), so it can
+# never reproduce the asymmetry this fix addresses. A literal source is
+# what stays genuinely raw all the way to #apply, which is the shape that
+# actually surfaces the bug.
+RSpec.describe "mutation Value-wrap asymmetry fix" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["mutation-value-wrap-asymmetry-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  # `count` is declared with NO default: -- a phantom field, genuinely
+  # nil until the first mutation ever touches it.
+  MUTATION_VALUE_WRAP_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "MutationValueWrapGrowth" do
+      aggregate "Breaker" do
+        identified_by { id.value }
+
+        value_object "BreakerId" do
+          attribute :value, String
+        end
+
+        value_object "FailureCount" do
+          attribute :value, Integer
+        end
+
+        attribute :id,    BreakerId
+        attribute :count, FailureCount
+
+        command "Open" do
+          attribute :id, BreakerId
+          emits "BreakerOpened"
+        end
+
+        command "RecordFailure" do
+          reference_to Breaker
+
+          then_set :count, increment: 1
+          emits "FailureRecorded"
+        end
+
+        command "Scale" do
+          reference_to Breaker
+
+          then_set :count, multiply: 5
+          emits "FailureScaled"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime)
+    aggregate = runtime.registry.bluebook("MutationValueWrapGrowth").aggregate("Breaker")
+    runtime.registry.repository("MutationValueWrapGrowth", aggregate)
+  end
+
+  def boot_value_wrap
+    boot(MUTATION_VALUE_WRAP_SOURCE, "MutationValueWrapGrowth") do
+      ::MutationValueWrapGrowth::Breaker.persisted_by("Memory")
+    end
+  end
+
+  it "increments a phantom (never-touched) VO-typed field on its FIRST mutation, not just later ones" do
+    runtime = boot_value_wrap
+    runtime.dispatch("MutationValueWrapGrowth::Breaker.Open", id: { value: "b1" })
+    runtime.dispatch("MutationValueWrapGrowth::Breaker.RecordFailure", id: "b1")
+
+    breaker = repository_for(runtime).find("b1")
+    expect(breaker[:count][:value]).to eq(1)
+  end
+
+  it "keeps mutating correctly on the SECOND increment, once the field is no longer phantom" do
+    runtime = boot_value_wrap
+    runtime.dispatch("MutationValueWrapGrowth::Breaker.Open", id: { value: "b2" })
+    runtime.dispatch("MutationValueWrapGrowth::Breaker.RecordFailure", id: "b2")
+    runtime.dispatch("MutationValueWrapGrowth::Breaker.RecordFailure", id: "b2")
+
+    breaker = repository_for(runtime).find("b2")
+    expect(breaker[:count][:value]).to eq(2)
+  end
+
+  it "multiplies a phantom field correctly on its first mutation too" do
+    runtime = boot_value_wrap
+    runtime.dispatch("MutationValueWrapGrowth::Breaker.Open", id: { value: "b3" })
+    runtime.dispatch("MutationValueWrapGrowth::Breaker.Scale", id: "b3")
+
+    breaker = repository_for(runtime).find("b3")
+    # current starts at the raw, unwrapped 0 (never touched) -- 0 * 5 stays 0,
+    # so this confirms the phantom path completes WITHOUT raising, not that
+    # zero times anything is a meaningful business result.
+    expect(breaker[:count][:value]).to eq(0)
+  end
+end

--- a/spec/runtime/command_rules_spec.rb
+++ b/spec/runtime/command_rules_spec.rb
@@ -35,13 +35,22 @@ RSpec.describe "the rules a command obeys" do
   def narrative = { text: "Corrected" }
 
   describe "Integer-or-nothing arithmetic" do
+    # `till.bluebook`'s Money is a SINGLE-field value object (`cents` alone),
+    # so a bare scalar amount is exactly the unambiguous case
+    # `Value::Coercion#fields_for` deliberately widened to auto-wrap
+    # (migration plan task 5, this split's own item 17) — the same
+    # precedent `#from_identifier` already set. It no longer refuses at the
+    # "give me an object, not a scalar" gate; it auto-wraps to
+    # `{ cents: "a lot" }` and refuses one step later, at
+    # `check_numeric_fields`, with a message that names the actual
+    # field and type rather than a generic shape complaint.
     it "refuses a non-Integer amount on a RECORD, in so many words" do
       runtime = boot_till
       runtime.dispatch("TillRoom::Till.OpenTill", number: { value: "till-1" })
 
       expect do
         runtime.dispatch("TillRoom::Till.TakeIn", number: { value: "till-1" }, amount: "a lot")
-      end.to raise_error(Hecksagain::Runtime::TypeMismatch, /pass its fields as an object/)
+      end.to raise_error(Hecksagain::Runtime::TypeMismatch, 'Money.cents expects Integer, got "a lot"')
     end
 
     it "refuses a non-Integer amount on an ELEMENT, in the same words" do


### PR DESCRIPTION
**Migration findings doc**: task 9 + task 5 (hecks-hecksagain-migration). Item 17 of the PR-split plan (renumbered from original 16), **merged with item 17d** — see below for why.

`#apply`'s `:increment`/`:decrement`/`:multiply` branches used to wrap `amount` into a `Value` unconditionally whenever the target attribute existed, never checking whether `current` (the field's own existing value) was ALSO wrapped. On a PHANTOM-CREATED field — a VO-typed attribute with no declared default, genuinely nil until first touched — `current` comes back as a raw, unwrapped `0`, so the two sides of the same arithmetic call disagreed on Value-ness and the primitive path refused a correctly-typed number as a type mismatch the caller never made.

Fixed at the call site by wrapping `amount` ONLY when `current` is already a `Value`, and by a new `#rewrap_arithmetic_result` giving the plain-Numeric path's raw result the same wrap `:set` already gives its own resolved value.

**Real, inseparable dependency found while implementing** (merging items 17 and 17d): `#rewrap_arithmetic_result` calls `Value.for_attribute` on a raw scalar RESULT once a phantom field's arithmetic takes the plain-Numeric path — and for the overwhelmingly common case (a single-field auto-synthesised VO wrapper, "the norm" per this corpus's own convention), `Value::Coercion#fields_for` REFUSED that raw scalar (`"pass its fields as an object, not 0"`) until `fields_for`'s own bare-scalar-auto-wrap widening (item 17d, same source commit) lands too. Confirmed by direct experiment: the Value-wrap fix alone crashes on `fields_for`'s own refusal. Genuinely inseparable, matching item 12's own documented precedent — combined into one PR.

Landing the bare-scalar widening also required pulling forward two of the three spec-expectation updates from `5f08158` (originally item 38) — `spec/dsl_spec.rb`'s "refuses a scalar for every value object" → "...every multi-field value object", and `spec/runtime/command_rules_spec.rb`'s refusal-message update (now `"Money.cents expects Integer, got ..."` instead of a generic shape complaint) — because those two pre-existing specs asserted the OLD refusal-for-every-VO behavior this widening intentionally changes. (The third `5f08158` assertion — a `Widget`-collision / bare-primitive-VO-synthesis test — is unrelated and stays with `1855be0-b`.)

**What this PR does**
- `MutationApplier#apply`: conditional `amount` wrap + `#rewrap_arithmetic_result`.
- `Value::Coercion#fields_for`: bare-scalar auto-wrap for single-field VOs.
- Updates the two dependent pre-existing spec expectations.
- Adds `spec/mutation_value_wrap_asymmetry_growth_spec.rb`: increments and multiplies a phantom field on its first mutation, confirms the second increment still works. Uses a **literal** mutation source deliberately — a Symbol source naming a command argument arrives pre-wrapped by an earlier, unrelated coercion pass and can never reproduce this asymmetry.

**Verification**: `bundle exec rspec` — 1325 examples, 14 failures, same 14 as the previous item (the two spec-expectation updates absorbed the two regressions the widening otherwise caused; net zero new failures). Confirmed via before/after: all 3 new spec examples fail without this PR's changes.

Stacks after #49 (item 16, `clamp`).
