### PR TITLE
meta_validator: Readings mutation_rows bare-symbol append crash (item 1855be0-k)

### DIFF
--- a/lib/hecksagain/bluebook/meta_validator/readings.rb
+++ b/lib/hecksagain/bluebook/meta_validator/readings.rb
@@ -157,12 +157,20 @@ module Hecksagain
           Array(node.mutations).flat_map do |mutation|
             next set_row(mutation) unless mutation.op == :append
 
-            mutation.source.map do |field, argument|
-              # Spelled the way IR::Mutation#appended_fields spells it, because
-              # Assembly::Marks reads this row back through the same reader it
-              # reads that field with. `then_set :marks, append: { direction:
-              # "out" }` binds a LITERAL, and storing it raw made it
-              # indistinguishable from an argument called out.
+            # Vendored addition, not (yet) upstream hecksagain: a bare-symbol
+            # append (`then_set :list, append: :single_value`, appending a
+            # scalar directly rather than a hash of named fields) has no
+            # "field" to iterate -- treat it as one field named :value,
+            # mirroring IR::Command::Mutation#appended_fields's own
+            # vendored fallback. TODO upstream (migration plan task 7).
+            source = mutation.source.is_a?(Hash) ? mutation.source : { value: mutation.source }
+
+            source.map do |field, argument|
+              # Spelled the way IR::Mutation#appended_fields spells it: a symbol bare
+              # because it names an argument, anything else inspected because it IS
+              # the value. `then_set :marks, append: { direction: "out" }` binds a
+              # LITERAL, and storing it raw made it indistinguishable from an
+              # argument called out.
               { target: mutation.target, op: mutation.op, field: field,
                 kind: argument.is_a?(Symbol) ? "argument" : "literal",
                 source: Literal.render(argument) }

--- a/spec/readings_bare_symbol_append_growth_spec.rb
+++ b/spec/readings_bare_symbol_append_growth_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for MetaValidator::Readings#mutation_rows's own
+# bare-symbol append handling: `then_set :list, append: :single_value`
+# appends a scalar/single-field-VO value DIRECTLY, rather than a Hash
+# of named fields (`append: { field: :src, ... }`). The Judge's own
+# mutation-row projection had no "field" to iterate for that shape --
+# mirrors `IR::Command::Mutation#appended_fields`'s own already-landed
+# vendored fallback (one field named :value).
+#
+# Exercised WITH real meta-validation ON (no ENV override) -- this is
+# specifically the self-hosted grammar's own Judge path, not the
+# runtime MutationApplier (which already handled the bare-symbol shape
+# before this fix).
+RSpec.describe "MetaValidator::Readings bare-symbol append" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["readings-bare-append-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    file&.close!
+  end
+
+  BARE_APPEND_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "ReadingsBareAppendGrowth" do
+      aggregate "Playlist" do
+        identified_by { playlist_id.value }
+
+        value_object "PlaylistId" do
+          attribute :value, String
+        end
+
+        value_object "TrackName" do
+          attribute :value, String
+        end
+
+        attribute :playlist_id, PlaylistId
+        attribute :tracks, list_of(TrackName)
+
+        command "AddTrack" do
+          attribute :playlist_id, PlaylistId
+          attribute :track, TrackName
+          then_set :tracks, append: :track
+          emits "TrackAdded"
+        end
+      end
+    end
+  BLUEBOOK
+
+  it "boots without a MetaValidator refusal -- the Judge's own mutation-row projection survives a bare-symbol append" do
+    expect do
+      boot(BARE_APPEND_SOURCE, "ReadingsBareAppendGrowth") do
+        ::ReadingsBareAppendGrowth::Playlist.persisted_by("Memory")
+      end
+    end.not_to raise_error
+  end
+
+  it "a real dispatch through the fully-validated bluebook appends the value onto the list" do
+    runtime = boot(BARE_APPEND_SOURCE, "ReadingsBareAppendGrowth") do
+      ::ReadingsBareAppendGrowth::Playlist.persisted_by("Memory")
+    end
+
+    runtime.dispatch("ReadingsBareAppendGrowth::Playlist.AddTrack",
+                      playlist_id: { value: "p1" }, track: { value: "Track One" })
+
+    bluebook = runtime.registry.bluebook("ReadingsBareAppendGrowth")
+    aggregate = bluebook.aggregate("Playlist")
+    record = runtime.registry.repository("ReadingsBareAppendGrowth", aggregate).find("p1")
+
+    expect(record[:tracks].map { |t| t[:value] }).to eq(["Track One"])
+  end
+end


### PR DESCRIPTION
Item `1855be0-k` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-j` (#71). Not in the original plan — found on real-diff read.

**What this lands**: `then_set :list, append: :single_value` — appending a scalar/single-field-VO value directly, rather than a Hash of named fields — crashed the self-hosted grammar's own Judge: `mutation.source.map` was called directly on the bare Symbol, which has no `#map`. Treated as one field named `:value`, mirroring `IR::Command::Mutation#appended_fields`'s own already-landed vendored fallback for the SAME shape (that fix covers the runtime `MutationApplier` path; this covers the separate meta-validation Judge path, which reads mutations through its own `readings.rb` projection).

**Spec coverage**: `spec/readings_bare_symbol_append_growth_spec.rb` — boots a real bluebook WITH meta-validation ON (no ENV override, since this is specifically the Judge path) using a bare-symbol `append:`, and confirms a real dispatch actually appends the value onto the list. Verified genuinely failing without this fix via `git stash` (2/2 examples; a `NoMethodError` crash on `Symbol#map` inside the Judge's own `walk_all`, not merely a refusal).

**Verification**: 1391 examples, 18 failures (up from 1389/18, identical failure set, no regressions).
