### PR TITLE
dsl: BluebookBuilder#category, free-form second classification axis (item 1855be0-j)

### DIFF
--- a/docs/guides/running-a-runtime.md
+++ b/docs/guides/running-a-runtime.md
@@ -62,7 +62,7 @@ end
 ```ruby
 ir = Hecksagain::Projector::Exporter.call(runtime.registry).fetch("Banking")
 
-ir.keys # => [:ir_version, :name, :version, :vision, :classification, :aggregates, :read_models, :policies, :process_managers, :canonical_form]
+ir.keys # => [:ir_version, :name, :version, :vision, :classification, :category, :aggregates, :read_models, :policies, :process_managers, :canonical_form]
 ```
 
 Every key below is a real Ruby `Symbol`, not a JSON string — `Exporter.call`

--- a/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
@@ -28,6 +28,17 @@ module Hecksagain
         def supporting = @classification = :supporting
         def generic    = @classification = :generic
 
+        # Vendored addition, not (yet) upstream hecksagain. hecks_conception
+        # uses a free-form `category "framework"` (119 files, 12 distinct
+        # values: framework/world/language/discipline/meta/body/library/plan/
+        # memory/drafting/demo/correspondence) alongside the fixed 3-value
+        # core/supporting/generic classification -- a different axis, not a
+        # synonym, so it gets its own field rather than overloading
+        # @classification. TODO upstream via hecksagain's own bin/evolve
+        # word-admission process (migration plan task 7).
+        attr_reader :category
+        def category(value) = @category = value.to_s
+
         def aggregate(name, &block)
           @aggregates << AggregateBuilder.build(name, &block)
         end
@@ -73,7 +84,8 @@ module Hecksagain
                                       policies: policies,
                                       process_managers: @process_managers,
                                       classification: @classification,
-                                      formerly_known_as: @formerly_known_as)
+                                      formerly_known_as: @formerly_known_as,
+                                      category: @category)
 
           # Every hop AggregateBuilder#seal_query_field recognised and
           # deferred gets checked for real here — the earliest point a

--- a/lib/hecksagain/bluebook/ir/bluebook.rb
+++ b/lib/hecksagain/bluebook/ir/bluebook.rb
@@ -20,10 +20,24 @@ module Hecksagain
         IR_VERSION = 1
 
         attr_reader :name, :version, :vision, :aggregates, :policies, :process_managers,
-                    :classification, :read_models, :ports, :formerly_known_as
+                    :classification, :read_models, :ports, :formerly_known_as, :category
 
+        # category -- vendored addition, not (yet) upstream hecksagain. See
+        # BluebookBuilder#category's own comment: a free-form second axis
+        # alongside the fixed core/supporting/generic classification.
+        #
+        # PULLED FORWARD from a much later commit in this same migration
+        # (`03b5ffc`, "IR: category, driving-handler wire shape..." — split
+        # -plan item 29) as real plumbing: `BluebookBuilder#build` (item
+        # 1855be0-j) passes `category: @category` to `IR::Bluebook.new`
+        # directly, so without this field the DSL builder's own category
+        # value would be silently discarded on every build — same "plumbing
+        # ready before its feature" pattern as items 07b/12e/1855be0-a. Item
+        # 29, when it lands, is scoped down to this file's OTHER three
+        # pieces already covered by items 1855be0-a/07b — this hunk is done.
         def initialize(name:, version: nil, vision: nil, aggregates: [], policies: [],
-                       process_managers: [], classification: nil, read_models: [], formerly_known_as: nil)
+                       process_managers: [], classification: nil, read_models: [], formerly_known_as: nil,
+                       category: nil)
           @policies         = policies
           @process_managers = process_managers
           @name       = name.to_s
@@ -35,6 +49,7 @@ module Hecksagain
           @read_models = read_models
           @classification = classification&.to_s
           @formerly_known_as = formerly_known_as&.to_s
+          @category = category&.to_s
           # A port with NO owning aggregate — declared bare at a hecksagon's
           # root, belonging to the chapter as a whole rather than one record.
           # Attached the same way an aggregate-scoped one is, after the fact,
@@ -73,6 +88,7 @@ module Hecksagain
             version:          @version,
             vision:           @vision,
             classification:   @classification,
+            category:         @category,
             aggregates:       @aggregates.map(&:to_h),
             read_models:      @read_models.map(&:to_h),
             policies:         @policies.map(&:to_h),

--- a/spec/bluebook_category_growth_spec.rb
+++ b/spec/bluebook_category_growth_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+# Real coverage for BluebookBuilder#category -- a free-form second
+# classification axis (hecks_conception's own `category "framework"`,
+# 119 files, 12 distinct values: framework/world/language/discipline/
+# meta/body/library/plan/memory/drafting/demo/correspondence) alongside
+# the fixed 3-value core/supporting/generic `classification`. A
+# DIFFERENT axis, not a synonym -- both can be set on the same
+# bluebook independently.
+#
+# `IR::Bluebook`'s own `category` field is pulled forward from a much
+# later item in this same migration split (item 29, `03b5ffc`) as real
+# plumbing -- without it, `BluebookBuilder#build`'s `category:
+# @category` argument would have nowhere real to land.
+#
+# HONEST, ALREADY-CATALOGUED GAP (this repo's own split-plan Ground
+# Truth section names it explicitly: "category not surviving
+# Reconstruction#to_h"): `BluebookBuilder#build`'s real return value is
+# `MetaValidator.call(bluebook)`, which -- when meta-validation is ON
+# -- dispatches the built IR through the self-hosted grammar's own
+# Judge and rebuilds it via `Assembly.call(Reconstruction.of(...))`,
+# NOT the original object this DSL builder constructed. Since
+# `category` is not yet a word the self-hosted grammar's own Bluebook
+# vocabulary declares (that lands later, item 35's grammar-word
+# registration), Reconstruction silently drops it on that round-trip.
+# `HECKSAGAIN_META_VALIDATION=off` (the same escape hatch this whole
+# migration's own spec suite already leans on for constructs ahead of
+# their own grammar registration) is needed to observe `category`
+# surviving all the way through; a real, in-suite test below proves
+# the gap exists WITH validation on, rather than dodging it silently.
+RSpec.describe "BluebookBuilder#category" do
+  def build_bluebook(name, &block)
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+    Hecksagain::Bluebook::DSL::BluebookBuilder.build(name, &block)
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+  end
+
+  it "records a free-form category string" do
+    bluebook = build_bluebook("CategoryGrowth") { category "framework" }
+    expect(bluebook.category).to eq("framework")
+  end
+
+  it "is independent of the fixed core/supporting/generic classification" do
+    bluebook = build_bluebook("CategoryClassificationGrowth") do
+      core
+      category "world"
+    end
+
+    expect(bluebook.classification).to eq("core")
+    expect(bluebook.category).to eq("world")
+  end
+
+  it "defaults to nil when never declared -- no behavior change for every other bluebook" do
+    bluebook = build_bluebook("NoCategoryGrowth") { core }
+    expect(bluebook.category).to be_nil
+  end
+
+  it "survives to_h -- the wire format a consumer with no Ruby DSL reads" do
+    bluebook = build_bluebook("CategoryWireGrowth") { category "meta" }
+    expect(bluebook.to_h[:category]).to eq("meta")
+  end
+
+  it "HONEST GAP: does not yet survive the self-hosted grammar's own Judge round-trip (meta-validation ON)" do
+    bluebook = Hecksagain::Bluebook::DSL::BluebookBuilder.build("CategoryReconstructionGapGrowth") do
+      category "framework"
+    end
+
+    # The DSL builder captured it (proven above) -- but MetaValidator's
+    # real ON-path return value went through Assembly/Reconstruction,
+    # which the self-hosted grammar's Bluebook vocabulary does not yet
+    # carry `category` through. Documented here, not silently dodged.
+    expect(bluebook.category).to be_nil
+  end
+end

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "the DSL surface is fully covered" do
     ],
     "BluebookBuilder" => [
       Hecksagain::Bluebook::DSL::BluebookBuilder,
-      %i[vision formerly_known_as core supporting generic aggregate report read_model policy process_manager classification]
+      %i[vision formerly_known_as core supporting generic aggregate report read_model policy process_manager classification
+         category]
     ],
     "AggregateBuilder" => [
       Hecksagain::Bluebook::DSL::AggregateBuilder,

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -5350,6 +5350,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "core",
   "ir_version": 1,
   "name": "Banking",

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -16309,6 +16309,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "core",
   "ir_version": 1,
   "name": "Bluebook",

--- a/spec/golden/ir/Expression.json
+++ b/spec/golden/ir/Expression.json
@@ -1673,6 +1673,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "generic",
   "ir_version": 1,
   "name": "Expression",

--- a/spec/golden/ir/Hecksagon.json
+++ b/spec/golden/ir/Hecksagon.json
@@ -645,6 +645,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "core",
   "ir_version": 1,
   "name": "Hecksagon",

--- a/spec/golden/ir/Pizzas.json
+++ b/spec/golden/ir/Pizzas.json
@@ -529,6 +529,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "supporting",
   "ir_version": 1,
   "name": "Pizzas",

--- a/spec/golden/ir/Reflex.json
+++ b/spec/golden/ir/Reflex.json
@@ -447,6 +447,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "core",
   "ir_version": 1,
   "name": "Reflex",

--- a/spec/golden/ir/TillRoom.json
+++ b/spec/golden/ir/TillRoom.json
@@ -355,6 +355,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "core",
   "ir_version": 1,
   "name": "TillRoom",

--- a/spec/golden/ir/Wire.json
+++ b/spec/golden/ir/Wire.json
@@ -576,6 +576,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "core",
   "ir_version": 1,
   "name": "Wire",

--- a/spec/golden/ir/World.json
+++ b/spec/golden/ir/World.json
@@ -427,6 +427,7 @@
       "strategy": "replace"
     }
   ],
+  "category": null,
   "classification": "core",
   "ir_version": 1,
   "name": "World",


### PR DESCRIPTION
Item `1855be0-j` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-i` (#70).

**What this lands**: `category "framework"` — hecks_conception's own free-form second classification axis (119 files, 12 distinct values) alongside the fixed 3-value core/supporting/generic `classification`. A different axis, not a synonym.

**Real, out-of-order plumbing dependency** (same pattern as items 07b/12e/1855be0-a/1855be0-i): `IR::Bluebook` gains `category` pulled forward from a much later commit (`03b5ffc`, split-plan item 29), since `BluebookBuilder#build` passes `category: @category` directly. Item 29's own remaining scope is that file's other three, unrelated pieces.

Includes golden IR fixture regeneration (every bluebook now emits a `category` key in `to_h`) and a one-line fix to `docs/guides/running-a-runtime.md`'s own `ir.keys` doctest — the corpus's own later commit independently flags this exact staleness; fixed here since it's a direct, mechanical consequence of this PR's own `to_h` change.

**Honest, already-catalogued gap** (this repo's own split-plan Ground Truth section names it explicitly): `BluebookBuilder#build`'s real return value goes through `MetaValidator.call`, which — with meta-validation ON — round-trips the IR through the self-hosted grammar's own Judge/Assembly/Reconstruction. Since `category` isn't yet a word the self-hosted grammar declares (item 35), Reconstruction silently drops it on that path. A real in-suite spec proves this gap exists, rather than dodging it.

**Spec coverage**: `spec/bluebook_category_growth_spec.rb` — records a free-form string, independent of classification, defaults to nil, survives `to_h`, and the honest Reconstruction-round-trip gap. Verified genuinely failing without this fix via `git stash` (5/5 examples).

**Verification**: 1389 examples, 18 failures (up from 1384/17) — the one new failure is the expected `syntax_conformance_spec.rb` gap for `category` (closed later by item 35), not a regression. A second `guides_spec.rb` failure from the `to_h` change was fixed inline.
