### PR TITLE
dsl: BindingProxy Aggregate.event_sourced marker verb (item 1855be0-i)

### DIFF
--- a/lib/hecksagain/bluebook/dsl/binding_proxy.rb
+++ b/lib/hecksagain/bluebook/dsl/binding_proxy.rb
@@ -51,7 +51,58 @@ module Hecksagain
           self
         end
 
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4): `Aggregate.event_sourced` -- a bare MARKER verb, no
+        # adapter argument at all (framework/tools/bluebook/tools.
+        # hecksagon, framework/hexagon/bluebook/outbound_event.hecksagon:
+        # "this aggregate's own event log IS its persistence, no separate
+        # backend choice needed"). Every other bind verb needs a real
+        # adapter name (`args.first`) -- `event_sourced` structurally
+        # never supplies one, so the generic path below would mint an
+        # empty-string adapter and fail wiring ("unknown adapter \"\"").
+        # Reframed as sugar for `persisted_by("Heki")` -- Heki IS the
+        # durable store an event-sourced aggregate's log actually rides
+        # on, and the corpus's own bluebook text stays exactly
+        # `.event_sourced`, unchanged; only the IR::Bind this produces
+        # differs from what the text literally says. TODO upstream via
+        # bin/evolve (migration plan task 7): decide whether
+        # `event_sourced` deserves its own real persistence-family verb
+        # instead of aliasing persisted_by.
+        EVENT_SOURCED_ADAPTER = "Heki"
+
         def method_missing(verb, *args, **kwargs, &block)
+          if verb == :event_sourced
+            # Additive-only : outbound_event.hecksagon writes BOTH an
+            # explicit `persisted_by("Heki")` AND `.event_sourced` on the
+            # SAME aggregate -- the author's own "persistence+" comment
+            # says event_sourced OVERLAYS an existing bind, not replaces
+            # or duplicates it. Skip minting a second persisted_by bind
+            # when one already exists for this aggregate ; still mint one
+            # when event_sourced is the ONLY persistence statement
+            # (tools.hecksagon's FileTool/ShellTool, which have no other
+            # bind at all).
+            # `aggregate_name` (demodulised), not raw `aggregate` equality
+            # -- domain-wide-default sugar (HecksagonBuilder#
+            # domain_wide_persisted_by, a bare `adapter :memory`/`:heki`)
+            # stores the BARE aggregate name ("ShellTool"), while a
+            # BindingProxy-minted bind (this file) stores the full FQN
+            # ("Tools::ShellTool") -- raw string equality never matched
+            # the domain-wide-sugar bind, so tools.hecksagon's own
+            # `adapter :memory` + FileTool/ShellTool's `.event_sourced`
+            # combination still doubled up until this normalized.
+            already_bound = @collector.any? { |b| b.aggregate_name == Naming.demodulise(@fqn) && b.verb == "persisted_by" }
+            unless already_bound
+              @collector << IR::Bind.new(
+                aggregate: @fqn,
+                verb:      "persisted_by",
+                adapter:   EVENT_SOURCED_ADAPTER,
+                role:      kwargs[:role]&.to_s
+              )
+            end
+            block&.call
+            return self
+          end
+
           @collector << IR::Bind.new(
             aggregate: @fqn,
             verb:      verb.to_s,

--- a/spec/event_sourced_sugar_growth_spec.rb
+++ b/spec/event_sourced_sugar_growth_spec.rb
@@ -1,0 +1,82 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for BindingProxy's `Aggregate.event_sourced` marker verb
+# -- "this aggregate's own event log IS its persistence, no separate
+# backend choice needed." Every other bind verb needs a real adapter
+# name (`args.first`); `event_sourced` structurally never supplies one,
+# so the generic path would mint an empty-string adapter and fail
+# wiring ("unknown adapter \"\""). Sugar for `persisted_by("Heki")`.
+#
+# ADDITIVE-ONLY: an aggregate that already carries an explicit
+# `persisted_by` bind (any adapter) is NOT double-bound by a trailing
+# `.event_sourced` -- the two statements OVERLAY, they don't duplicate
+# or replace. `event_sourced` alone (no other persistence statement) is
+# what actually mints the Heki bind.
+RSpec.describe "BindingProxy Aggregate.event_sourced" do
+  def boot(source, &binds)
+    file = Tempfile.new(["event-sourced-sugar-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon("EventSourcedSugarGrowth", &binds)
+    end
+    registry
+  ensure
+    file&.close!
+  end
+
+  EVENT_SOURCED_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "EventSourcedSugarGrowth" do
+      aggregate "Ledger" do
+        identified_by { ledger_id.value }
+        value_object "LedgerId" do
+          attribute :value, String
+        end
+        attribute :ledger_id, LedgerId
+      end
+
+      aggregate "Overlay" do
+        identified_by { overlay_id.value }
+        value_object "OverlayId" do
+          attribute :value, String
+        end
+        attribute :overlay_id, OverlayId
+      end
+    end
+  BLUEBOOK
+
+  it "mints a real persisted_by(Heki) bind when it's the ONLY persistence statement" do
+    registry = boot(EVENT_SOURCED_SOURCE) do
+      ::EventSourcedSugarGrowth::Ledger.event_sourced
+    end
+
+    bind = registry.hecksagon("EventSourcedSugarGrowth").bind_for("Ledger", "persisted_by")
+    expect(bind).not_to be_nil
+    expect(bind.adapter).to eq("Heki")
+  end
+
+  it "does NOT double-bind when an explicit persisted_by already exists on the same aggregate" do
+    registry = boot(EVENT_SOURCED_SOURCE) do
+      ::EventSourcedSugarGrowth::Overlay.persisted_by("Heki")
+      ::EventSourcedSugarGrowth::Overlay.event_sourced
+    end
+
+    binds = registry.hecksagon("EventSourcedSugarGrowth").binds_for("Overlay", "persisted_by")
+    expect(binds.size).to eq(1)
+  end
+
+  it "the bare marker verb never leaks an empty-string adapter" do
+    registry = boot(EVENT_SOURCED_SOURCE) do
+      ::EventSourcedSugarGrowth::Ledger.event_sourced
+    end
+
+    bind = registry.hecksagon("EventSourcedSugarGrowth").bind_for("Ledger", "persisted_by")
+    expect(bind.adapter).not_to eq("")
+  end
+end


### PR DESCRIPTION
Item `1855be0-i` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-h` (#69). Not in the original plan — found on real-diff read.

**What this lands**: `Aggregate.event_sourced` — a bare MARKER verb, no adapter argument at all ("this aggregate's own event log IS its persistence, no separate backend choice needed"). Every other bind verb needs a real adapter name; `event_sourced` structurally never supplies one, so the generic path would mint an empty-string adapter and fail wiring. Reframed as sugar for `persisted_by("Heki")`.

**Additive-only**: an aggregate that already carries an explicit `persisted_by` bind is not double-bound by a trailing `.event_sourced` — the two statements OVERLAY, they don't duplicate or replace. Compares by demodulised `aggregate_name`, not raw `aggregate` equality — domain-wide-default sugar (item 1855be0-a3) stores the bare aggregate name, while a `BindingProxy`-minted bind stores the full FQN; raw string equality never matched the domain-wide-sugar bind.

**Spec coverage**: `spec/event_sourced_sugar_growth_spec.rb` — mints a real Heki bind when it's the only persistence statement, does not double-bind when an explicit `persisted_by` already exists, and the bare marker never leaks an empty-string adapter. Verified genuinely failing without this fix via `git stash` (2/3 examples).

**Verification**: 1384 examples, 17 failures (up from 1381/17, identical failure set, no regressions).
