### PR TITLE
dsl: aggregate-level whole-record predicates (item 1855be0-e)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
@@ -75,6 +75,67 @@ module Hecksagain
           wrapper_name
         end
 
+        # Vendored addition, not (yet) upstream hecksagain: miette's
+        # consciousness.bluebook (and others) declare NAMED, reusable
+        # boolean predicates over the aggregate's own state --
+        # `specification :in_lucid_rem do |body| body.state == "sleeping" && ... end`
+        # -- distinct from a command's `given` (precondition) or a VO's
+        # `invariant` (field rule): a specification belongs to the
+        # AGGREGATE, named, presumably referenced elsewhere by name.
+        # Stored structurally (captured via the same canonical-source
+        # extraction `given`/`invariant` use) so the corpus boots; NOT
+        # yet threaded into IR::Aggregate or referenceable by name
+        # elsewhere -- a real, documented gap, not silently pretended
+        # complete. TODO upstream via bin/evolve (migration plan task 7).
+        attr_reader :specifications
+        def specification(name, &predicate)
+          canonical = Ports::Extraction.canonical(predicate)
+          (@specifications ||= []) << { name: name.to_s, canonical: canonical, predicate: predicate }
+        end
+
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4): an AGGREGATE-level `invariant "description" do ... end`
+        # — a whole-record rule (miette's mind/awareness/witness.bluebook:
+        # "WitnessedMoments are append-only — never updated, never
+        # deleted"), distinct from a value object's field-scoped
+        # `invariant` (ValueObjectBuilder#invariant, which this mirrors)
+        # and a command's `given` precondition. Same documented-gap shape
+        # as `specification` right above: captured structurally so the
+        # corpus boots, NOT yet threaded into IR::Aggregate or walked at
+        # dispatch time — the corpus's own comment already says as much
+        # ("once the runtime walks specifications + invariants in
+        # production... until then, the antibody at commit time scans").
+        # TODO upstream via bin/evolve (migration plan task 7).
+        attr_reader :aggregate_invariants
+        def invariant(description = "an invariant holds", &predicate)
+          canonical = Ports::Extraction.canonical(predicate)
+          (@aggregate_invariants ||= []) << { description: description, canonical: canonical, predicate: predicate }
+        end
+        # Vendored alias, not (yet) upstream hecksagain (migration plan
+        # task 8): `rule` at the AGGREGATE level too, not just inside a
+        # value_object (ValueObjectBuilder's own alias) -- bin-buddy's
+        # add_on.bluebook writes a whole-aggregate `rule` the same way
+        # macrophage.bluebook writes a whole-aggregate `invariant`.
+        alias_method :rule, :invariant
+
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): `validation :field, presence: true` -- a Rails-
+        # style field-presence declaration (pigeoncoop.bluebook, 5
+        # occurrences, always `presence: true`). Genuinely a field-level
+        # invariant in spirit ("this field must always be present"), but
+        # NOT synthesized as a real `invariant` call here : `invariant`'s
+        # predicate is canonicalized from its OWN literal source text
+        # (Ports::Extraction.canonical reads the block's actual bluebook-
+        # file location), and a dynamically-built predicate standing in
+        # for a `validation` call has no real source line to extract from
+        # -- attempting it risked a subtly wrong canonical form rather
+        # than an honest gap. Structurally captured so the file boots,
+        # not enforced -- same documented-gap pattern as `gate`/
+        # `success`/`failure` elsewhere in this migration. TODO upstream
+        # via bin/evolve (migration plan task 7): a real field-presence
+        # sugar, not a one-off stub.
+        def validation(*) = nil
+
         # ORIGIN, not runtime identity — a concept adopted from a canonical
         # source (§28) names where it came from without that fact ever
         # touching `hecks_fqn`/dispatch. Captured raw, the same way

--- a/spec/aggregate_level_predicates_growth_spec.rb
+++ b/spec/aggregate_level_predicates_growth_spec.rb
@@ -1,0 +1,145 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for AggregateBuilder's whole-record predicate surface:
+#
+#   specification :in_lucid_rem do |body| body.state == "sleeping" end
+#   invariant "append-only" do |record| record.retracted_at.nil? end
+#   rule "..." do ... end          # alias for invariant, at the AGGREGATE level
+#   validation :field, presence: true
+#
+# `specification` (a NAMED, reusable boolean predicate) and `invariant`/
+# `rule` (a whole-record rule, mirroring ValueObjectBuilder's own
+# field-scoped invariant) are captured structurally so the file boots
+# -- NOT yet threaded into IR::Aggregate or walked at dispatch time, a
+# real documented gap. `validation` is a deliberate no-op stub: unlike
+# invariant/specification, its predicate is not built from real literal
+# source text, so canonicalizing it risked a subtly wrong form rather
+# than an honest gap.
+#
+# `Ports::Extraction.canonical` (the mechanism both `specification` and
+# `invariant` use to capture their own literal source text) only
+# resolves DURING a real bluebook load -- so this spec boots a real
+# bluebook rather than driving AggregateBuilder standalone.
+RSpec.describe "AggregateBuilder whole-record predicates" do
+  def boot(source, hecksagon_name)
+    file = Tempfile.new(["aggregate-level-predicates-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name) { }
+    end
+    registry
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  def aggregate_builder_for(source, hecksagon_name, aggregate_name)
+    captured = nil
+    original_build = Hecksagain::Bluebook::DSL::AggregateBuilder.method(:build)
+    Hecksagain::Bluebook::DSL::AggregateBuilder.define_singleton_method(:build) do |name, inline = nil, &block|
+      builder = new(name)
+      builder.description(inline) if inline
+      builder.instance_eval(&block) if block
+      captured = builder if name == aggregate_name
+      builder.build
+    end
+
+    boot(source, hecksagon_name)
+    captured
+  ensure
+    Hecksagain::Bluebook::DSL::AggregateBuilder.define_singleton_method(:build, original_build)
+  end
+
+  SPEC_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "AggregatePredicatesGrowth" do
+      aggregate "Sleeper" do
+        identified_by { sleeper_id.value }
+
+        value_object "SleeperId" do
+          attribute :value, String
+        end
+
+        attribute :sleeper_id, SleeperId
+        attribute :state, String
+
+        specification(:in_lucid_rem) { |body| body.state == "sleeping" }
+        invariant("append-only — never updated, never deleted") { |record| true }
+        rule("a rule holds too") { |record| true }
+        validation :state, presence: true
+
+        command "Sleep" do
+          attribute :sleeper_id, SleeperId
+          emits "SleeperSlept"
+        end
+      end
+    end
+  BLUEBOOK
+
+  it "specification captures a named predicate with its own canonical source text" do
+    builder = aggregate_builder_for(SPEC_SOURCE, "AggregatePredicatesGrowth", "Sleeper")
+
+    expect(builder.specifications.size).to eq(1)
+    spec = builder.specifications.first
+    expect(spec[:name]).to eq("in_lucid_rem")
+    expect(spec[:canonical]).to be_a(String)
+    expect(spec[:canonical]).not_to be_empty
+    expect(spec[:predicate]).to be_a(Proc)
+  end
+
+  it "invariant captures a whole-record rule, distinct from a value object's field-scoped invariant" do
+    builder = aggregate_builder_for(SPEC_SOURCE, "AggregatePredicatesGrowth", "Sleeper")
+
+    # Both `invariant("...")` and its `rule("...")` alias landed here --
+    # two entries in the SAME list, one shared method under two names.
+    expect(builder.aggregate_invariants.size).to eq(2)
+    descriptions = builder.aggregate_invariants.map { |r| r[:description] }
+    expect(descriptions).to eq(["append-only — never updated, never deleted", "a rule holds too"])
+    expect(builder.aggregate_invariants.first[:canonical]).not_to be_empty
+  end
+
+  it "invariant defaults its description when none is given" do
+    source = <<~BLUEBOOK
+      Hecks.bluebook "AggregatePredicatesDefaultGrowth" do
+        aggregate "DefaultDescribed" do
+          identified_by { id.value }
+          value_object "DefaultDescribedId" do
+            attribute :value, String
+          end
+          attribute :id, DefaultDescribedId
+
+          invariant { |record| true }
+
+          command "Touch" do
+            attribute :id, DefaultDescribedId
+            emits "Touched"
+          end
+        end
+      end
+    BLUEBOOK
+
+    builder = aggregate_builder_for(source, "AggregatePredicatesDefaultGrowth", "DefaultDescribed")
+    expect(builder.aggregate_invariants.first[:description]).to eq("an invariant holds")
+  end
+
+  it "validation is a documented no-op stub -- the file boots, nothing is stored or enforced" do
+    expect { boot(SPEC_SOURCE, "AggregatePredicatesGrowth") }.not_to raise_error
+  end
+
+  it "specifications and invariants are NOT yet threaded into IR::Aggregate (documented gap, not silently faked)" do
+    registry = boot(SPEC_SOURCE, "AggregatePredicatesGrowth")
+    aggregate = registry.bluebook("AggregatePredicatesGrowth").aggregate("Sleeper")
+
+    expect(aggregate).not_to respond_to(:specifications)
+    expect(aggregate).not_to respond_to(:aggregate_invariants)
+  end
+end

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "the DSL surface is fully covered" do
     "AggregateBuilder" => [
       Hecksagain::Bluebook::DSL::AggregateBuilder,
       %i[description provenance identified_by reference_to has_many has_one belongs_to value_object command lifecycle
-         entity query policy attribute list_of attributes synthesise_primitive_wrapper]
+         entity query policy attribute list_of attributes synthesise_primitive_wrapper
+         specification specifications invariant rule validation aggregate_invariants]
     ],
     "ValueObjectBuilder" => [
       Hecksagain::Bluebook::DSL::ValueObjectBuilder,


### PR DESCRIPTION
Item `1855be0-e` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-c` (#60).

**What this lands**: aggregate-level whole-record predicates — a family that didn't exist at all before this, three surface spellings:

- `specification :name do |record| ... end` — a NAMED, reusable boolean predicate over the aggregate's own state (miette's `consciousness.bluebook`), distinct from a command's `given` or a VO's `invariant`.
- `invariant "description" do |record| ... end` — a whole-record rule (miette's `witness.bluebook`: "WitnessedMoments are append-only"), mirroring `ValueObjectBuilder`'s own field-scoped `invariant`. `rule` is its alias at the aggregate level too.
- `validation :field, presence: true` — a Rails-style field-presence declaration, deliberately a NO-OP stub (not synthesized into a real `invariant`, since its predicate has no real literal source line to canonicalize from — attempting it risked a subtly wrong canonical form).

All three captured structurally so the file boots — **NOT yet threaded into `IR::Aggregate`** or walked at dispatch time, matching the corpus's own comment about this being a documented, deferred gap.

**Spec coverage**: `spec/aggregate_level_predicates_growth_spec.rb` — a real bluebook boot exercising all four spellings: `specification`'s own canonical text + predicate, `invariant`'s default description, `invariant`/`rule` sharing one list under two names, `validation`'s no-op boot, and the honest "not threaded into IR::Aggregate" gap. Verified genuinely failing without this fix via `git stash` (5/5 examples, `NoMethodError`).

**Verification**: 1365 examples, 16 failures (up from 1360/16, identical failure set, no regressions).
