### PR TITLE
dsl: CommandBuilder#redirects_native DSL builder (item 1855be0-m)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/command_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/command_builder.rb
@@ -255,6 +255,13 @@ module Hecksagain
           @emits << event_name.to_s
         end
 
+        # Vendored addition, not (yet) upstream hecksagain -- see
+        # IR::Command's own comment on this field. `redirects_native "Bash"`
+        # or `redirects_native "Edit", "MultiEdit", "NotebookEdit"`.
+        def redirects_native(*tools)
+          @redirects_native = tools.map(&:to_s)
+        end
+
         def build
           IR::Command.declare(
             name:       @name,
@@ -266,7 +273,8 @@ module Hecksagain
             mutations:  @mutations,
             emits:      @emits,
             references: @references,
-            provenance: @provenance
+            provenance: @provenance,
+            redirects_native: @redirects_native || []
           )
         end
 

--- a/spec/command_redirects_native_builder_growth_spec.rb
+++ b/spec/command_redirects_native_builder_growth_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+# Real coverage for CommandBuilder#redirects_native -- the DSL BUILDER
+# half of the `redirects_native` construct. The IR/contracts/self-hosted
+# -grammar side already landed (split-plan item 05, PR #22); nothing
+# could actually CALL `redirects_native "Read"` from a real `.bluebook`
+# file until THIS lands.
+#
+# Honest scope note: landing this alone does not yet close
+# `plan_spec.rb`/`plurality_coverage_spec.rb`/`judge_coverage_spec.rb`'s
+# own `redirects_native` gaps for real -- those also need a corpus
+# fixture actually USING the construct (banking.bluebook's
+# `redirects_native "ComplianceHold"` line), which is separate, later
+# migration content, not this DSL builder method.
+RSpec.describe "CommandBuilder#redirects_native" do
+  it "captures a single tool name" do
+    command = Hecksagain::Bluebook::DSL::CommandBuilder.build("SingleTool", owner: "Thing") do
+      redirects_native "Bash"
+      emits "Done"
+    end
+
+    expect(command.redirects_native).to eq(["Bash"])
+  end
+
+  it "captures multiple tool names in one call" do
+    command = Hecksagain::Bluebook::DSL::CommandBuilder.build("MultiTool", owner: "Thing") do
+      redirects_native "Edit", "MultiEdit", "NotebookEdit"
+      emits "Done"
+    end
+
+    expect(command.redirects_native).to eq(%w[Edit MultiEdit NotebookEdit])
+  end
+
+  it "defaults to an empty list when never called -- no behavior change for every other command" do
+    command = Hecksagain::Bluebook::DSL::CommandBuilder.build("NoRedirect", owner: "Thing") do
+      emits "Done"
+    end
+
+    expect(command.redirects_native).to eq([])
+  end
+end

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "the DSL surface is fully covered" do
     ],
     "CommandBuilder" => [
       Hecksagain::Bluebook::DSL::CommandBuilder,
-      %i[role goal provenance reference_to given ensures then_set sets emits attribute list_of attributes]
+      %i[role goal provenance reference_to given ensures then_set sets emits attribute list_of attributes
+         redirects_native]
     ],
     "PortBuilder" => [
       Hecksagain::Bluebook::DSL::PortBuilder,


### PR DESCRIPTION
Item `1855be0-m` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-f` (#64). Not in the original plan — found on real-diff read.

**What this lands**: `CommandBuilder#redirects_native(*tools)` — the DSL BUILDER half of item 05's `redirects_native` construct (that item only landed the IR/contracts/self-hosted-grammar side; nothing could actually CALL `redirects_native "Read"` from a real `.bluebook` file until this lands).

**Honest scope note**, predicted at item 05's own PR body: landing this alone does not yet close `plan_spec.rb`/`plurality_coverage_spec.rb`/`judge_coverage_spec.rb`'s own `redirects_native` gaps for real — those also need a corpus fixture actually using it (banking.bluebook's `redirects_native "ComplianceHold"` line, later migration content, not this commit). Noting that explicitly here rather than over-claiming.

**Spec coverage**: `spec/command_redirects_native_builder_growth_spec.rb` — single tool name, multiple tool names in one call, and the empty-list default for every command that never calls it. Verified genuinely failing without this fix via `git stash` (2/3 examples).

**Verification**: 1373 examples, 17 failures (up from 1370/16) — the one new failure is the expected, documented `syntax_conformance_spec.rb` gap for CommandBuilder's new methods (closed later by item 35), not a regression.
