### PR TITLE
dsl: HecksagonBuilder success/failure async-verdict stub (item 1855be0-a4)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/hecksagon_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/hecksagon_builder.rb
@@ -162,6 +162,40 @@ module Hecksagain
           bluebook_ir.add_port(built)
         end
 
+        # Vendored no-op stub, not (yet) upstream hecksagain — and a
+        # MAJOR finding, not a small one (migration plan task 4): the
+        # `Aggregate.verb("Adapter", on: "Event") do success "Cmd"
+        # failure "Cmd" end` shape — the EFFECT-family async-verdict
+        # pattern the Pizzas example itself documents as canonical
+        # (`Order.charged_by("Stripe", on: "OrderPlaced") do success
+        # "Order.Authorize" failure "Order.Decline" end`) — has NO
+        # implementation ANYWHERE in hecksagain: confirmed by grepping
+        # both the vendored copy AND the untouched original
+        # ~/Projects/hecksagain repo for `def success`/`def failure` —
+        # zero hits in either. `IR::Bind` itself
+        # (bluebook/ir/hexagon.rb) has no `on`/`success`/`failure`
+        # fields at all, only `aggregate`/`verb`/`adapter`/`role`. Found
+        # live via miette's dream.hecksagon (`BodyDream::Dream.
+        # imaged_by("DreamImage", on: "DreamImageRequested") do success
+        # "Dream.RecordImage" end`) — a block whose `success`/`failure`
+        # calls land on THIS builder (BindingProxy#method_missing just
+        # `block&.call`s the block in its ORIGINAL lexical scope, never
+        # instance_eval's it against the bind), so they need to exist
+        # here regardless of who resolves them.
+        #
+        # Stubbed structurally so the file boots — NOT a real fix. A
+        # real fix means: `on:` threaded onto IR::Bind, an actual async
+        # delivery mechanism (there is no adapter-host process in this
+        # runtime the way the Pizzas narrative implies), and genuine
+        # verdict re-entry wiring (a refused/succeeded response
+        # dispatching the named command back in). That is a whole
+        # subsystem, not a missing keyword — deliberately not attempted
+        # under this session's time pressure. TODO upstream via
+        # bin/evolve (migration plan task 7): this is the single
+        # highest-value remaining gap this migration surfaced.
+        def success(*) = nil
+        def failure(*) = nil
+
         def build
           apply_domain_wide_defaults!
           IR::Hecksagon.new(domain: @domain, binds: @binds, subscriptions: @subscriptions,

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe "the DSL surface is fully covered" do
     "HecksagonBuilder" => [
       Hecksagain::Bluebook::DSL::HecksagonBuilder,
       %i[binds subscribe subscriptions port uses_framework framework_members
-         adapter raw_adapters driving_handlers domain_wide_persisted_by apply_domain_wide_defaults!]
+         adapter raw_adapters driving_handlers domain_wide_persisted_by apply_domain_wide_defaults!
+         success failure]
     ],
     "TranslationBuilder" => [
       Hecksagain::Bluebook::DSL::TranslationBuilder,

--- a/spec/hecksagon_builder_success_failure_growth_spec.rb
+++ b/spec/hecksagon_builder_success_failure_growth_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for HecksagonBuilder#success/#failure: a documented,
+# structural-only stub for the EFFECT-family async-verdict shape the
+# Pizzas example itself documents as canonical --
+#
+#   Order.charged_by("Stripe", on: "OrderPlaced") do
+#     success "Order.Authorize"
+#     failure "Order.Decline"
+#   end
+#
+# -- which has NO implementation anywhere in hecksagain. Before this,
+# a hecksagon that used this shape (miette's dream.hecksagon:
+# `BodyDream::Dream.imaged_by("DreamImage", on: "DreamImageRequested")
+# do success "Dream.RecordImage" end`) raised a plain NoMethodError on
+# `success`, because BindingProxy#method_missing calls the trailing
+# block WITHOUT instance_eval -- it runs in the block's own original
+# lexical scope, which (inside `Hecks.hecksagon "X" do ... end`, itself
+# `instance_eval`'d against a HecksagonBuilder) is the HecksagonBuilder
+# instance, not the BindingProxy that recorded the bind.
+#
+# This PR captures the shape structurally so the file boots -- NOT a
+# real fix. `on:` is silently dropped by BindingProxy#method_missing
+# (pre-existing, untouched by this PR); success/failure's own command
+# names are accepted and discarded. That is an honest, documented gap,
+# not silently pretended complete.
+RSpec.describe "HecksagonBuilder#success/#failure (async-verdict stub)" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["hecksagon-success-failure-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+    registry
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  ASYNC_VERDICT_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "AsyncVerdictGrowth" do
+      aggregate "Order" do
+        identified_by { order_id.value }
+
+        value_object "OrderId" do
+          attribute :value, String
+        end
+
+        attribute :order_id, OrderId
+
+        command "Authorize" do
+          attribute :order_id, OrderId
+          emits "OrderAuthorized"
+        end
+
+        command "Decline" do
+          attribute :order_id, OrderId
+          emits "OrderDeclined"
+        end
+      end
+    end
+  BLUEBOOK
+
+  it "boots a hecksagon using the canonical charged_by/on/success/failure shape without raising" do
+    expect do
+      boot(ASYNC_VERDICT_SOURCE, "AsyncVerdictGrowth") do
+        ::AsyncVerdictGrowth::Order.charged_by("Stripe", on: "OrderPlaced") do
+          success "AsyncVerdictGrowth::Order.Authorize"
+          failure "AsyncVerdictGrowth::Order.Decline"
+        end
+      end
+    end.not_to raise_error
+  end
+
+  it "still records the real charged_by bind, on: dropped (pre-existing, untouched by this stub)" do
+    registry = boot(ASYNC_VERDICT_SOURCE, "AsyncVerdictGrowth") do
+      ::AsyncVerdictGrowth::Order.charged_by("Stripe", on: "OrderPlaced") do
+        success "AsyncVerdictGrowth::Order.Authorize"
+        failure "AsyncVerdictGrowth::Order.Decline"
+      end
+    end
+
+    bind = registry.hecksagon("AsyncVerdictGrowth").bind_for("Order", "charged_by")
+    expect(bind).not_to be_nil
+    expect(bind.adapter).to eq("Stripe")
+  end
+
+  it "success/failure are no-ops -- accepted, not stored or dispatched anywhere" do
+    builder = Hecksagain::Bluebook::DSL::HecksagonBuilder.new("AsyncVerdictGrowth")
+    expect(builder.success("AsyncVerdictGrowth::Order.Authorize")).to be_nil
+    expect(builder.failure("AsyncVerdictGrowth::Order.Decline")).to be_nil
+  end
+end


### PR DESCRIPTION
Item `1855be0-a4` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-a3` (#57).

**What this lands**: `HecksagonBuilder#success`/`#failure` — a structural no-op stub for the EFFECT-family async-verdict shape the Pizzas example itself documents as canonical:

```
Order.charged_by("Stripe", on: "OrderPlaced") do
  success "Order.Authorize"
  failure "Order.Decline"
end
```

The source commit's own message flags this as **"a MAJOR finding, not a small one"** — confirmed by grepping both the vendored copy and the untouched original `~/Projects/hecksagain` repo for `def success`/`def failure`: zero hits in either. `IR::Bind` has no `on:`/`success`/`failure` fields at all, only `aggregate`/`verb`/`adapter`/`role`. Found live via miette's `dream.hecksagon`.

Before this fix, that block raised a plain `NoMethodError` on `success` — `BindingProxy#method_missing` calls the trailing block WITHOUT `instance_eval` (it runs in the block's own original lexical scope), which inside `Hecks.hecksagon "X" do ... end` is the `HecksagonBuilder` instance, not the `BindingProxy` that recorded the bind. So `success`/`failure` have to exist on `HecksagonBuilder`, not `BindingProxy`.

Stubbed structurally so the file boots — **NOT a real fix**, documented as such in the source comment (a real fix needs `on:` threaded onto `IR::Bind`, an actual async delivery mechanism, and genuine verdict re-entry wiring — a whole subsystem).

**Spec coverage**: `spec/hecksagon_builder_success_failure_growth_spec.rb` — boots a real hecksagon using the exact canonical `charged_by`/`on:`/`success`/`failure` shape, confirms the real `charged_by` bind is still recorded (`on:` silently dropped, pre-existing/untouched by this PR), and confirms `success`/`failure` are accepted no-ops. Verified genuinely failing without this fix via `git stash` (`NoMethodError` on `success`, all 3 examples).

**Verification**: 1351 examples, 15 failures both runs (one run showed a 16th, `rust_conformance_spec.rb[1:10]`, that disappeared on rerun — confirmed as a pre-existing environment flake unrelated to this change, not a regression from this PR).
