### PR TITLE
dsl: CommandBuilder#given default description + named-condition guards (item 1855be0-n)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/command_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/command_builder.rb
@@ -126,7 +126,49 @@ module Hecksagain
 
         public
 
-        def given(description, &predicate)
+        # Vendored default, not (yet) upstream hecksagain: hecks_nursury
+        # (375 files) writes bare `given { predicate }` with no
+        # description string -- hecksagain requires one. Given a
+        # generic fallback rather than requiring a corpus-wide text
+        # change across every nursery domain. TODO upstream via
+        # bin/evolve (migration plan task 7).
+        # Vendored guard, not (yet) upstream hecksagain (migration plan
+        # task 8): `requires "SoldOut" => false` (pigeoncoop.bluebook) --
+        # `requires`/`expects`, aliased to `given` elsewhere in this
+        # file, called with NO block at all (Ruby folds the trailing
+        # `key => value` into a single Hash positional argument, landing
+        # in `description`). `Ports::Extraction.canonical(nil)` crashed
+        # on `nil.source_location` -- a real, distinct DSL shape (a
+        # NAMED-CONDITION-EQUALS-VALUE guard, not a full predicate block)
+        # this session doesn't have real semantics for. Guarded so the
+        # file boots ; the guard is recorded as metadata only, never
+        # evaluated -- a documented gap, not silently pretended
+        # equivalent to a real given. TODO upstream via bin/evolve
+        # (migration plan task 7): a real design pass on what this shape
+        # means.
+        #
+        # `given :field, not_in: :other_field` -- vendored addition,
+        # not (yet) upstream hecksagain (migration plan task 8): a
+        # SECOND named-condition-guard shape (hecks_nursury's
+        # verbs.bluebook, `given :verb, not_in: :known_verbs`) --
+        # `:field` as the first positional instead of a description
+        # string, PLUS a trailing keyword-shaped hash Ruby folds into a
+        # SECOND positional (no `**kwargs` in this signature) -- two
+        # positionals, still no block, `ArgumentError` before reaching
+        # this guard at all until `condition` was added below. Same
+        # family, same treatment as the `requires "X" => false` guard
+        # just above : recorded as metadata only (folded into the
+        # description text), never evaluated. TODO upstream via
+        # bin/evolve (migration plan task 7), alongside the guard above
+        # -- one real design pass should cover both named-condition
+        # shapes at once.
+        def given(description = "a rule holds", condition = nil, &predicate)
+          unless predicate
+            text = condition ? "#{description.inspect} #{condition.inspect}" : description.inspect
+            @givens << IR::Given.new(description: text, canonical: "true", predicate: nil)
+            return
+          end
+
           canonical = Ports::Extraction.canonical(predicate)
 
           # moved to the language: given "a rule says what it means", on Verb.Rule

--- a/spec/command_given_guard_shapes_growth_spec.rb
+++ b/spec/command_given_guard_shapes_growth_spec.rb
@@ -1,0 +1,130 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for CommandBuilder#given's own real gaps:
+#
+# 1. A default description -- hecks_nursury (375 files) writes bare
+#    `given { predicate }` with no description string; hecksagain used
+#    to require one.
+# 2. Two named-condition-guard shapes, called with NO block at all:
+#    `requires "SoldOut" => false` (Ruby folds the trailing `key =>
+#    value` into a single Hash positional, landing in `description`)
+#    and `given :field, not_in: :other_field` (`:field` as the first
+#    positional, a trailing keyword-shaped hash folded into a SECOND
+#    positional). Neither has real predicate semantics yet -- both are
+#    recorded as metadata only (folded into the description text),
+#    never evaluated. A documented gap, not silently pretended
+#    equivalent to a real `given`.
+#
+# `requires`/`expects` are aliases of `given` landed separately (item
+# 1855be0-g's catch-all); this spec exercises the guard shapes through
+# `given` itself, which is the real method underneath either name.
+#
+# `Ports::Extraction.canonical` (the mechanism a real predicate block
+# uses to capture its own literal source text) only resolves DURING a
+# real bluebook load -- so the real-predicate examples boot an actual
+# bluebook rather than driving CommandBuilder standalone. The two
+# no-block guard shapes don't touch extraction at all and can be
+# tested at the builder level directly.
+RSpec.describe "CommandBuilder#given's default description and named-condition guards" do
+  def boot(source, hecksagon_name)
+    file = Tempfile.new(["command-given-guard-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name) { }
+    end
+    registry
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  def command_for(source, hecksagon_name, command_name)
+    boot(source, hecksagon_name)
+      .bluebook(hecksagon_name)
+      .aggregate("Thing")
+      .command(command_name)
+  end
+
+  BARE_GIVEN_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "CommandGivenGuardGrowth" do
+      aggregate "Thing" do
+        identified_by { id.value }
+        value_object "ThingId" do
+          attribute :value, String
+        end
+        attribute :id, ThingId
+
+        command "BareGiven" do
+          given { true }
+          emits "Done"
+        end
+
+        command "DescribedGiven" do
+          given("stock remains") { true }
+          emits "Done"
+        end
+      end
+    end
+  BLUEBOOK
+
+  it "given { predicate } with no description defaults to a generic one" do
+    command = command_for(BARE_GIVEN_SOURCE, "CommandGivenGuardGrowth", "BareGiven")
+
+    expect(command.givens.size).to eq(1)
+    expect(command.givens.first.description).to eq("a rule holds")
+    expect(command.givens.first.canonical).not_to be_empty
+  end
+
+  it "an explicit description still wins over the default" do
+    command = command_for(BARE_GIVEN_SOURCE, "CommandGivenGuardGrowth", "DescribedGiven")
+    expect(command.givens.first.description).to eq("stock remains")
+  end
+
+  def build_command(name, &block)
+    Hecksagain::Bluebook::DSL::CommandBuilder.build(name, owner: "Thing") do
+      instance_eval(&block) if block
+      emits "Done"
+    end
+  end
+
+  it "requires 'X' => false (a Hash positional, no block) is captured as metadata, never evaluated" do
+    command = nil
+    expect do
+      command = build_command("HashGuardGiven") do
+        given "SoldOut" => false
+      end
+    end.not_to raise_error
+
+    expect(command.givens.size).to eq(1)
+    guard = command.givens.first
+    expect(guard.canonical).to eq("true")
+    expect(guard.predicate).to be_nil
+    expect(guard.description).to include("SoldOut")
+    expect(guard.description).to include("false")
+  end
+
+  it "given :field, not_in: :other_field (two positionals, no block) is captured as metadata, never evaluated" do
+    command = nil
+    expect do
+      command = build_command("FieldGuardGiven") do
+        given :verb, not_in: :known_verbs
+      end
+    end.not_to raise_error
+
+    guard = command.givens.first
+    expect(guard.canonical).to eq("true")
+    expect(guard.predicate).to be_nil
+    expect(guard.description).to include("verb")
+    expect(guard.description).to include("known_verbs")
+  end
+end


### PR DESCRIPTION
Item `1855be0-n` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-m` (#67). Not in the original plan — found on real-diff read.

**What this lands** — real gaps, one method, three pieces:

1. A default description — `given { predicate }` with no description string (375 files in hecks_nursury); hecksagain required one.
2. `requires "SoldOut" => false` — called with NO block at all (Ruby folds the trailing `key => value` into a single Hash positional). `Ports::Extraction.canonical(nil)` crashed on `nil.source_location` before this fix.
3. `given :field, not_in: :other_field` — a SECOND named-condition-guard shape: `:field` as the first positional, plus a trailing keyword-shaped hash folded into a second positional — `ArgumentError` before reaching the method body at all until `condition` was added to the signature.

Both guard shapes are a real, distinct DSL construct this session doesn't have real semantics for — recorded as metadata only (folded into the description text), never evaluated. A documented gap.

**Spec coverage**: `spec/command_given_guard_shapes_growth_spec.rb` — default description (and an explicit one still winning), both guard shapes captured without raising and without a real predicate, their descriptions carrying the guard's own field/value text. Verified genuinely failing without this fix via `git stash` (4/4 examples).

**Verification**: 1377 examples, 17 failures (up from 1373/17, identical failure set, no regressions).
