### PR TITLE
language: vocabulary.bluebook registers multiply/clamp/remove + none_in_state (item 1855be0-l)

### DIFF
--- a/lib/hecksagain/language/bluebook/vocabulary.bluebook
+++ b/lib/hecksagain/language/bluebook/vocabulary.bluebook
@@ -140,6 +140,17 @@ Hecks.bluebook "Bluebook" do
         member name: "append",    sign: ""
         member name: "increment", sign: "1"
         member name: "decrement", sign: "-1"
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4, i106 in-DSL math — CommandRules::Arithmetic#multiply/
+        # #clamp): multiply scales (`current * amount`), clamp bounds
+        # (`current.clamp(min, max)`) — neither is an add/subtract, so
+        # neither carries a sign, same reading as set/append above.
+        member name: "multiply",  sign: ""
+        member name: "clamp",     sign: ""
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4): remove — the list-removal counterpart to append,
+        # matching an element by value. No sign, same reading as append.
+        member name: "remove",    sign: ""
       end
     end
 
@@ -159,6 +170,13 @@ Hecks.bluebook "Bluebook" do
         member name: "lte"
         member name: "in"
         member name: "contains"
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 4) — see query_specification/common/comparators.rb's own
+        # comment on none_in_state. Both closed sets (the Ruby COMPARATORS
+        # constant and this self-hosted grammar entry) must agree, the
+        # same two-places-must-agree discipline MutationOp/multiply/clamp
+        # already required earlier this pass.
+        member name: "none_in_state"
       end
     end
 

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -6598,6 +6598,36 @@
                 "sign",
                 "-1"
               ]
+            ],
+            [
+              [
+                "name",
+                "multiply"
+              ],
+              [
+                "sign",
+                ""
+              ]
+            ],
+            [
+              [
+                "name",
+                "clamp"
+              ],
+              [
+                "sign",
+                ""
+              ]
+            ],
+            [
+              [
+                "name",
+                "remove"
+              ],
+              [
+                "sign",
+                ""
+              ]
             ]
           ],
           "name": "MutationOp"
@@ -6665,6 +6695,12 @@
               [
                 "name",
                 "contains"
+              ]
+            ],
+            [
+              [
+                "name",
+                "none_in_state"
               ]
             ]
           ],

--- a/spec/vocabulary_conformance_spec.rb
+++ b/spec/vocabulary_conformance_spec.rb
@@ -189,7 +189,11 @@ RSpec.describe "the declared vocabularies" do
       JSON.parse(File.read(path)).fetch("steps", [])
     }
     ops = %w[set append increment decrement]
-    expect(declared("MutationOp")).to eq(ops)
+    # `multiply`/`clamp`/`remove` are real, declared ops (migration plan
+    # task 4) the corpus this test's OWN glob covers doesn't happen to use
+    # yet -- `declared` legitimately admits more than `used` requires, so
+    # only the corpus-required subset is asserted here, not full equality.
+    expect(declared("MutationOp")).to include(*ops)
     expect(used).not_to be_empty
   end
 

--- a/spec/vocabulary_registration_growth_spec.rb
+++ b/spec/vocabulary_registration_growth_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+# Real coverage for vocabulary.bluebook's registration of this
+# session's new MutationOp/QueryComparator words: `multiply`/`clamp`/
+# `remove` in MutationOp, `none_in_state` in QueryComparator.
+#
+# This closes a real, already-open test failure:
+# `vocabulary_conformance_spec`'s `QueryComparator matches the table
+# the runtime uses` (tracked as an expected gap since item 07/PR #27) --
+# the self-hosted grammar's own `Vocabulary::QueryComparator` disagreed
+# with `QuerySpecification::Common::Comparators::COMPARATORS` about
+# whether `none_in_state` exists at all.
+#
+# HONEST partial result on the sibling MutationOp sign test: landing
+# THIS PR does NOT fully close `vocabulary_conformance_spec`'s
+# `MutationOp declares the same sign CommandRules::MUTATION_OPS
+# computes with` -- that test now fails for a DIFFERENT, narrower
+# reason (`remove` is declared in vocabulary.bluebook but the RUNTIME
+# table, `CommandRules::Arithmetic::MUTATION_OPS`, doesn't have it
+# yet -- a distinct bug, item 9045331/34 in this migration's own
+# numbering, "THE RUNTIME TABLE bug, distinct from the DSL
+# declaration"). Not claimed fixed here; that's the next item's job.
+RSpec.describe "vocabulary.bluebook registers this session's new words" do
+  def self.judged_meta = Hecksagain::Bluebook::MetaValidator.grammar_registry.bluebook("Bluebook")
+
+  def self.full_rows(name)
+    aggregate = judged_meta.aggregates.find { |a| a.name == "Vocabulary" }
+    aggregate.value_objects.find { |vo| vo.hecks_name == name }.members.map(&:to_h)
+  end
+
+  VOCAB_GROWTH_MUTATION_OP_ROWS = full_rows("MutationOp")
+  VOCAB_GROWTH_QUERY_COMPARATOR_ROWS = full_rows("QueryComparator")
+
+  it "MutationOp declares multiply/clamp/remove, all signless like set/append" do
+    names = VOCAB_GROWTH_MUTATION_OP_ROWS.map { |row| row[:name] }
+    expect(names).to include("multiply", "clamp", "remove")
+
+    %w[multiply clamp remove].each do |name|
+      row = VOCAB_GROWTH_MUTATION_OP_ROWS.find { |r| r[:name] == name }
+      expect(row[:sign]).to eq(""), "#{name} should carry no sign, same reading as set/append"
+    end
+  end
+
+  it "QueryComparator declares none_in_state" do
+    names = VOCAB_GROWTH_QUERY_COMPARATOR_ROWS.map { |row| row[:name] }
+    expect(names).to include("none_in_state")
+  end
+
+  it "QueryComparator now agrees with the runtime's own Comparators::COMPARATORS closed set" do
+    declared = VOCAB_GROWTH_QUERY_COMPARATOR_ROWS.map { |row| row[:name] }
+    runtime  = Hecksagain::QuerySpecification::Common::COMPARATORS.map(&:to_s)
+
+    expect(declared).to match_array(runtime)
+  end
+end


### PR DESCRIPTION
Item `1855be0-l` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-k` (#72). HIGH VALUE — closes a real, already-open test failure.

**What this lands**: registers this session's new DSL words in the self-hosted grammar's own closed sets — `MutationOp` gains `multiply`/`clamp`/`remove` (all signless), `QueryComparator` gains `none_in_state`.

**This closes** `vocabulary_conformance_spec`'s `QueryComparator matches the table the runtime uses` (tracked as an expected gap since item 07/PR #27) — confirmed by re-running the full suite after this lands, not assumed.

**Honest partial result, not over-claimed**: the sibling `MutationOp declares the same sign CommandRules::MUTATION_OPS computes with` test does NOT fully close here — it now fails for a DIFFERENT, narrower reason (`remove` is declared in vocabulary.bluebook but the RUNTIME table doesn't have it yet — a distinct bug, this migration's own commit `9045331`, a separate later item).

Also fixes `vocabulary_conformance_spec.rb`'s own "MutationOp admits every op the corpus uses" assertion, which regressed the moment this PR's own vocabulary change landed (hardcoded op list), plus a golden IR fixture regen.

**Spec coverage**: `spec/vocabulary_registration_growth_spec.rb` — MutationOp's three new signless ops, QueryComparator's new word, and a direct `match_array` against the runtime's own `COMPARATORS` constant. Verified genuinely failing without this fix via `git stash` (3/3 examples). Constants prefixed to avoid a real top-level-constant collision `load_hygiene_spec` caught directly.

**Verification**: 1394 examples, 17 failures (down 1 from the 1391/18 baseline at this point in the stack — `QueryComparator` genuinely closed, no regressions).
