### PR TITLE
dsl: domain-wide persisted_by adapter defaults (item 1855be0-a3)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/hecksagon_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/hecksagon_builder.rb
@@ -43,17 +43,75 @@ module Hecksagain
         # method rather than split further: both branches are genuinely
         # new capability sharing one dispatch surface (block presence),
         # not two features that happened to land together -- no partial
-        # form of this method ever existed to split around. (The THIRD
-        # branch this same method gains in the real source commit --
-        # `:heki`/`:memory`/`:sqlite` domain-wide persisted_by defaults --
-        # is its own, later, independently-meaningful PR: it carries its
-        # own DEFERRED-apply subtlety and its own migration-plan citation,
-        # not fabricated as separate, just genuinely a third concern
-        # layered onto the same no-block branch.)
+        # form of this method ever existed to split around.
+        #
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 8): `:sqlite` alongside the original `:heki`/`:memory`
+        # domain-wide-default kinds -- the CANONICAL PIZZAS EXAMPLE itself
+        # (pizzeria/domain/pizzas.hecksagon) writes `adapter :sqlite, db:
+        # "..." ` as a context-wide default with its own documented
+        # PRECEDENCE rule ("an aggregate-level persisted_by(...) binding
+        # is applied LAST and would OVERRIDE this wiring — exactly how
+        # Cart stays in Memory"). Unlike heki/memory, sqlite is written
+        # WITH opts (a real inline db path, not a .world-file value), so
+        # the trigger condition widens to tolerate opts for a KNOWN
+        # backend kind -- opts are accepted structurally but not yet
+        # wired to real per-deployment config (a documented, narrower
+        # gap: inline hecksagon-level adapter config bypassing .world
+        # entirely is a genuinely separate feature this migration didn't
+        # build). DOMAIN_WIDE_KINDS maps the DSL's bare kind symbol to
+        # its real registered adapter name (Sqlite's own .adapter file
+        # names it "SqlitePersistence", not "Sqlite").
+        DOMAIN_WIDE_KINDS = { heki: "Heki", memory: "Memory", sqlite: "SqlitePersistence" }.freeze
+
         def adapter(kind, **opts, &block)
+          return domain_wide_persisted_by(kind) if !block && DOMAIN_WIDE_KINDS.key?(kind)
           return @raw_adapters << { kind: kind.to_s, opts: opts } unless block
 
           @driving_handlers.concat(DrivingAdapterBuilder.build(kind, &block))
+        end
+
+        # Vendored addition, not (yet) upstream hecksagain: `adapter
+        # :heki` / `adapter :memory` / `adapter :sqlite` bare (no
+        # aggregate qualifier, no block) is a DOMAIN-WIDE default --
+        # "every aggregate in this bluebook persists here unless
+        # overridden" -- widespread across miette's organ/memory domains
+        # (i728 Phase B, "durable-by-default") and the canonical pizzas
+        # example's sqlite context, which states the precedence
+        # explicitly: "an aggregate-level persisted_by(...) binding is
+        # applied LAST and would OVERRIDE this wiring." hecksagain has no
+        # domain-wide default; every aggregate needs its own explicit
+        # persisted_by bind.
+        #
+        # DEFERRED, not immediate -- pizzeria's own file declares the
+        # domain-wide `adapter :sqlite` FIRST and Cart's overriding
+        # `Cart.persisted_by("Memory")` AFTER it, so resolving the
+        # default immediately (as this used to) saw an empty @binds and
+        # synthesized a bind for Cart too, colliding with Cart's own
+        # explicit one two lines later ("2 authoritative persisted_by
+        # bindings"). Recorded here, applied once in #build once every
+        # explicit bind in THIS FILE is known -- scoped to this
+        # hecksagon file only, the known, narrower gap a multi-file-per-
+        # domain override in a DIFFERENT file wouldn't be caught by ;
+        # pizzeria is single-file, so this is exact there. TODO upstream
+        # via bin/evolve (migration plan task 7).
+        def domain_wide_persisted_by(kind)
+          (@domain_wide_defaults ||= []) << DOMAIN_WIDE_KINDS.fetch(kind)
+        end
+
+        def apply_domain_wide_defaults!
+          return if @domain_wide_defaults.nil? || @domain_wide_defaults.empty?
+
+          bluebook_ir = Hecksagain.current_registry.bluebook(@domain) or return
+          already_bound = @binds.select { |b| b.verb == "persisted_by" }.map(&:aggregate_name).to_set
+          @domain_wide_defaults.each do |backend|
+            bluebook_ir.aggregates.each do |agg|
+              next if already_bound.include?(agg.hecks_name)
+
+              @binds << IR::Bind.new(aggregate: agg.hecks_name, verb: "persisted_by", adapter: backend, role: nil)
+              already_bound << agg.hecks_name
+            end
+          end
         end
 
         # An event this hecksagon takes from OUTSIDE the domain's own
@@ -105,6 +163,7 @@ module Hecksagain
         end
 
         def build
+          apply_domain_wide_defaults!
           IR::Hecksagon.new(domain: @domain, binds: @binds, subscriptions: @subscriptions,
                              framework_members: @framework_members, driving_handlers: @driving_handlers)
         end

--- a/spec/domain_wide_adapter_defaults_growth_spec.rb
+++ b/spec/domain_wide_adapter_defaults_growth_spec.rb
@@ -1,0 +1,124 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for HecksagonBuilder's domain-wide persisted_by defaults:
+# a bare `adapter :heki` / `adapter :memory` / `adapter :sqlite` (no
+# aggregate qualifier, no block) inside a hecksagon means "every
+# aggregate in this bluebook persists here unless overridden" -- the
+# exact shape the canonical pizzas example's own sqlite context uses,
+# with its own documented precedence rule: an aggregate-level
+# `persisted_by(...)` bind, wherever it appears in the file, wins.
+#
+# Applied at #build time (once every explicit bind in the SAME
+# hecksagon file is known), not the moment `adapter :kind` is
+# evaluated -- resolving it immediately would see an empty @binds and
+# synthesize a bind for an aggregate whose own explicit override
+# appears LATER in the same file, colliding with it.
+RSpec.describe "HecksagonBuilder domain-wide adapter defaults" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["domain-wide-adapter-defaults-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  DOMAIN_WIDE_ADAPTER_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "DomainWideAdapterGrowth" do
+      aggregate "Lamp" do
+        identified_by { lamp_id.value }
+
+        value_object "LampId" do
+          attribute :value, String
+        end
+
+        attribute :lamp_id, LampId
+
+        command "TurnOn" do
+          attribute :lamp_id, LampId
+          emits "LampTurnedOn"
+        end
+      end
+
+      aggregate "Fuse" do
+        identified_by { fuse_id.value }
+
+        value_object "FuseId" do
+          attribute :value, String
+        end
+
+        attribute :fuse_id, FuseId
+
+        command "Blow" do
+          attribute :fuse_id, FuseId
+          emits "FuseBlown"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime, aggregate_name)
+    bluebook = runtime.registry.bluebook("DomainWideAdapterGrowth")
+    aggregate = bluebook.aggregate(aggregate_name)
+    runtime.registry.repository("DomainWideAdapterGrowth", aggregate)
+  end
+
+  it "binds every aggregate to the domain-wide default when nothing overrides it" do
+    runtime = boot(DOMAIN_WIDE_ADAPTER_SOURCE, "DomainWideAdapterGrowth") do
+      adapter :memory
+    end
+
+    expect { runtime.dispatch("DomainWideAdapterGrowth::Lamp.TurnOn", lamp_id: { value: "lamp-1" }) }
+      .not_to raise_error
+    expect { runtime.dispatch("DomainWideAdapterGrowth::Fuse.Blow", fuse_id: { value: "fuse-1" }) }
+      .not_to raise_error
+  end
+
+  it "an explicit aggregate-level persisted_by bind, declared AFTER the domain-wide default, still wins" do
+    runtime = boot(DOMAIN_WIDE_ADAPTER_SOURCE, "DomainWideAdapterGrowth") do
+      adapter :memory
+      ::DomainWideAdapterGrowth::Fuse.persisted_by("Memory")
+    end
+
+    bluebook_ir = runtime.registry.bluebook("DomainWideAdapterGrowth")
+    hecksagon_ir = runtime.registry.hecksagon("DomainWideAdapterGrowth")
+
+    fuse_binds = hecksagon_ir.binds.select { |b| b.aggregate_name == "Fuse" && b.verb == "persisted_by" }
+    expect(fuse_binds.size).to eq(1), "the explicit bind must not be duplicated by the domain-wide default"
+
+    lamp_binds = hecksagon_ir.binds.select { |b| b.aggregate_name == "Lamp" && b.verb == "persisted_by" }
+    expect(lamp_binds.size).to eq(1), "Lamp has no explicit bind, so the domain-wide default must supply one"
+    expect(lamp_binds.first.adapter).to eq("Memory")
+
+    expect(bluebook_ir).not_to be_nil
+  end
+
+  it "records nothing extra when the hecksagon declares no domain-wide adapter at all" do
+    runtime = boot(DOMAIN_WIDE_ADAPTER_SOURCE, "DomainWideAdapterGrowth") do
+      ::DomainWideAdapterGrowth::Lamp.persisted_by("Memory")
+      ::DomainWideAdapterGrowth::Fuse.persisted_by("Memory")
+    end
+
+    hecksagon_ir = runtime.registry.hecksagon("DomainWideAdapterGrowth")
+    expect(hecksagon_ir.binds.size).to eq(2)
+  end
+end

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "the DSL surface is fully covered" do
     "HecksagonBuilder" => [
       Hecksagain::Bluebook::DSL::HecksagonBuilder,
       %i[binds subscribe subscriptions port uses_framework framework_members
-         adapter raw_adapters driving_handlers]
+         adapter raw_adapters driving_handlers domain_wide_persisted_by apply_domain_wide_defaults!]
     ],
     "TranslationBuilder" => [
       Hecksagain::Bluebook::DSL::TranslationBuilder,


### PR DESCRIPTION
Item `1855be0-a3` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item 18 (`1855be0-a`). Splits the third branch of `1855be0`'s `HecksagonBuilder#adapter` change (the driving-grammar + raw-adapter-bug-fix branches landed at #56).

**What this lands**: `adapter :heki` / `adapter :memory` / `adapter :sqlite` bare (no aggregate qualifier, no block) inside a hecksagon is a DOMAIN-WIDE `persisted_by` default — "every aggregate in this bluebook persists here unless overridden." hecksagain had no domain-wide default before this; every aggregate needed its own explicit `persisted_by` bind. Real and live: miette's organ/memory domains (i728 Phase B, "durable-by-default") and the canonical pizzas example's own sqlite context, which states the precedence rule explicitly in its own comments.

`:sqlite` is new alongside the original `:heki`/`:memory` kinds — pizzeria writes `adapter :sqlite, db: "..."` with opts, so the trigger condition tolerates opts for a known backend kind (opts accepted structurally, not yet wired to real per-deployment config — a documented, narrower gap).

**DEFERRED-apply, not immediate**: resolved once at `#build` time, after every explicit bind in the same hecksagon file is known — not the moment `adapter :kind` is evaluated. Applying it immediately would synthesize a bind for an aggregate whose own explicit override appears LATER in the same file (exactly pizzeria's own file shape: the domain-wide `adapter :sqlite` line comes first, `Cart.persisted_by("Memory")`'s override two lines later). Known, narrower gap: a multi-file-per-domain override in a DIFFERENT file isn't caught by this (pizzeria is single-file, so it's exact there).

**Spec coverage**: `spec/domain_wide_adapter_defaults_growth_spec.rb` — a real two-aggregate bluebook, dispatched end-to-end (not just bind inspection). Verified genuinely failing without the fix via `git stash`: dispatch against the domain-wide-defaulted aggregate raised `WiringError` ("has no persisted_by bind"), and the precedence check found the un-overridden aggregate with zero binds instead of one.

**Verification**: 1348 examples, 15 failures (up from 1345/15 — same 15 known, already-catalogued failures, zero diff against the previous checkpoint's failure set, no regressions).
