### PR TITLE
runtime: Value.scalar unwrap in the lifecycle-transition matcher

### DIFF
--- a/lib/hecksagain/runtime/command_rules/admissibility.rb
+++ b/lib/hecksagain/runtime/command_rules/admissibility.rb
@@ -2,6 +2,7 @@ require_relative "../../bluebook/expression/evaluator"
 require_relative "../../rendering"
 require_relative "../errors"
 require_relative "../refusal_wording"
+require_relative "../value"
 
 module Hecksagain
   module Runtime
@@ -45,7 +46,29 @@ module Hecksagain
           candidates = lifecycle.transitions_for(command.hecks_name)
           return nil if candidates.empty?
 
-          current  = subject[lifecycle.field].to_s
+          # `Value.scalar` unwrap -- vendored addition, not (yet)
+          # upstream hecksagain (migration plan task 9): a VO-typed
+          # lifecycle field (the norm, not the exception, per this
+          # corpus's own no-primitive-envy convention) holds a real
+          # `Runtime::Value` here, and a bare `.to_s` on that hit Ruby's
+          # default `Object#to_s` instead of unwrapping the inner
+          # scalar first -- `current` came back as a raw object-pointer
+          # string (`"#<Hecksagain::Runtime::Value:0x...>"`) that could
+          # never match any declared `from` state, so EVERY transition
+          # on a VO-typed lifecycle field refused unconditionally, and
+          # when it refused the message leaked the pointer too.
+          # Confirmed live via `Plan::Task.Complete` (status defaults to
+          # `TaskStatus`, a single-field VO), not inferred. Reuses
+          # `Value.scalar` -- this file's own third candidate for "how
+          # to unwrap a Value/Hash-shaped field," already built and
+          # already documented for exactly this job ("rendering a value
+          # object into a column or a message, where there is no path
+          # to consult," `value/coercion.rb`'s own comment) -- rather
+          # than inventing a second unwrap helper beside `Resolver#
+          # unwrap_scalar`'s bare-comparison one. Duck-typed the same
+          # way : a bare, non-VO lifecycle field passes through
+          # unchanged (`Value.scalar` only opens a `Value` instance).
+          current  = Value.scalar(subject[lifecycle.field]).to_s
           admitted = candidates.find { |t| !t.constrained? || Array(t.from).include?(current) }
           return admitted if admitted
 

--- a/spec/lifecycle_value_scalar_growth_spec.rb
+++ b/spec/lifecycle_value_scalar_growth_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the Value.scalar unwrap fix in the lifecycle-
+# transition matcher: a VO-typed lifecycle field's bare `.to_s` used to hit
+# Ruby's default Object#to_s instead of unwrapping the inner scalar, so
+# `current` came back as a raw object-pointer string that could never match
+# any declared `from` state. Bites on the SECOND transition specifically:
+# the field starts as a raw, unwrapped default, and only becomes a real
+# Value once the FIRST transition's `then_set` wraps it -- a subsequent
+# transition attempt is where the bug shows.
+RSpec.describe "lifecycle transition on a VO-typed field" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["lifecycle-value-scalar-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  LIFECYCLE_VALUE_SCALAR_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "LifecycleValueScalarGrowth" do
+      aggregate "Task" do
+        identified_by { id.value }
+
+        value_object "TaskId" do
+          attribute :value, String
+        end
+
+        value_object "TaskStatus" do
+          attribute :value, String
+        end
+
+        attribute :id,     TaskId
+        attribute :status, TaskStatus
+
+        command "Open" do
+          attribute :id, TaskId
+          emits "TaskOpened"
+        end
+
+        lifecycle :status, default: "open" do
+          transition "Advance" => "closed", from: "open"
+          transition "Finish"  => "done",   from: "closed"
+        end
+
+        command "Advance" do
+          reference_to Task
+          then_set :status, to: "closed"
+          emits "TaskAdvanced"
+        end
+
+        command "Finish" do
+          reference_to Task
+          then_set :status, to: "done"
+          emits "TaskFinished"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime)
+    aggregate = runtime.registry.bluebook("LifecycleValueScalarGrowth").aggregate("Task")
+    runtime.registry.repository("LifecycleValueScalarGrowth", aggregate)
+  end
+
+  def boot_lifecycle_value_scalar
+    boot(LIFECYCLE_VALUE_SCALAR_SOURCE, "LifecycleValueScalarGrowth") do
+      ::LifecycleValueScalarGrowth::Task.persisted_by("Memory")
+    end
+  end
+
+  it "admits a SECOND transition once the field is already Value-wrapped by the first" do
+    runtime = boot_lifecycle_value_scalar
+    runtime.dispatch("LifecycleValueScalarGrowth::Task.Open", id: { value: "t1" })
+    runtime.dispatch("LifecycleValueScalarGrowth::Task.Advance", id: "t1")
+
+    expect { runtime.dispatch("LifecycleValueScalarGrowth::Task.Finish", id: "t1") }.not_to raise_error
+
+    task = repository_for(runtime).find("t1")
+    expect(task[:status][:value]).to eq("done")
+  end
+
+  it "still refuses a transition from a state the field never held" do
+    runtime = boot_lifecycle_value_scalar
+    runtime.dispatch("LifecycleValueScalarGrowth::Task.Open", id: { value: "t2" })
+
+    expect { runtime.dispatch("LifecycleValueScalarGrowth::Task.Finish", id: "t2") }
+      .to raise_error(Hecksagain::Runtime::LifecycleRefused)
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 9 (hecks-hecksagain-migration). Item 17b of the PR-split plan — found on real-diff read of `6df3840`, unrelated to mutations, not in the original plan at all.

A VO-typed lifecycle field (the norm, not the exception, per this corpus's own no-primitive-envy convention) holds a real `Runtime::Value` once its FIRST transition wraps it — and a bare `.to_s` on that hit Ruby's default `Object#to_s` instead of unwrapping the inner scalar first. `current` came back as a raw object-pointer string (`"#<Hecksagain::Runtime::Value:0x...>"`) that could never match any declared `from` state, so **every subsequent transition on a VO-typed lifecycle field refused unconditionally**, and the refusal message leaked the object pointer too.

Reuses `Value.scalar` — this file's own established candidate for "how to unwrap a Value/Hash-shaped field," already built for exactly this job — rather than inventing a second unwrap helper.

**What this PR does**
- `admissible_transition`: `Value.scalar(subject[lifecycle.field]).to_s` instead of a bare `.to_s`.
- Adds `spec/lifecycle_value_scalar_growth_spec.rb`: a task whose status is a single-field VO advances through TWO real transitions (the second is where the bug bites), and a transition from a state the field never held is still correctly refused.

**Verification**: `bundle exec rspec` — 1330 examples, 14 failures, same 14 as the previous item — no regressions. Confirmed via before/after: without this fix, the second transition raises `LifecycleRefused` with the object pointer literally in the message (`status is "#<Hecksagain::Runtime::Value:0x...>"`).

Stacks after #51 (item 17a).
