### PR TITLE
dsl: EntityBuilder reference_to optional:, the only syntax.bluebook hunk (item 1855be0-h)

### DIFF
--- a/docs/reference/entity.md
+++ b/docs/reference/entity.md
@@ -90,12 +90,13 @@ Declares a field on the entity, scalar or value object — same word, same modif
 ## reference_to
 
 <!-- generated:begin word=reference_to -->
-`reference_to type, as:` — fills `attributes`
+`reference_to type, as:, optional:` — fills `attributes`
 
 | argument | kind | required | fills |
 |---|---|---|---|
 | positional 1 | constant | true | type |
 | `as:` | symbol | false | name |
+| `optional:` | flag | false | optional |
 <!-- generated:end -->
 
 Points an entity at a real ROOT, the same way an aggregate's own `reference_to` does — a `Card` entity's own `assignee_id`, pointing at a `Team`. Never at another entity: there's no cross-piece addressing anywhere in this language to resolve one against, so this only ever reaches a head.

--- a/lib/hecksagain/bluebook/dsl/entity_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/entity_builder.rb
@@ -13,16 +13,6 @@ module Hecksagain
 
         def description(value) = @description = value
 
-        # THE SAME FIELD AggregateBuilder's OWN reference_to BUILDS — a
-        # piece can hold a reference to another root exactly the way its
-        # own head can (Card.assignee_id, a Team's own id), just never
-        # to another PIECE, since there's no cross-piece addressing
-        # anywhere in this language to resolve one against.
-        def reference_to(type, as: nil)
-          target = Naming.demodulise(type)
-          attribute(as || :"#{Naming.snake(target)}_id", IR::Reference.new(target))
-        end
-
         # A PIECE is known by a field, not by a whole value object.
         # `identified_by { sequence.value }` names the SCALAR inside it, which
         # is what an id actually is — a LedgerEntry is entry 3, not entry
@@ -54,6 +44,24 @@ module Hecksagain
           raise Malformed, "#{@name}.identified_by names no field" if paths.empty?
 
           @identity_paths = paths
+        end
+
+        # THE SAME FIELD AggregateBuilder's OWN reference_to BUILDS — a
+        # piece can hold a reference to another root exactly the way its
+        # own head can (Card.assignee_id, a Team's own id), just never
+        # to another PIECE, since there's no cross-piece addressing
+        # anywhere in this language to resolve one against. `optional:`
+        # exists here too — a piece free to point at one of several
+        # possible targets, never more than one at a time, same as an
+        # aggregate's own sibling `reference_to` calls. Does NOT
+        # register the target in the owning aggregate's own
+        # `reference_targets` (the bidirectional-relationship list
+        # `bluebook_builder.rb` builds for docs) — `IR::Entity` has no
+        # such reader to populate. A real, small, deliberately deferred
+        # gap; nothing about dispatch, hydration, or querying needs it.
+        def reference_to(type, as: nil, optional: false)
+          target = Naming.demodulise(type)
+          attribute(as || :"#{Naming.snake(target)}_id", IR::Reference.new(target), optional: optional)
         end
 
         def command(name, &block)

--- a/lib/hecksagain/language/bluebook/syntax.bluebook
+++ b/lib/hecksagain/language/bluebook/syntax.bluebook
@@ -633,6 +633,11 @@ Hecks.bluebook "Bluebook" do
         member keyword: "attribute",       context: "Entity", at: "",  named: "admits",   kind: "text",     required: "false", fills: "admits"
         member keyword: "reference_to",    context: "Entity", at: "1", named: "",         kind: "constant", required: "true",  fills: "type"
         member keyword: "reference_to",    context: "Entity", at: "",  named: "as",       kind: "symbol",   required: "false", fills: "name"
+        # THE SAME THIRD ARGUMENT an aggregate's own `reference_to` takes —
+        # a piece free to point at one of several possible targets, never
+        # more than one at a time, same as an aggregate's own sibling
+        # `reference_to` calls.
+        member keyword: "reference_to",    context: "Entity", at: "",  named: "optional", kind: "flag",     required: "false", fills: "optional"
 
         member keyword: "role",            context: "Command", at: "1", named: "",          kind: "text",     required: "true",  fills: "role"
         member keyword: "goal",            context: "Command", at: "1", named: "",          kind: "text",     required: "true",  fills: "goal"

--- a/rust/parser/src/keywords.rs
+++ b/rust/parser/src/keywords.rs
@@ -203,6 +203,7 @@ pub static ARGUMENTS: &[ArgumentRow] = &[
     ArgumentRow { keyword: "attribute", context: "Entity", at: "", named: "admits", kind: "text", required: "false", fills: "admits", selects: "", pair_key_fills: "", pair_value_fills: "", pairs_shape: "", status: "" },
     ArgumentRow { keyword: "reference_to", context: "Entity", at: "1", named: "", kind: "constant", required: "true", fills: "type", selects: "", pair_key_fills: "", pair_value_fills: "", pairs_shape: "", status: "" },
     ArgumentRow { keyword: "reference_to", context: "Entity", at: "", named: "as", kind: "symbol", required: "false", fills: "name", selects: "", pair_key_fills: "", pair_value_fills: "", pairs_shape: "", status: "" },
+    ArgumentRow { keyword: "reference_to", context: "Entity", at: "", named: "optional", kind: "flag", required: "false", fills: "optional", selects: "", pair_key_fills: "", pair_value_fills: "", pairs_shape: "", status: "" },
     ArgumentRow { keyword: "role", context: "Command", at: "1", named: "", kind: "text", required: "true", fills: "role", selects: "", pair_key_fills: "", pair_value_fills: "", pairs_shape: "", status: "" },
     ArgumentRow { keyword: "goal", context: "Command", at: "1", named: "", kind: "text", required: "true", fills: "goal", selects: "", pair_key_fills: "", pair_value_fills: "", pairs_shape: "", status: "" },
     ArgumentRow { keyword: "provenance", context: "Command", at: "", named: "from", kind: "literal", required: "true", fills: "provenance", selects: "", pair_key_fills: "", pair_value_fills: "", pairs_shape: "", status: "" },

--- a/spec/entity_reference_to_optional_growth_spec.rb
+++ b/spec/entity_reference_to_optional_growth_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+# Real coverage for EntityBuilder#reference_to's new `optional:` kwarg —
+# the same third argument an aggregate's own `reference_to` already
+# takes: a piece free to point at one of several possible targets,
+# never more than one at a time. Does NOT register the target in the
+# owning aggregate's own `reference_targets` (the bidirectional-
+# relationship list `bluebook_builder.rb` builds for docs) — `IR::Entity`
+# has no such reader to populate. A real, small, deliberately deferred
+# gap; nothing about dispatch, hydration, or querying needs it.
+RSpec.describe "EntityBuilder#reference_to optional:" do
+  def build_entity(name, &block)
+    Hecksagain::Bluebook::DSL::EntityBuilder.build(name) do
+      instance_eval(&block) if block
+    end
+  end
+
+  it "defaults to required (optional: false) exactly as before" do
+    entity = build_entity("Card") { reference_to "Team" }
+
+    field = entity.attribute(:team_id)
+    expect(field).not_to be_nil
+    expect(field.optional?).to be(false)
+  end
+
+  it "optional: true marks the reference field optional, same as an aggregate's own reference_to" do
+    entity = build_entity("Card") { reference_to "Team", optional: true }
+
+    field = entity.attribute(:team_id)
+    expect(field.optional?).to be(true)
+  end
+
+  it "optional: still composes with as:" do
+    entity = build_entity("Card") { reference_to "Team", as: :assigned_team, optional: true }
+
+    field = entity.attribute(:assigned_team)
+    expect(field).not_to be_nil
+    expect(field.optional?).to be(true)
+  end
+
+  it "the reference field is still a real IR::Reference, unaffected by optional:" do
+    entity = build_entity("Card") { reference_to "Team", optional: true }
+    field_type = entity.attribute(:team_id).type
+    expect(field_type).to be_a(Hecksagain::Bluebook::IR::Reference)
+    expect(field_type.target_name).to eq("Team")
+  end
+end

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -12388,6 +12388,36 @@
             [
               [
                 "keyword",
+                "reference_to"
+              ],
+              [
+                "context",
+                "Entity"
+              ],
+              [
+                "at",
+                ""
+              ],
+              [
+                "named",
+                "optional"
+              ],
+              [
+                "kind",
+                "flag"
+              ],
+              [
+                "required",
+                "false"
+              ],
+              [
+                "fills",
+                "optional"
+              ]
+            ],
+            [
+              [
+                "keyword",
                 "role"
               ],
               [


### PR DESCRIPTION
Item `1855be0-h` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-n` (#68). The ONLY `syntax.bluebook` hunk in the entire `1855be0` commit (confirmed on real-diff read — the driving-adapter grammar's own claimed contribution to that file was checked and found absent).

**What this lands**: `reference_to type, as:, optional:` — the same third argument an aggregate's own `reference_to` already takes. Does NOT register the target in the owning aggregate's own `reference_targets` (the bidirectional-relationship list `bluebook_builder.rb` builds for docs) — `IR::Entity` has no such reader to populate. A small, deliberately deferred gap; nothing about dispatch, hydration, or querying needs it.

Includes the real self-hosted-grammar registration and its three downstream regenerated artifacts: `bin/reference` (docs/reference/entity.md), `bin/project_parser_table` (rust/parser/src/keywords.rs), and `GOLDEN=rewrite bundle exec rspec spec/ir_golden_spec.rb` (spec/golden/ir/Bluebook.json — the self-hosted grammar's own frozen IR, since syntax.bluebook parses itself).

**Spec coverage**: `spec/entity_reference_to_optional_growth_spec.rb` — defaults to required, `optional: true` marking the field optional, composing with `as:`, and the reference type itself unaffected. Verified genuinely failing without this fix via `git stash` (3/4 examples).

**Verification**: 1381 examples, 17 failures (up from 1377/17, identical failure set — confirmed after regenerating the three golden artifacts, which briefly added 3 more failures before regen, not real regressions).
