### PR TITLE
runtime: numeric identity field coercion in from_identifier

### DIFF
--- a/lib/hecksagain/runtime/value/coercion.rb
+++ b/lib/hecksagain/runtime/value/coercion.rb
@@ -227,9 +227,49 @@ module Hecksagain
           return identifier unless value_object
 
           fields = value_object.attributes
-          return build(value_object, { fields.first.name => identifier }) if fields.size == 1
+          if fields.size == 1
+            field = fields.first
+            return build(value_object, { field.name => coerce_identifier(field, identifier) })
+          end
 
           raise TypeMismatch, RefusalWording.render("TypeMismatch", "composite_identity", type: value_object.hecks_name)
+        end
+
+        # Vendored fix, not (yet) upstream hecksagain (migration plan
+        # task 9): `identifier` here is always the DERIVED IDENTITY
+        # STRING -- `Identity.of`/`Identity.from` intentionally return
+        # one (correct for naming a repository key), and
+        # `Runtime::Instance#materialize_identity!` calls `from_identifier`
+        # with exactly that string on every fresh hydration -- but when
+        # the identity field's OWN declared type is Integer/Float (not
+        # the overwhelmingly common String), seeding it straight from
+        # that string round-trips a correctly-derived identity back in
+        # as the WRONG Ruby type -- and #build's own
+        # `check_numeric_fields` (added specifically to catch a genuine
+        # CALLER mismatch) then refused the runtime's OWN internal
+        # identity seed instead, on every dispatch, valid input or not.
+        #
+        # Reuses THIS SAME FILE's own `NUMERIC` table (declared-type ->
+        # expected-Ruby-class, already read by `check_numeric_fields`)
+        # to decide WHICH declared types need converting, and
+        # Kernel#Integer/#Float to do the converting. A genuinely
+        # malformed identifier (should never happen, since an identity
+        # is always derived FROM a correctly-typed field in the first
+        # place, but this stays defensive rather than assume it) passes
+        # back unconverted, and `check_numeric_fields` refuses it
+        # exactly as it always has -- preserving its real job of
+        # catching a genuine caller mismatch, not just this migration's
+        # own runtime-internal one.
+        private def coerce_identifier(field, identifier)
+          return identifier unless identifier.is_a?(String) && NUMERIC.key?(field.type.to_s)
+
+          case field.type.to_s
+          when "Integer" then Integer(identifier)
+          when "Float"   then Float(identifier)
+          else identifier
+          end
+        rescue ArgumentError
+          identifier
         end
 
         def canonical_fields(fields)

--- a/spec/identifier_numeric_coercion_growth_spec.rb
+++ b/spec/identifier_numeric_coercion_growth_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for Value::Coercion#coerce_identifier: when an
+# aggregate's identified_by field is itself numeric (Integer/Float, not the
+# overwhelmingly common String), #from_identifier re-seeding a freshly-
+# hydrated instance from the DERIVED IDENTITY STRING used to round-trip it
+# back in as the wrong Ruby type, and #build's own check_numeric_fields (a
+# rule meant to catch a genuine CALLER mismatch) then refused the runtime's
+# own internal identity seed instead -- blocking every command on any
+# aggregate with a numeric identity field, unconditionally, valid input or
+# not.
+RSpec.describe "identity coercion on a numeric identified_by field" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["identifier-numeric-coercion-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  NUMERIC_IDENTITY_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "NumericIdentityGrowth" do
+      aggregate "SleepCycle" do
+        identified_by { cycle_number.value }
+
+        value_object "CycleNumber" do
+          attribute :value, Integer
+        end
+
+        attribute :cycle_number, CycleNumber
+
+        command "StartCycle" do
+          attribute :cycle_number, CycleNumber
+          emits "CycleStarted"
+        end
+
+        command "AdvanceStage" do
+          reference_to SleepCycle
+          emits "StageAdvanced"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime)
+    aggregate = runtime.registry.bluebook("NumericIdentityGrowth").aggregate("SleepCycle")
+    runtime.registry.repository("NumericIdentityGrowth", aggregate)
+  end
+
+  def boot_numeric_identity
+    boot(NUMERIC_IDENTITY_SOURCE, "NumericIdentityGrowth") do
+      ::NumericIdentityGrowth::SleepCycle.persisted_by("Memory")
+    end
+  end
+
+  it "creates a record whose identity field is genuinely numeric, not a type mismatch" do
+    runtime = boot_numeric_identity
+
+    expect { runtime.dispatch("NumericIdentityGrowth::SleepCycle.StartCycle", cycle_number: { value: 1 }) }
+      .not_to raise_error
+
+    cycle = repository_for(runtime).find("1")
+    expect(cycle[:cycle_number][:value]).to eq(1)
+  end
+
+  it "dispatches a SECOND command against the same numeric-identity record without a false TypeMismatch" do
+    runtime = boot_numeric_identity
+    runtime.dispatch("NumericIdentityGrowth::SleepCycle.StartCycle", cycle_number: { value: 1 })
+
+    expect { runtime.dispatch("NumericIdentityGrowth::SleepCycle.AdvanceStage", cycle_number: 1) }
+      .not_to raise_error
+  end
+end


### PR DESCRIPTION
**Migration findings doc**: task 9 (hecks-hecksagain-migration). Item 17e of the PR-split plan — found on real-diff read of `6df3840`, unrelated to mutations, not in the original plan at all. This closes out `6df3840`'s full 10-piece breakdown (items 13-17, 17a-17e).

`identifier` in `Value::Coercion#from_identifier` is always the DERIVED IDENTITY STRING — `Identity.of`/`Identity.from` intentionally return one (correct for naming a repository key), and `Runtime::Instance#materialize_identity!` calls `from_identifier` with exactly that string on **every** fresh `Instance` — but when the identity field's own declared type is `Integer`/`Float` (not the overwhelmingly common `String`), seeding it straight from that string round-trips a correctly-derived identity back in as the WRONG Ruby type, and `#build`'s own `check_numeric_fields` (added to catch a genuine CALLER mismatch) then refused the runtime's OWN internal identity seed instead — blocking every command on any aggregate with a numeric identity field, unconditionally, valid input or not.

Reuses this same file's own `NUMERIC` table to decide which declared types need converting, and `Kernel#Integer`/`#Float` to convert. A genuinely malformed identifier passes back unconverted and `check_numeric_fields` refuses it exactly as it always has, preserving its real job.

**What this PR does**
- `from_identifier` + new private `coerce_identifier`.
- Adds `spec/identifier_numeric_coercion_growth_spec.rb`: creates a record whose identity field is genuinely Integer-typed, and dispatches a second command against the same record — both go through `materialize_identity!` on every `Instance.new`, creating or hydrating.

**Verification**: `bundle exec rspec` — 1332 examples, 14 failures, same 14 as the previous item — no regressions. Confirmed via before/after: both new examples fail without this fix, with the exact `check_numeric_fields` refusal the fix's own comment describes (`CycleNumber.value expects Integer, got "1"`).

Stacks after #52 (item 17b).
