### PR TITLE
IR: Attribute gains logged:

### DIFF
--- a/lib/hecksagain/bluebook/ir/attribute.rb
+++ b/lib/hecksagain/bluebook/ir/attribute.rb
@@ -2,7 +2,7 @@ module Hecksagain
   module Bluebook
     module IR
       class Attribute
-        attr_reader :name, :type, :default, :pattern, :admits
+        attr_reader :name, :type, :default, :pattern, :admits, :logged
 
         # A Reference is kept AS ITSELF. Every other type is still a name, and
         # crosses over as its construct does.
@@ -27,8 +27,19 @@ module Hecksagain
         # The wire carries the NAME, not the members. A reader resolves it
         # against the IR it holds, so the members are declared once and
         # copied nowhere — which is the same reason `admits` exists at all.
+        # `logged:`, vendored addition not (yet) upstream hecksagain
+        # (migration plan task 4): `attribute :old_string, OldString,
+        # logged: false` (framework/tools/bluebook/tools.bluebook) --
+        # marks a field as excluded from the audit-log record (a large or
+        # sensitive payload -- a diff's old_string/new_string, file
+        # content -- that shouldn't ride the event-log trail whole).
+        # Defaults true (logged unless told otherwise). Captured
+        # structurally so the corpus boots ; NOT yet consulted by
+        # whatever writes the audit log -- a documented gap, matching
+        # this session's other structural-only additions. TODO upstream
+        # via bin/evolve (migration plan task 7).
         def initialize(name:, type:, list: false, default: nil, optional: false, pattern: nil,
-                       admits: nil)
+                       admits: nil, logged: true)
           @name     = name.to_sym
           @type     = type.is_a?(Reference) ? type : type.to_s
           @list     = list
@@ -36,6 +47,7 @@ module Hecksagain
           @optional = optional
           @pattern  = pattern
           @admits   = admits&.to_s
+          @logged   = logged
         end
 
         def list?   = @list

--- a/spec/ir_attribute_logged_growth_spec.rb
+++ b/spec/ir_attribute_logged_growth_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+# Real coverage for IR::Attribute#logged: a command argument (old_string,
+# in particular) that should never round-trip into an audit log verbatim.
+# Structural-only at this point in the split -- captured on the IR so the
+# corpus boots, NOT YET consulted by whatever writes the audit log (a
+# documented, deliberate gap matching this session's other structural-only
+# additions), and NOT yet on `#to_h` (the wire) for the same reason.
+#
+# The DSL surface itself (`attribute :x, T, logged: false`) is bundled,
+# in the real source, inside attribute_collector.rb's own much larger
+# rewrite alongside `as:`'s inverted-form resolution, `required:`, and
+# `enum:` (1855be0, this split's own 1855be0-b/1855be0-c territory) --
+# untangling that bundle is deliberately deferred rather than pulled
+# forward here, since `logged` itself is safe, isolated, and has no
+# functional consumer yet either way. This spec exercises IR::Attribute
+# directly instead of through a real bluebook dispatch.
+RSpec.describe "IR::Attribute#logged" do
+  def build_attribute(**overrides)
+    Hecksagain::Bluebook::IR::Attribute.new(name: :old_string, type: "OldString", **overrides)
+  end
+
+  it "defaults to true -- logged unless told otherwise" do
+    attribute = build_attribute
+
+    expect(attribute.logged).to be(true)
+  end
+
+  it "captures logged: false" do
+    attribute = build_attribute(logged: false)
+
+    expect(attribute.logged).to be(false)
+  end
+
+  it "does not (yet) appear on #to_h -- structural-only, not on the wire" do
+    attribute = build_attribute(logged: false)
+
+    expect(attribute.to_h).not_to have_key(:logged)
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 4 (hecks-hecksagain-migration). Item 17a of the PR-split plan — found on real-diff read of `6df3840`, unrelated to mutations, not in the original plan at all.

`IR::Attribute` gains `logged:` (default `true`) — a command argument (`old_string`, in particular) that should never round-trip into an audit log verbatim. Structural-only at this point: captured on the IR so the corpus boots, NOT YET consulted by whatever writes the audit log (a documented, deliberate gap matching this session's other structural-only additions), and NOT yet on `#to_h` (the wire) for the same reason.

**Real scope note**: the DSL surface (`attribute :x, T, logged: false`) is deliberately NOT pulled forward here. In the real source it's bundled inside `attribute_collector.rb`'s own much larger rewrite alongside `as:`'s inverted-form resolution, `required:`, and `enum:` (`1855be0`, this split's own `1855be0-b`/`1855be0-c` territory) — untangling that bundle is deferred to when those items are actually split, since `logged` itself is safe, isolated, and has no functional consumer yet either way.

**What this PR does**
- Adds `logged:` to `IR::Attribute#initialize` + `attr_reader`.
- Adds `spec/ir_attribute_logged_growth_spec.rb`, exercising `IR::Attribute` directly (no DSL surface to dispatch through yet): defaults to `true`, captures `logged: false`, and confirms it's intentionally absent from `#to_h`.

**Verification**: `bundle exec rspec` — 1328 examples, 14 failures, same 14 as the previous item — no regressions.

Stacks after #50 (item 17).
