### PR TITLE
DSL: bare-primitive value-object auto-synthesis + collision fix

### DIFF
--- a/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
@@ -21,6 +21,60 @@ module Hecksagain
           @description = value
         end
 
+        # Vendored addition, not (yet) upstream hecksagain: hecksagain's
+        # own named principle is "primitives live in value objects
+        # only" (lib/hecksagain/language/bluebook/vocabulary.bluebook) --
+        # a bare `attribute :x, String` directly on an aggregate is
+        # refused by the self-hosted meta-validator. hecks_conception +
+        # miette's own convention does this 260+ times at the aggregate
+        # level (value_object-internal bare types were always fine and
+        # are untouched here). DECISION, documented not hidden: rather
+        # than a corpus-wide rewrite touching every declaration AND
+        # every call site that constructs these attributes, this
+        # transparently AUTO-SYNTHESISES a single-field wrapper value
+        # object per bare-primitive aggregate attribute -- the exact
+        # same mechanism `one_of(...)`'s `synthesise_closed_set` already
+        # uses for inline closed sets, just triggered by a bare
+        # primitive Class instead of a OneOf. Preserves hecksagain's own
+        # "primitives only live in VOs" invariant (the VO now just has
+        # an author of "the runtime" instead of "the corpus") rather
+        # than relaxing it. TODO upstream via bin/evolve (migration plan
+        # task 7) -- or supersede with the real corpus-wide VO-wrapping
+        # pass if Chris prefers that path instead.
+        PRIMITIVE_CLASSES = [String, Integer, Float, TrueClass, FalseClass, Numeric].freeze
+
+        def attribute(name, type = String, **kwargs)
+          # Vendored fix, not (yet) upstream hecksagain (migration plan task
+          # 4): apply the SAME inverted-form correction AttributeCollector#
+          # attribute makes -- but BEFORE the primitive-wrapper check below,
+          # not after. `super` (which is where the base correction actually
+          # lived) runs LAST, so a bare `attribute App` (no `as:`) used to
+          # reach the primitive check below still shaped `name: :App, type:
+          # String` (the un-fixed positional default) -- String IS a
+          # PRIMITIVE_CLASS, so it synthesised a wrapper VO NAMED "App",
+          # colliding with a real hand-written `value_object "App"` a few
+          # lines above it in the same file. See AttributeCollector.
+          # resolve_inverted's own comment for why the check is reliable.
+          name, type = AttributeCollector.resolve_inverted(name, type, kwargs[:as])
+          type = AttributeCollector.normalize_boolean_alias(type)
+
+          if PRIMITIVE_CLASSES.include?(type)
+            type = synthesise_primitive_wrapper(name, type)
+          elsif type.is_a?(ListOf) && PRIMITIVE_CLASSES.include?(type.type)
+            type = ListOf.new(synthesise_primitive_wrapper(name, type.type))
+          end
+          super(name, type, **kwargs)
+        end
+
+        def synthesise_primitive_wrapper(name, primitive_class)
+          wrapper_name = Naming.pascal(name)
+          (@closed_sets ||= closed_sets) << IR::ValueObject.declare(
+            name:       wrapper_name,
+            attributes: [IR::Attribute.new(name: :value, type: primitive_class.name)]
+          )
+          wrapper_name
+        end
+
         # ORIGIN, not runtime identity — a concept adopted from a canonical
         # source (§28) names where it came from without that fact ever
         # touching `hecks_fqn`/dispatch. Captured raw, the same way
@@ -159,6 +213,9 @@ module Hecksagain
 
         def build
           resolve_pending_identity!
+
+          resolve_bare_primitive_collisions
+
           seal_mutation_targets
           seal_query_targets
           seal_defaults
@@ -199,6 +256,61 @@ module Hecksagain
             @identity_paths = resolve_identity_type!(type, as, insert_at, @value_objects + closed_sets, @name)
           elsif @identity_field_pending
             @identity_paths = resolve_identity_field!(@identity_field_pending, @value_objects + closed_sets, @name)
+          end
+        end
+
+        # Vendored fix, not (yet) upstream hecksagain (migration plan task
+        # 8): `synthesise_primitive_wrapper` (above) mints an auto-wrapper
+        # VO named after a bare attribute's own field (PascalCase) with NO
+        # check for whether an EXPLICIT, hand-written `value_object` of
+        # that same name already exists elsewhere in the same aggregate,
+        # for an entirely unrelated purpose. hecks_nursury's own
+        # biology.bluebook: `Neuron`'s bare `attribute :neurotransmitter,
+        # String` (a plain field on the neuron itself) shares its
+        # PascalCased name with a hand-written `value_object
+        # "Neurotransmitter" do ... end` (an embedded shape `Synapse`'s
+        # OWN `neurotransmitter` field uses) -- same English word, two
+        # unrelated, both CORRECTLY-authored concepts, an ordinary domain-
+        # modeling coincidence, not a corpus bug to rewrite around. This
+        # is the same FAMILY of bug as the earlier "App" collision
+        # (AttributeCollector's own comment) but not the same CAUSE --
+        # that one was a misparse ; this is two independently-intended
+        # declarations. And unlike the App case, attribute-call-time could
+        # not have caught this even with a perfect check : the bare
+        # attribute here is declared BEFORE the value_object it collides
+        # with, so @value_objects is not yet populated when the wrapper is
+        # synthesised. Deferred to build time on purpose, once
+        # @value_objects holds everything the block declared. Resolved by
+        # disambiguating the SYNTHESISED wrapper only -- the hand-written
+        # VO's name is real authorial intent and is never touched -- and
+        # re-pointing the bare attribute's own type string at the
+        # disambiguated name, so both concepts keep their own, non-
+        # colliding IR entry rather than the second Declare crashing the
+        # boot. TODO upstream via bin/evolve (migration plan task 7).
+        def resolve_bare_primitive_collisions
+          return if closed_sets.empty?
+
+          handwritten = @value_objects.map { |vo| vo.hecks_name.to_s }
+          taken       = handwritten + closed_sets.map { |c| c.hecks_name.to_s }
+
+          closed_sets.each do |synthesised|
+            old_name = synthesised.hecks_name.to_s
+            next unless handwritten.include?(old_name)
+
+            new_name = "#{old_name}Value"
+            new_name = "#{old_name}Value#{taken.count(new_name) + 1}" while taken.include?(new_name)
+            taken << new_name
+            synthesised.hecks_name = new_name
+
+            attributes.each_with_index do |attr, i|
+              next unless attr.type.to_s == old_name
+
+              attributes[i] = IR::Attribute.new(
+                name: attr.name, type: new_name, list: attr.list?, default: attr.default,
+                optional: attr.optional?, pattern: attr.pattern, admits: attr.admits,
+                logged: attr.logged
+              )
+            end
           end
         end
 

--- a/lib/hecksagain/bluebook/dsl/attribute_collector.rb
+++ b/lib/hecksagain/bluebook/dsl/attribute_collector.rb
@@ -5,6 +5,53 @@ module Hecksagain
         ListOf = Struct.new(:type)
         OneOf  = Struct.new(:values)
 
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4): shared by BOTH `AttributeCollector#attribute` (below) AND
+        # `AggregateBuilder#attribute`'s own override, which needs the
+        # CORRECTED name/type BEFORE its own bare-primitive-wrapper decision
+        # runs, not after -- calling `super` too late let `attribute App`
+        # (no `as:`) reach AggregateBuilder's primitive check as `name: :App,
+        # type: String` (the un-fixed shape), which then synthesised a
+        # wrapper VO NAMED "App", colliding with a real hand-written one. A
+        # module_function here is the one place both layers call, instead of
+        # the correction living only where the second caller couldn't reach
+        # it in time. See `attribute`'s own comment for why the check itself
+        # (`/\A[A-Z]/`) is right.
+        def self.resolve_inverted(name, type, as)
+          return [name, type] unless name.is_a?(Symbol) && name.to_s.match?(/\A[A-Z]/)
+
+          [as || Naming.snake(name).to_sym, name]
+        end
+
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 8): `attribute :flag, Boolean` -- 55 occurrences across 19
+        # hecks_nursury files. `Boolean` is not a real Ruby constant, so it
+        # resolves through ConstShim's bare identity resolver to the Symbol
+        # `:Boolean`, same mechanism every ordinary type constant already
+        # goes through -- but `PRIMITIVE_CLASSES` (AggregateBuilder) only
+        # recognises actual Ruby classes (`TrueClass`/`FalseClass` among
+        # them), never a Symbol, so `:Boolean` fell straight through to
+        # becoming a literal type NAME string `"Boolean"`, which no
+        # ValueObject anywhere is ever declared under -- "no ValueObject
+        # with ... name Cartography:Datum:Boolean". Shared here (not only
+        # in AggregateBuilder#attribute) because `include AttributeCollector`
+        # reaches value_object/entity/command/query attributes too, and a
+        # bare `Boolean` inside any of THOSE would hit the identical dead
+        # end at type-resolution time, just later and less obviously.
+        # Mapped to `FalseClass` -- arbitrary between the two boolean
+        # classes, but `FalseClass`/`TrueClass` are already treated as
+        # interchangeable everywhere else a boolean primitive is checked
+        # (IR::Attribute::PRIMITIVES lists both), so either name reads a
+        # true/false field correctly. TODO upstream via bin/evolve
+        # (migration plan task 7): a first-class `Boolean` alias, not a
+        # Symbol-sniffing workaround.
+        def self.normalize_boolean_alias(type)
+          return FalseClass if type == :Boolean
+          return ListOf.new(FalseClass) if type.is_a?(ListOf) && type.type == :Boolean
+
+          type
+        end
+
         def attributes = @attributes ||= []
 
         # Value objects synthesised from inline closed sets, collected here and
@@ -31,8 +78,56 @@ module Hecksagain
         # TOP-LEVEL constant, so the moment any facade exists, `Vocabulary`
         # resolves to that module and the shim is never asked. A spelling that
         # works only until a facade is built is worse than a quoted one.
-        def attribute(name, type = String, default: nil, optional: false, pattern: nil,
-                      admits: nil)
+        # Vendored addition, not (yet) upstream hecksagain: 147+ lines in
+        # hecks_conception's storehouse/bluebook/ (framework kernel) write
+        # the INVERTED call shape `attribute TypeConstant, as: :field_name`
+        # (or bare `attribute TypeConstant` with no `as:` at all, name
+        # inferred from the type) instead of `attribute :field_name,
+        # TypeConstant` -- type leads, name comes from `as:` or is derived.
+        #
+        # CORRECTED detection, not the original (migration plan task 4): the
+        # original checked "the first positional arg is NOT a Symbol" -- but
+        # `App` (a bare constant reference) resolves through ConstShim's
+        # bluebook-scope resolver (`->(const) { const }`, bluebook_builder.rb)
+        # to the Symbol `:App`, ALWAYS, the same way every ordinary
+        # `attribute :field, TypeConstant` call's OWN type argument already
+        # does. So "not a Symbol" can never be true for a bare constant, and
+        # the original check silently never fired: `attribute App`
+        # (command_bus.bluebook, framework kernel) parsed as `name: :App,
+        # type: String` (default) -- a bogus String field literally NAMED
+        # "App" -- which then hit the aggregate's bare-primitive auto-
+        # synthesis (Part 3a) and tried to mint a wrapper value object ALSO
+        # named "App", colliding with the real, hand-written `value_object
+        # "App" do ... end` a few lines above it ("Declare creates a
+        # ValueObject that already exists").
+        #
+        # The real, reliable signal: a bare-constant-resolved Symbol is
+        # ALWAYS PascalCase (Ruby constants must start uppercase) ; a
+        # literal field-name Symbol (`:app`, `:field_name`) is always this
+        # corpus's own snake_case convention. `/\A[A-Z]/` tells them apart
+        # regardless of whether `as:` was given.
+        # `required:` -- vendored alias, not (yet) upstream hecksagain
+        # (migration plan task 4): `attribute :project, Project, required:
+        # true` (aggregates/plan/bluebook/plan.bluebook, 3 occurrences) --
+        # semantically the exact inverse of `optional:`, different word.
+        # TODO upstream via bin/evolve (migration plan task 7): decide
+        # which spelling becomes canonical.
+        # `logged:` -- vendored addition, not (yet) upstream hecksagain
+        # (migration plan task 4): see IR::Attribute's own comment.
+        # `enum:` -- vendored alias, not (yet) upstream hecksagain
+        # (migration plan task 8): `attribute :value, String, enum:
+        # ["permit", "forbid"]` (pizzeria/domain/authorization.bluebook) --
+        # a Rails-style kwarg spelling of the SAME closed-set concept
+        # `one_of(*values)` already sugars in the type position ; the base
+        # type ("String") is a placeholder the closed set replaces, same
+        # as `one_of`'s own behavior. TODO upstream via bin/evolve
+        # (migration plan task 7): decide the one canonical spelling.
+        def attribute(name, type = String, as: nil, default: nil, optional: false, required: nil,
+                      pattern: nil, admits: nil, logged: true, enum: nil)
+          optional = !required unless required.nil?
+          type = OneOf.new(enum) if enum
+          name, type = AttributeCollector.resolve_inverted(name, type, as)
+          type = AttributeCollector.normalize_boolean_alias(type)
           # moved to the language: FieldName invariant, on Root.Attribute
 
           refuse_unshared_pattern(name, pattern) if pattern
@@ -46,7 +141,8 @@ module Hecksagain
             default:  default,
             optional: optional,
             pattern:  pattern,
-            admits:   admits
+            admits:   admits,
+            logged:   logged
           )
         end
 

--- a/spec/bare_primitive_vo_synthesis_growth_spec.rb
+++ b/spec/bare_primitive_vo_synthesis_growth_spec.rb
@@ -1,0 +1,217 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for AggregateBuilder's bare-primitive VO auto-synthesis:
+# hecksagain's own named principle is "primitives live in value objects
+# only" -- a bare `attribute :x, String` directly on an aggregate is
+# refused by the self-hosted meta-validator. This transparently
+# auto-synthesises a single-field wrapper value object per bare-primitive
+# aggregate attribute, the exact same mechanism `one_of(...)`'s
+# `synthesise_closed_set` already uses for inline closed sets.
+#
+# Also covers the companion collision fix: a synthesised wrapper VO
+# named after a bare attribute's own field can collide with a real,
+# independently hand-written value_object of the same name declared
+# elsewhere in the same aggregate -- resolved by disambiguating the
+# SYNTHESISED wrapper only, never the hand-written one.
+RSpec.describe "bare-primitive value-object auto-synthesis" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["bare-primitive-vo-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  describe "a bare primitive attribute on an aggregate" do
+    BARE_PRIMITIVE_SOURCE = <<~BLUEBOOK
+      Hecks.bluebook "BarePrimitiveGrowth" do
+        aggregate "Sensor" do
+          identified_by { id.value }
+
+          value_object "SensorId" do
+            attribute :value, String
+          end
+
+          attribute :id,    SensorId
+          attribute :label, String
+
+          command "Install" do
+            attribute :id,    SensorId
+            attribute :label, String
+            emits "Installed"
+          end
+        end
+      end
+    BLUEBOOK
+
+    it "auto-wraps into a synthesised single-field value object, no refusal" do
+      runtime = boot(BARE_PRIMITIVE_SOURCE, "BarePrimitiveGrowth") do
+        ::BarePrimitiveGrowth::Sensor.persisted_by("Memory")
+      end
+
+      expect { runtime.dispatch("BarePrimitiveGrowth::Sensor.Install", id: { value: "s1" }, label: { value: "porch" }) }
+        .not_to raise_error
+
+      record = runtime.registry.repository("BarePrimitiveGrowth", runtime.registry.bluebook("BarePrimitiveGrowth").aggregate("Sensor")).find("s1")
+      expect(record[:label]).to be_a(Hecksagain::Runtime::Value)
+      expect(record[:label].to_h).to eq(value: "porch")
+    end
+  end
+
+  describe "a synthesised wrapper colliding with a hand-written value_object of the same name" do
+    COLLISION_SOURCE = <<~BLUEBOOK
+      Hecks.bluebook "PrimitiveCollisionGrowth" do
+        aggregate "Neuron" do
+          identified_by { id.value }
+
+          value_object "NeuronId" do
+            attribute :value, String
+          end
+
+          value_object "Neurotransmitter" do
+            attribute :kind,  String
+            attribute :level, Integer
+          end
+
+          attribute :id,                NeuronId
+          attribute :neurotransmitter,  String
+          attribute :embedded,          Neurotransmitter
+
+          command "Fire" do
+            attribute :id,               NeuronId
+            attribute :neurotransmitter, String
+            emits "Fired"
+          end
+        end
+      end
+    BLUEBOOK
+
+    it "disambiguates the synthesised wrapper, leaving the hand-written value_object untouched" do
+      runtime = boot(COLLISION_SOURCE, "PrimitiveCollisionGrowth") do
+        ::PrimitiveCollisionGrowth::Neuron.persisted_by("Memory")
+      end
+
+      neuron = runtime.registry.bluebook("PrimitiveCollisionGrowth").aggregate("Neuron")
+
+      # The hand-written value_object keeps its own real name, untouched.
+      handwritten = neuron.value_object("Neurotransmitter")
+      expect(handwritten.attributes.map(&:name)).to eq(%i[kind level])
+
+      # The bare `attribute :neurotransmitter, String` field is re-pointed at
+      # a DISAMBIGUATED synthesised wrapper name, not "Neurotransmitter".
+      field = neuron.attributes.find { |a| a.name == :neurotransmitter }
+      expect(field.type.to_s).not_to eq("Neurotransmitter")
+      expect(field.type.to_s).to eq("NeurotransmitterValue")
+
+      # And a real dispatch proves both concepts actually resolve, not just
+      # that the IR happened to build without raising.
+      expect do
+        runtime.dispatch("PrimitiveCollisionGrowth::Neuron.Fire",
+                          id: { value: "n1" }, neurotransmitter: { value: "dopamine" })
+      end.not_to raise_error
+    end
+  end
+
+  describe "the inverted call shape and its kwarg surface (attribute_collector.rb)" do
+    INVERTED_ATTRIBUTE_SOURCE = <<~BLUEBOOK
+      Hecks.bluebook "InvertedAttributeGrowth" do
+        aggregate "Engine" do
+          identified_by { id.value }
+
+          value_object "EngineId" do
+            attribute :value, String
+          end
+
+          value_object "App" do
+            attribute :value, String
+          end
+
+          attribute :id, EngineId
+          attribute App, as: :running_app
+          attribute :armed, Boolean
+
+          command "Boot" do
+            attribute :id, EngineId
+            attribute App, as: :running_app
+            attribute :armed, Boolean
+            emits "EngineBooted"
+          end
+        end
+      end
+    BLUEBOOK
+
+    it "attribute TypeConstant, as: :name resolves the real hand-written type, no wrapper collision" do
+      runtime = boot(INVERTED_ATTRIBUTE_SOURCE, "InvertedAttributeGrowth") do
+        ::InvertedAttributeGrowth::Engine.persisted_by("Memory")
+      end
+
+      engine = runtime.registry.bluebook("InvertedAttributeGrowth").aggregate("Engine")
+      field = engine.attributes.find { |a| a.name == :running_app }
+      expect(field).not_to be_nil
+      expect(field.type.to_s).to eq("App")
+
+      expect do
+        runtime.dispatch("InvertedAttributeGrowth::Engine.Boot",
+                          id: { value: "e1" }, running_app: { value: "hecksagain" }, armed: true)
+      end.not_to raise_error
+    end
+
+    it "the Boolean alias resolves to a real true/false field, not a dangling 'Boolean' type name" do
+      runtime = boot(INVERTED_ATTRIBUTE_SOURCE, "InvertedAttributeGrowth") do
+        ::InvertedAttributeGrowth::Engine.persisted_by("Memory")
+      end
+      runtime.dispatch("InvertedAttributeGrowth::Engine.Boot",
+                        id: { value: "e2" }, running_app: { value: "hecksagain" }, armed: true)
+
+      record = runtime.registry.repository(
+        "InvertedAttributeGrowth", runtime.registry.bluebook("InvertedAttributeGrowth").aggregate("Engine")
+      ).find("e2")
+      expect(record[:armed].to_h).to eq(value: true)
+    end
+  end
+
+  describe "required: and enum: kwargs (attribute_collector.rb, via ValueObjectBuilder — no aggregate-level primitive wrap in the way)" do
+    it "required: false is optional: true's exact inverse alias" do
+      vo = Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("RequiredGrowthVo") do
+        attribute :nickname, String, required: false
+      end
+
+      field = vo.attributes.find { |a| a.name == :nickname }
+      expect(field.optional?).to be(true)
+    end
+
+    it "enum: is one_of's Rails-style kwarg spelling, synthesising the same closed set one_of would" do
+      builder = Hecksagain::Bluebook::DSL::ValueObjectBuilder.new("EnumGrowthVo")
+      builder.instance_eval do
+        attribute :access, String, enum: %w[permit forbid]
+      end
+
+      field = builder.attributes.find { |a| a.name == :access }
+      expect(field.type.to_s).to eq("Access")
+
+      closed_set = builder.closed_sets.find { |c| c.hecks_name.to_s == "Access" }
+      expect(closed_set).not_to be_nil
+      expect(closed_set.members.map { |m| m[:value] }).to eq(%w[permit forbid])
+    end
+  end
+end

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "the DSL surface is fully covered" do
     "AggregateBuilder" => [
       Hecksagain::Bluebook::DSL::AggregateBuilder,
       %i[description provenance identified_by reference_to has_many has_one belongs_to value_object command lifecycle
-         entity query policy attribute list_of attributes]
+         entity query policy attribute list_of attributes synthesise_primitive_wrapper]
     ],
     "ValueObjectBuilder" => [
       Hecksagain::Bluebook::DSL::ValueObjectBuilder,

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -252,9 +252,27 @@ RSpec.describe "the DSL surface" do
     # `identified_by`, which is the SINGLE head and goes nil the moment an
     # identity has two parts. The quoted id was always the JOIN of those two
     # ("Primitive:Thing" and "String"); now the message says so.
+    # `attribute :code, String` no longer reaches here: bare Ruby-primitive
+    # types (String/Integer/Float/TrueClass/FalseClass/Numeric) are now
+    # deliberately auto-wrapped into a synthesised single-field value object
+    # (AggregateBuilder#synthesise_primitive_wrapper, migration's
+    # "bare-primitive VO synthesis" — see aggregate_builder.rb's own
+    # PRIMITIVE_CLASSES comment), preserving "primitives only live in VOs"
+    # rather than relaxing it. What still hits this Malformed is a type name
+    # that is neither a declared value object NOR one of those primitive
+    # classes — an undeclared bare constant, resolved through ConstShim to a
+    # Symbol nothing declares a ValueObject under.
+    #
+    # NOT `Widget` — spec/fixtures/dispatch_order.bluebook declares a real
+    # aggregate under that name, and once any spec builds its facade
+    # `Widget` resolves as a genuine top-level constant for the rest of the
+    # process (ConstShim's own `const_missing` hook only fires for a name
+    # nothing already answers to) — a real, order-dependent collision this
+    # example hit BEFORE this comment existed. A name no fixture anywhere
+    # declares is the only spelling that reaches ConstShim reliably.
     it "refuses an aggregate attribute that is not a value object" do
-      expect { build_aggregate("Primitive") { attribute :code, String } }
-        .to raise_error(Malformed, %r{no ValueObject with aggregate_id, name "Primitive:Thing:String"})
+      expect { build_aggregate("Primitive") { attribute :code, UtterlyUndeclaredValueObjectType } }
+        .to raise_error(Malformed, %r{no ValueObject with aggregate_id, name "Primitive:Thing:UtterlyUndeclaredValueObjectType"})
     end
 
     # A PIECE IS REACHED THROUGH ITS AGGREGATE, so a command on one addresses

--- a/spec/saga_template_and_for_each_growth_spec.rb
+++ b/spec/saga_template_and_for_each_growth_spec.rb
@@ -80,7 +80,12 @@ RSpec.describe "saga template composition and for_each dispatch fan-out" do
       runtime = boot(TEMPLATE_SOURCE, "TemplateGrowth") { ::TemplateGrowth::GrowthNote.persisted_by("Memory") }
       runtime.dispatch("TemplateGrowth::GrowthNote.Open", id: { value: "n1" }, target: "the archive")
 
-      expect(TemplateGrowth::GrowthNote.find("n1").last_text.to_s).to eq("going deeper into the archive")
+      # `last_text` is a bare `String` attribute on the aggregate, so it
+      # auto-wraps into a single-field synthesised value object
+      # (Hecksagain::Runtime::Value) -- unwrap via Value.scalar the same
+      # way any bare-primitive aggregate field reads back.
+      last_text = Hecksagain::Runtime::Value.scalar(TemplateGrowth::GrowthNote.find("n1").last_text)
+      expect(last_text).to eq("going deeper into the archive")
     end
   end
 
@@ -169,8 +174,11 @@ RSpec.describe "saga template composition and for_each dispatch fan-out" do
 
       runtime.dispatch("SagaFanoutGrowth::GrowthCart.Checkout", cart_key: { value: "c1" })
 
-      expect(SagaFanoutGrowth::GrowthLine.find("l1").status).to eq("confirmed")
-      expect(SagaFanoutGrowth::GrowthLine.find("l2").status).to eq("confirmed")
+      # `status` is a bare `String` attribute on the aggregate, so it
+      # auto-wraps into a single-field synthesised value object -- see
+      # the same note on the template example above.
+      expect(Hecksagain::Runtime::Value.scalar(SagaFanoutGrowth::GrowthLine.find("l1").status)).to eq("confirmed")
+      expect(Hecksagain::Runtime::Value.scalar(SagaFanoutGrowth::GrowthLine.find("l2").status)).to eq("confirmed")
     end
   end
 end


### PR DESCRIPTION
hecksagain's own named principle is "primitives live in value objects only" — a bare `attribute :x, String` directly on an aggregate is refused by the self-hosted meta-validator. hecks_conception + miette's own convention does this 260+ times at the aggregate level.

**Finding**: `docs/hecks-migration-findings.md`. Rather than a corpus-wide rewrite, `AggregateBuilder#attribute` transparently auto-synthesises a single-field wrapper value object per bare-primitive aggregate attribute — the exact same mechanism `one_of`'s own `synthesise_closed_set` already uses for inline closed sets. Preserves the "primitives only live in VOs" invariant rather than relaxing it.

**Bundled dependency** (same "plumbing before feature" pattern as #29/#45/#56): `AttributeCollector.resolve_inverted` (the inverted `attribute TypeConstant, as: :name` form must be corrected BEFORE the primitive-wrapper decision runs, not after — calling `super` too late let a bare `attribute App` reach the primitive check unfixed and mint a wrapper VO colliding with a real hand-written one) and `.normalize_boolean_alias` (`Boolean` resolves through `ConstShim` to a Symbol `PRIMITIVE_CLASSES` never recognized). `attribute_collector.rb`'s own `attribute` method also gains `as:`/`required:`/`enum:` kwargs in the same hunk.

**Companion collision fix**: a synthesised wrapper VO named after a bare attribute's own field can collide with a real, independently hand-written `value_object` of the same name declared elsewhere in the same aggregate (an ordinary domain-modeling coincidence, not a corpus bug) — resolved at build time by disambiguating the SYNTHESISED wrapper only, appending "Value"/"Value2"/... until unique, never touching the hand-written VO's own name.

**Real regression found and fixed while verifying this PR**: two existing saga specs (item 12/#37's own coverage) had bare-String aggregate fields that now read back as `Runtime::Value` instances instead of raw strings — fixed via `Value.scalar`. Also updates `dsl_spec.rb`'s "refuses an aggregate attribute that is not a value object" test to reflect this intentional, documented behavior change: a bare primitive no longer reaches that refusal at all (it auto-wraps); what still hits it is a genuinely undeclared type name.

**Verification**: `bundle exec rspec --no-color --exclude-pattern "**/postgres/**"` — 1320 examples, 16 failures (up 1 expected gap: `syntax_conformance_spec` wants the new DSL surface registered in the self-hosted grammar, a later item). No other regressions — the two real ones found were fixed in this same PR, not deferred.

Split out of the original bundled PR #16 — stacks on #58, item 1855be0-b of the corrected `1855be0` breakdown.
