### PR TITLE
dsl: CommandBuilder#role structured form, role Role as: Agent (item 1855be0-f)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/command_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/command_builder.rb
@@ -33,13 +33,54 @@ module Hecksagain
         # otherwise silently win while the first still looked declared,
         # exactly the failure mode `reference_to`'s own duplicate guard
         # (below) already exists to prevent for a command's root.
-        def role(value)
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4, i483): `role Role, as: Agent` -- a STRUCTURED role
+        # declaration, deliberate and documented (framework/agent/bluebook/
+        # role.bluebook's own vision: "Role is the type ; Agent is the
+        # role-bearer... reads as 'this command runs in the role of Role,
+        # and the role-bearer is referenced as Agent in the command's
+        # attribute scope'. Same type-plus-alias pattern as `attribute
+        # Role, as: :role`.") -- confirmed real by reading role.bluebook in
+        # full, NOT a mistake (an earlier pass in this same migration
+        # wrongly downgraded one occurrence to a bare string before this
+        # was understood; caught and reverted -- see dispatch_audit.
+        # bluebook's own comments for which occurrence that was and why
+        # THAT one specific command genuinely doesn't need a bearer).
+        #
+        # Synthesises a reference_to the role-bearer type (`as: Agent` ->
+        # an `agent` attribute referencing Agent, via CommandBuilder's own
+        # `reference_to`) and keeps `@role` set to the role TYPE's own
+        # name as a string, so existing string-role authorization code
+        # (Runtime.as_caller(role:)) still has something to compare
+        # against. Extra kwargs (`kind:`, seen in the corpus) are recorded
+        # but NOT enforced -- role.bluebook itself calls this "the first
+        # chapter," a documented gap, not silently pretended complete.
+        # TODO upstream via bin/evolve (migration plan task 7).
+        def role(value, as: nil, **extra)
           raise Malformed,
                 "#{@name} declares role twice — a command carries ONE " \
                 "responsibility; the second would silently win and the " \
                 "first would still look declared" if @role
 
-          @role = value
+          if as
+            # NOT `reference_to` (revised after the first attempt hit
+            # exactly the single-domain wall documented on
+            # conductor/lease.bluebook and demo.bluebook): Agent is a
+            # framework-wide concept referenced from MANY different
+            # domains' commands, so a structural reference back to it
+            # would fail from every domain except Agent's own. A plain
+            # opaque identity field is the same cross-domain convention
+            # already established there -- bare String is fine HERE
+            # because the "primitives live in value objects only" rule
+            # (Part 3a) targets an AGGREGATE's own PERSISTED schema; a
+            # command's ephemeral input isn't that.
+            bearer = Naming.demodulise(as)
+            attribute(Naming.snake(bearer).to_sym, String)
+            @role_kind = extra[:kind]
+            @role = Naming.demodulise(value).to_s
+          else
+            @role = value
+          end
         end
 
         def goal(value) = @goal = value

--- a/spec/command_role_as_agent_growth_spec.rb
+++ b/spec/command_role_as_agent_growth_spec.rb
@@ -1,0 +1,126 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for CommandBuilder#role's STRUCTURED form: `role Role,
+# as: Agent` (i483) -- role.bluebook's own vision: "Role is the type ;
+# Agent is the role-bearer... reads as 'this command runs in the role
+# of Role, and the role-bearer is referenced as Agent in the command's
+# attribute scope'."
+#
+# Synthesises a reference_to the role-bearer type (`as: Agent` -> an
+# `agent` attribute, a bare opaque-identity String, deliberately NOT a
+# real `reference_to` -- Agent is referenced cross-domain from many
+# different domains' commands, and a structural reference back to it
+# fails from every domain except Agent's own) and keeps `@role` as the
+# role TYPE's own name so existing string-role authorization code still
+# has something to compare against. Extra kwargs (`kind:`) are recorded
+# but not enforced.
+RSpec.describe "CommandBuilder role Role, as: Agent" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["command-role-as-agent-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  STRUCTURED_ROLE_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "CommandRoleAsAgentGrowth" do
+      aggregate "Task" do
+        identified_by { task_id.value }
+
+        value_object "TaskId" do
+          attribute :value, String
+        end
+
+        attribute :task_id, TaskId
+
+        command "Create" do
+          attribute :task_id, TaskId
+          emits "TaskCreated"
+        end
+
+        command "Claim" do
+          reference_to Task
+          role Role, as: Agent, kind: "worker"
+          emits "TaskClaimed"
+        end
+      end
+    end
+  BLUEBOOK
+
+  def repository_for(runtime)
+    bluebook = runtime.registry.bluebook("CommandRoleAsAgentGrowth")
+    aggregate = bluebook.aggregate("Task")
+    runtime.registry.repository("CommandRoleAsAgentGrowth", aggregate)
+  end
+
+  def boot_structured_role
+    boot(STRUCTURED_ROLE_SOURCE, "CommandRoleAsAgentGrowth") do
+      ::CommandRoleAsAgentGrowth::Task.persisted_by("Memory")
+    end
+  end
+
+  it "synthesises a bearer attribute (agent) rather than a structural reference_to" do
+    runtime = boot_structured_role
+    task = runtime.registry.bluebook("CommandRoleAsAgentGrowth").aggregate("Task")
+    claim = task.command("Claim")
+
+    field = claim.attributes.find { |a| a.name == :agent }
+    expect(field).not_to be_nil
+    expect(field.type.to_s).to eq("String")
+  end
+
+  it "keeps @role set to the role TYPE's own name, for existing string-role authorization code" do
+    runtime = boot_structured_role
+    task = runtime.registry.bluebook("CommandRoleAsAgentGrowth").aggregate("Task")
+    claim = task.command("Claim")
+
+    expect(claim.role).to eq("Role")
+  end
+
+  it "dispatches a real command carrying the bearer attribute" do
+    runtime = boot_structured_role
+    runtime.dispatch("CommandRoleAsAgentGrowth::Task.Create", task_id: { value: "t1" })
+
+    expect do
+      runtime.dispatch("CommandRoleAsAgentGrowth::Task.Claim",
+                        task_id: { value: "t1" }, agent: "agent-42")
+    end.not_to raise_error
+  end
+
+  it "role declared twice still raises, structured or not" do
+    expect do
+      Hecksagain::Bluebook::DSL::CommandBuilder.build("DoubleRole", owner: "Task") do
+        role "Creator"
+        role "Creator", as: "SomethingElse"
+      end
+    end.to raise_error(Hecksagain::Bluebook::DSL::Malformed, /declares role twice/)
+  end
+
+  it "the plain string form (no as:) still works exactly as before" do
+    command = Hecksagain::Bluebook::DSL::CommandBuilder.build("PlainRole", owner: "Task") do
+      role "Creator"
+    end
+    expect(command.role).to eq("Creator")
+  end
+end


### PR DESCRIPTION
Item `1855be0-f` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-e` (#61). Retracts an earlier premature "withdrawn" note on this item — it's real.

**What this lands**: `role Role, as: Agent` — a STRUCTURED role declaration (i483). `role.bluebook`'s own vision: "Role is the type ; Agent is the role-bearer... reads as 'this command runs in the role of Role, and the role-bearer is referenced as Agent in the command's attribute scope'." Confirmed real by reading `role.bluebook` in full.

Synthesises a `reference_to`-SHAPED bearer attribute (`as: Agent` → an `agent` attribute), deliberately NOT a real `reference_to` — Agent is referenced cross-domain from many different domains' commands, and a structural reference back to it fails from every domain except Agent's own. A plain opaque-identity String is the same cross-domain convention already established elsewhere.

Keeps `@role` set to the role TYPE's own name as a string, so existing string-role authorization code still has something to compare against. Extra kwargs (`kind:`) are recorded but not enforced — a documented gap.

**Spec coverage**: `spec/command_role_as_agent_growth_spec.rb` — a real dispatch carrying the synthesised bearer attribute, `@role`'s own value, the double-role guard still firing on the structured form, and the plain-string form's own unchanged behavior. Verified genuinely failing without this fix via `git stash` (4/5 examples; the 5th, plain-string role, correctly passes either way since that path is unchanged).

**Verification**: 1370 examples, 16 failures (up from 1365/16, identical failure set, no regressions).
