### PR TITLE
dsl: WorldBuilder ConstShim resolver, aggregate-qualified binding mirror (item 1855be0-c)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/world_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/world_builder.rb
@@ -13,6 +13,51 @@ module Hecksagain
         def to_h = @values
       end
 
+      # Vendored addition, not (yet) upstream hecksagain (migration plan
+      # task 4): the AGGREGATE-QUALIFIED world-binding mirror form —
+      # `Pizzas::Order.charged_by("Stripe") do ... end`, exactly the shape
+      # pizzas.world itself (the canonical example) uses to mirror its own
+      # hecksagon's bind line. Before this patch, `WorldBuilder` had no
+      # `ConstShim` resolver at all (unlike `HecksagonBuilder`/
+      # `BluebookBuilder`, which both wrap their block eval in one) — so
+      # `Pizzas` failed to resolve as a constant during a `.world` block's
+      # `instance_eval`, raising `NameError: uninitialized constant Pizzas`
+      # for EVERY world file using this form, canonical example included.
+      # Confirmed real, not theoretical: found live via miette's
+      # voice.world (`Voice::Voice.voiced_by("ElevenLabs") do ... end`).
+      #
+      # `IR::World#for_verb` / `#for_binding` key purely by verb and
+      # adapter name (`@settings["charged_by"]` / `@settings["charged_by:
+      # stripe"]`) — the aggregate qualifier is NEVER read back out, it
+      # exists only so a `.world` file visually mirrors its `.hecksagon`
+      # sibling. So the fix does not need a real per-aggregate binding
+      # object the way `BindingProxy` builds for hecksagon (which records
+      # aggregate-scoped `IR::Bind`s that a bind lookup DOES key by
+      # aggregate) — it only needs the qualified constant chain to resolve
+      # to something whose verb calls land in the SAME `@settings` write
+      # path the bare top-level form already uses. TODO upstream via
+      # bin/evolve.
+      class WorldConstProxy
+        def self.namespace(domain, builder)
+          Module.new do
+            define_singleton_method(:const_missing) { |aggregate| WorldConstProxy.new("#{domain}::#{aggregate}", builder) }
+          end
+        end
+
+        def initialize(fqn, builder)
+          @fqn     = fqn
+          @builder = builder
+        end
+
+        def method_missing(verb, *args, **kwargs, &block)
+          @builder.send(:record_binding, verb, *args, **kwargs, &block)
+          self
+        end
+
+        def respond_to_missing?(_name, _include_private = false) = true
+        def to_s = @fqn
+      end
+
       class WorldBuilder
         def initialize(domain)
           @domain   = domain
@@ -27,13 +72,7 @@ module Hecksagain
           @latest = required(value, "latest version")
         end
 
-        def method_missing(verb, *args, **kwargs, &block)
-          collector = SettingsCollector.new
-          collector.instance_eval(&block) if block
-          value = { adapter: args.first.to_s }.merge(kwargs).merge(collector.to_h)
-          @settings[verb.to_s] = value
-          @settings["#{verb}:#{args.first.to_s.downcase}"] = value
-        end
+        def method_missing(verb, *args, **kwargs, &block) = record_binding(verb, *args, **kwargs, &block)
 
         def respond_to_missing?(_name, _include_private = false) = true
 
@@ -44,9 +83,24 @@ module Hecksagain
         end
 
         def self.build(domain, &block)
-          builder = new(domain)
-          builder.instance_eval(&block) if block
+          builder  = new(domain)
+          resolver = ->(name) { WorldConstProxy.namespace(name, builder) }
+
+          ConstShim.with(resolver) { builder.instance_eval(&block) } if block
           builder.build
+        end
+
+        protected
+
+        # Shared by the bare top-level verb form (`method_missing` above)
+        # AND `WorldConstProxy` (the aggregate-qualified mirror form) — one
+        # write path, two spellings in.
+        def record_binding(verb, *args, **kwargs, &block)
+          collector = SettingsCollector.new
+          collector.instance_eval(&block) if block
+          value = { adapter: args.first.to_s }.merge(kwargs).merge(collector.to_h)
+          @settings[verb.to_s] = value
+          @settings["#{verb}:#{args.first.to_s.downcase}"] = value
         end
 
         private

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe "the DSL surface is fully covered" do
     [
       Hecksagain::Bluebook::DSL::WorldBuilder,
       Hecksagain::Bluebook::DSL::SettingsCollector,
-      Hecksagain::Bluebook::DSL::BindingProxy
+      Hecksagain::Bluebook::DSL::BindingProxy,
+      Hecksagain::Bluebook::DSL::WorldConstProxy
     ].each do |klass|
       expect(klass.public_instance_methods(false)).to include(:method_missing),
                                                       "#{klass} should answer to anything"

--- a/spec/world_builder_aggregate_qualified_growth_spec.rb
+++ b/spec/world_builder_aggregate_qualified_growth_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+
+# Real coverage for WorldBuilder's aggregate-qualified world-binding
+# mirror form: `Pizzas::Order.charged_by("Stripe") do ... end`, exactly
+# the shape the canonical pizzas.world itself uses to mirror its own
+# hecksagon's bind line. Before this fix, WorldBuilder had no ConstShim
+# resolver at all (unlike HecksagonBuilder/BluebookBuilder, which both
+# already wrap their block eval in one) -- so `Pizzas` failed to
+# resolve as a constant during a `.world` block's instance_eval,
+# raising `NameError: uninitialized constant Pizzas` for EVERY world
+# file using this form, canonical example included. Found live via
+# miette's voice.world (`Voice::Voice.voiced_by("ElevenLabs") do ...
+# end`).
+#
+# IR::World#for_verb/#for_binding key purely by verb and adapter name
+# -- the aggregate qualifier is NEVER read back out, it exists only so
+# a .world file visually mirrors its .hecksagon sibling. So the fix
+# writes into the SAME @settings path the bare top-level form already
+# uses.
+RSpec.describe "WorldBuilder aggregate-qualified binding mirror form" do
+  def in_registry
+    registry = Hecksagain::Runtime::Registry.new
+    Hecks.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      yield
+    end
+    registry
+  end
+
+  it "Domain::Aggregate.verb(...) resolves without raising NameError, exactly the pizzas.world shape" do
+    registry = in_registry do
+      Hecks.world("WorldMirrorGrowth") do
+        realm "Acme"
+        latest "v1"
+
+        WorldMirrorGrowth::Order.charged_by("Stripe") do
+          api_key "sk_test"
+        end
+      end
+    end
+
+    world = registry.world("WorldMirrorGrowth")
+    expect(world.to_h[:realm]).to eq("Acme")
+  end
+
+  it "writes into the SAME @settings path as the bare top-level verb form -- for_binding finds it" do
+    registry = in_registry do
+      Hecks.world("WorldMirrorBindingGrowth") do
+        realm "Acme"
+        latest "v1"
+
+        WorldMirrorBindingGrowth::Order.charged_by("Stripe") do
+          api_key "sk_test"
+        end
+      end
+    end
+
+    world = registry.world("WorldMirrorBindingGrowth")
+    settings = world.for_binding("charged_by", "Stripe")
+    expect(settings[:adapter]).to eq("Stripe")
+    expect(settings[:api_key]).to eq("sk_test")
+  end
+
+  it "the bare top-level form and the aggregate-qualified mirror form are interchangeable spellings" do
+    top_level_registry = in_registry do
+      Hecks.world("WorldMirrorBareGrowth") do
+        realm "Acme"
+        latest "v1"
+        charged_by("Stripe") { api_key "sk_test" }
+      end
+    end
+
+    mirror_registry = in_registry do
+      Hecks.world("WorldMirrorQualifiedGrowth") do
+        realm "Acme"
+        latest "v1"
+        WorldMirrorQualifiedGrowth::Order.charged_by("Stripe") { api_key "sk_test" }
+      end
+    end
+
+    bare = top_level_registry.world("WorldMirrorBareGrowth").for_binding("charged_by", "Stripe")
+    qualified = mirror_registry.world("WorldMirrorQualifiedGrowth").for_binding("charged_by", "Stripe")
+    expect(qualified).to eq(bare)
+  end
+end


### PR DESCRIPTION
Item `1855be0-c` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-b` (#59). Self-contained.

**What this lands**: `WorldBuilder` gains a `ConstShim` resolver so `Pizzas::Order.charged_by("Stripe") do ... end` — exactly the shape the canonical pizzas.world itself uses to mirror its own hecksagon's bind line — resolves without raising. Before this, `WorldBuilder` had no `ConstShim` resolver at all (unlike `HecksagonBuilder`/`BluebookBuilder`, which both already wrap their block eval in one), so `Pizzas` failed to resolve as a constant during a `.world` block's `instance_eval`, raising `NameError: uninitialized constant Pizzas` for EVERY world file using this form — canonical example included. Found live via miette's `voice.world`.

`IR::World#for_verb`/`#for_binding` key purely by verb and adapter name — the aggregate qualifier is never read back out, it exists only so a `.world` file visually mirrors its `.hecksagon` sibling. So `WorldConstProxy` just needs the qualified constant chain to resolve to something whose verb calls land in the SAME `@settings` write path the bare top-level form already uses (`record_binding`, extracted from the old `method_missing` body so both spellings share one write path).

**Spec coverage**: `spec/world_builder_aggregate_qualified_growth_spec.rb` — the aggregate-qualified form resolving without raising, writing into the exact same `@settings` path a `for_binding` lookup reads, and the bare top-level/aggregate-qualified spellings producing identical settings. Verified genuinely failing without this fix via `git stash` (all 3 examples: `NameError`).

**Verification**: 1360 examples, 16 failures (up from 1357/16 — identical failure SET, only the example count moved, no regressions).
