### PR TITLE
dsl: item 1855be0-g catch-all stubs + one_of/identified_by fixes (closes 1855be0)

### DIFF
--- a/docs/guides/aggregates-and-value-objects.md
+++ b/docs/guides/aggregates-and-value-objects.md
@@ -391,20 +391,23 @@ Banking::SafeDepositBox.rent(customer_id: customer.id, branch_code: { value: "up
 Reach for this one when the set is small, local, and not worth a name
 anyone else will ever reuse.
 
-The trap: the inline shorthand desugars by calling `one_of` on
+A onetime trap: the inline shorthand desugars by calling `one_of` on
 whichever builder currently has `self` — and a nested `value_object`
-block already defines its own `one_of`, for closed-set members. Writing
-the shorthand inside a `value_object` block does not synthesize a
-closed set — it calls the wrong `one_of`, with the wrong arity, and the
-bluebook does not load:
+block already defines its own `one_of`, for closed-set members. Since
+both spellings share the bare word, `ValueObjectBuilder#one_of`
+disambiguates by call shape: values with no block is the inline
+shorthand (delegated to the same synthesis every other builder uses),
+a block with no values is the closed-set-body form. Writing the
+shorthand inside a `value_object` block now synthesizes a closed set
+correctly, the same as anywhere else:
 
 ```ruby
-def banking_bad_one_of
+def banking_nested_one_of
   Hecksagain.with_registry(Hecksagain::Runtime::Registry.new) do
     Kernel.load(InMemoryDomain::EXTRACTION_PORT)
     Kernel.load(InMemoryDomain::PRISM_ADAPTER)
     code = <<~RUBY
-      Hecks.bluebook("BankingBadOneOf") do
+      Hecks.bluebook("BankingNestedOneOf") do
         aggregate "Thing" do
           identified_by { thing_id.value }
           attribute :box, Box
@@ -415,14 +418,15 @@ def banking_bad_one_of
         end
       end
     RUBY
-    file = Tempfile.new(["banking-bad-one-of-", ".bluebook"])
+    file = Tempfile.new(["banking-nested-one-of-", ".bluebook"])
     file.write(code)
     file.flush
     Kernel.eval(code, TOPLEVEL_BINDING, file.path, 1)
   end
+  true
 end
 
-banking_bad_one_of   # ~> ArgumentError: wrong number of arguments
+banking_nested_one_of   # => true
 ```
 
 ## A field that grows

--- a/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
@@ -264,6 +264,35 @@ module Hecksagain
           @value_objects << ValueObjectBuilder.build(name, &block)
         end
 
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): `fixture "Name" do field value ... end` declared
+        # INSIDE an aggregate block -- a THIRD fixture shape hecks_nursury
+        # uses (328 occurrences, 32 files) besides its 312 dedicated
+        # `.fixtures` files and BluebookBuilder's already-stubbed
+        # bluebook-level `fixture "Name", on: "Aggregate" do ... end`
+        # (deciderate). Same documented gap, same reasoning as that
+        # sibling stub's own comment : the field-setter calls inside
+        # (`name "House Battery Bank"`, `voltage 12.8`) have no real
+        # receiver methods, one per the aggregate's own attribute names,
+        # varying per file -- executing the block for real needs an
+        # actual seeding mechanism (dispatch a Declare-equivalent at
+        # boot, or write straight into the repository bypassing command
+        # validation), a real design question not attempted here.
+        # Accepted so the file boots ; block body captured via a tiny
+        # inert `method_missing` receiver (field names vary too widely
+        # per aggregate to enumerate), NOT stored or seeded anywhere.
+        # TODO upstream via bin/evolve (migration plan task 7): a real
+        # aggregate-fixture seeding mechanism, one design covering all
+        # three shapes at once.
+        class InlineFixtureFieldStub
+          def method_missing(*, **, &) = nil
+          def respond_to_missing?(*) = true
+        end
+
+        def fixture(*, **, &block)
+          InlineFixtureFieldStub.new.instance_eval(&block) if block
+        end
+
         def command(name, &block)
           # The verb is declared ON this aggregate — the owner `acts_on` answers
           # with — stamped by `IR::Aggregate#initialize` once the aggregate
@@ -274,6 +303,20 @@ module Hecksagain
 
         def build
           resolve_pending_identity!
+
+          # Vendored default, not (yet) upstream hecksagain: hecks_nursury
+          # (375 files) declares no identified_by anywhere -- hecksagain
+          # refuses an aggregate with none ("an aggregate says what it
+          # is known by"). Falls back to the FIRST declared attribute's
+          # own .value path rather than requiring a corpus-wide add-a-
+          # line pass across every nursery domain -- either exactly
+          # right (most nursery aggregates have one obviously-primary
+          # field) or a visible wrong guess a real boot/dispatch
+          # surfaces immediately, not a silent one. TODO upstream via
+          # bin/evolve (migration plan task 7).
+          if @identity_paths.empty? && attributes.any?
+            @identity_paths = ["#{attributes.first.name}.value"]
+          end
 
           resolve_bare_primitive_collisions
 
@@ -303,8 +346,17 @@ module Hecksagain
           ir
         end
 
-        def self.build(name, &block)
+        # inline_description -- vendored addition, not (yet) upstream
+        # hecksagain. hecks_conception writes `aggregate "Name", "desc" do
+        # ... end` (a second positional string) rather than a
+        # `description "desc"` call inside the block -- syntactic sugar
+        # over the same information, so this just calls #description
+        # first rather than duplicating what it does. TODO upstream via
+        # hecksagain's own bin/evolve word-admission process (migration
+        # plan task 7).
+        def self.build(name, inline_description = nil, &block)
           builder = new(name)
+          builder.description(inline_description) if inline_description
           builder.instance_eval(&block) if block
           builder.build
         end

--- a/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
@@ -39,8 +39,128 @@ module Hecksagain
         attr_reader :category
         def category(value) = @category = value.to_s
 
-        def aggregate(name, &block)
-          @aggregates << AggregateBuilder.build(name, &block)
+        # Vendored no-op stub, not (yet) upstream hecksagain: bluebook-level
+        # `glossary(strict: true) do ... end` (found in sleep_cycle.bluebook)
+        # -- accepted so the file boots, block body NOT evaluated/stored (a
+        # real, documented gap, not silently pretended complete). TODO
+        # upstream via bin/evolve (migration plan task 7): understand and
+        # implement the intended vocabulary-glossary semantics properly.
+        def glossary(**) = nil
+
+        # Vendored no-op stub, not (yet) upstream hecksagain: bluebook-level
+        # `entrypoint ...` (found in miette body/wake/bluebook). TODO
+        # upstream via bin/evolve (migration plan task 7).
+        def entrypoint(*) = nil
+
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): bluebook-level `fixture "Name", on: "Aggregate" do
+        # field value ... end` (found in deciderate's cloudflare.bluebook
+        # -- deploy-config seed data for `storehouse specialize
+        # wrangler_toml`, not live business-domain logic). Same shape as
+        # `glossary` just above -- accepted so the file boots, block body
+        # NOT evaluated (the field-setter calls inside it have no real
+        # receiver methods at all, so executing the block would need a
+        # real seeding mechanism : dispatch a Declare-equivalent command
+        # at boot, or write straight into the repository, bypassing
+        # command validation either way -- a real design question, not
+        # attempted under this pass's time pressure since this ONE
+        # occurrence is deploy tooling, not domain content). TODO
+        # upstream via bin/evolve (migration plan task 7).
+        def fixture(*, **) = nil
+
+        # Vendored no-op stub, not (yet) upstream hecksagain: bluebook-level
+        # `section "Name" do row "key", value ... end` (found in miette's
+        # system_prompt_assembly.bluebook — a declarative source/template
+        # pairing the corpus's OWN comment already names as a documented
+        # DSL gap: "a first-class `section "Header", source: :Identity,
+        # template: :header` form would let the bluebook declare the
+        # mapping without two row lines... stays bluebook-first" — written
+        # against an OLD Rust-runtime SectionBuilder no-op that has no
+        # hecksagain counterpart at all. `row` only exists inside the
+        # block, so it needs its own tiny inert receiver rather than a
+        # bare method stub. TODO upstream via bin/evolve (migration plan
+        # task 7): the corpus's own filed gap, not a new one.
+        class SectionRowStub
+          def row(*) = nil
+        end
+
+        def section(*, &block)
+          SectionRowStub.new.instance_eval(&block) if block
+        end
+
+        # Vendored no-op stub, not (yet) upstream hecksagain: bluebook-level
+        # `define "Term", "definition text"` (found in miette mind/bluebook
+        # — a glossary-TERM entry, sibling to the `glossary(strict: true)
+        # do prefer ... end` block right above, which is itself already a
+        # no-op stub). Same documented gap: accepted so the file boots,
+        # not stored or enforced. TODO upstream via bin/evolve (migration
+        # plan task 7), alongside `glossary`/`prefer` — they're one
+        # feature (a strict-mode vocabulary lock + its term definitions),
+        # not two, and should land together.
+        def define(*) = nil
+
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): bluebook-level `lifecycle "Name" do state "x" ;
+        # transition from: "a", to: "b", on: "Event" end` -- found 44
+        # times across hecks_nursury's 375-file corpus (100% of that
+        # corpus's OWN `lifecycle "..."` occurrences; its far more common
+        # `lifecycle :field, default: "x" do ... end` inline-attribute
+        # sugar is a wholly separate, already-working AggregateBuilder/
+        # EntityBuilder construct, unaffected). This bare-string-named
+        # form is disconnected from any specific aggregate or field --
+        # a documentation-flavored state-machine SUMMARY sitting as a
+        # sibling of `aggregate` blocks, not a real attribute-lifecycle
+        # declaration (the corpus's own generation pattern separately
+        # writes ad-hoc `attribute :status, String` + manual `then_set`
+        # calls inside the relevant aggregate's commands -- this block
+        # restates the same shape as prose, never wired to it). Grepped
+        # every occurrence's block body corpus-wide before writing this:
+        # only `state "name"` and `transition from:, to:, on:` ever
+        # appear inside one. Same documented-gap shape as `section`
+        # just above -- accepted so the file boots, block body captured
+        # structurally via a tiny inert receiver, NOT stored on the
+        # bluebook or wired to any aggregate's real lifecycle. TODO
+        # upstream via bin/evolve (migration plan task 7): decide
+        # whether this deserves real IR (a bluebook-level named lifecycle
+        # list) or should be corpus-rewritten into the real per-aggregate
+        # `lifecycle :field, default: ... do ... end` sugar once a human
+        # picks the owning aggregate/field per occurrence.
+        class LifecycleStub
+          def state(*) = nil
+          def transition(**) = nil
+        end
+
+        def lifecycle(*, &block)
+          LifecycleStub.new.instance_eval(&block) if block
+        end
+
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): bluebook-level `event "Name"` (found in
+        # hecks_nursury's alans_engine_additive_business/hecks/
+        # quality.bluebook only -- 3 occurrences, 1 file corpus-wide,
+        # not a dominant pattern like `lifecycle`/`fixture`). All three
+        # named events (TestRun/ResultRecorded/CertificateOfAnalysis
+        # Issued) are ALREADY `emits`-declared by real commands earlier
+        # in the same file -- this is a redundant vocabulary-listing
+        # sibling to `glossary`/`define`, not a new event source.
+        # Same documented-gap shape as those. TODO upstream via
+        # bin/evolve (migration plan task 7).
+        def event(*) = nil
+
+        # Vendored no-op stub, not (yet) upstream hecksagain (migration
+        # plan task 8): bluebook-level `actor "Name", description: "..."`
+        # -- 14 occurrences, 3 files (tag_management/hecks/, blog.bluebook,
+        # and its blog/hecks/ near-duplicate -- the same half-finished
+        # `hecks/`-subdir convention pair this migration's own inventory
+        # already flagged). A prose role-registry sibling to `role "X"`
+        # already used freely inside commands -- documentation, not a
+        # new construct with runtime meaning. Same documented-gap shape
+        # as `event`/`glossary`/`define`. TODO upstream via bin/evolve
+        # (migration plan task 7).
+        def actor(*, **) = nil
+
+        def aggregate(name, inline_description = nil, &block)
+          @aggregates << AggregateBuilder.build(name, inline_description, &block)
         end
 
         # `report` is the word; `read_model` is the spelling every existing

--- a/lib/hecksagain/bluebook/dsl/hecksagon_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/hecksagon_builder.rb
@@ -196,6 +196,51 @@ module Hecksagain
         def success(*) = nil
         def failure(*) = nil
 
+        # Vendored no-op stub, not (yet) upstream hecksagain: hecksagon-
+        # level `gate "Aggregate", :role do allow :Cmd1, :Cmd2, ... end`
+        # (found in miette's circuit_breaker.hecksagon). Investigated, not
+        # just stubbed blind: every command in circuit_breaker.bluebook
+        # already declares its OWN `role "..."` individually, which
+        # hecksagain's `Runtime.as_caller(role:)` already checks at
+        # dispatch time — so `gate`/`allow` looks like a duplicate,
+        # centralized restatement of the same authorization from an older
+        # convention, not new capability. It's also STALE where checked:
+        # the bluebook says `Trip`/`Reset` are role "Creator", but this
+        # gate block claims :system covers them too — a real disagreement,
+        # not just redundancy, which is one more reason not to silently
+        # promote it to enforcement without reconciling the conflict
+        # first. Accepted so the file boots ; not stored or enforced.
+        # TODO upstream via bin/evolve (migration plan task 7): decide
+        # whether `gate` is retired in favor of per-command `role`, or
+        # kept as an intentional stricter allowlist — and if kept,
+        # reconcile circuit_breaker's own conflicting statement.
+        class GateStub
+          def allow(*) = nil
+        end
+
+        def gate(*, &block)
+          GateStub.new.instance_eval(&block) if block
+        end
+
+        # Vendored catch-all no-op, not (yet) upstream hecksagain
+        # (migration plan task 8): bin-buddy's portal `.hecksagon` files
+        # (driver_portal/admin_portal/homeowner_portal) are a genuinely
+        # DIFFERENT genre of content from aggregate-wiring — app-surface
+        # branding and UI config (`capabilities :webapp`, `brand_color
+        # "#..."`, `task_colors do out "#..." end`, `refund_thresholds do
+        # role :support, cents: 2500 end`) — not persistence/payment
+        # binds at all. Real methods (`adapter`/`success`/`failure`/etc
+        # above) still win over method_missing, so this only absorbs
+        # whatever this vendored port doesn't know, same pattern as
+        # DrivingAdapterBuilder's own catch-all just above it in this
+        # migration. A block passed to an absorbed call is never
+        # yielded to, so its own inner calls (`out "#..."`, `role :x,
+        # cents: n`) never need to exist either — structurally captured,
+        # not wired to any real portal/branding concept. TODO upstream
+        # via bin/evolve (migration plan task 8).
+        def method_missing(*) = nil
+        def respond_to_missing?(*) = true
+
         def build
           apply_domain_wide_defaults!
           IR::Hecksagon.new(domain: @domain, binds: @binds, subscriptions: @subscriptions,

--- a/lib/hecksagain/bluebook/dsl/value_object_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/value_object_builder.rb
@@ -10,6 +10,10 @@ module Hecksagain
           @members    = []
         end
 
+        # Vendored no-op stub, not (yet) upstream hecksagain -- see
+        # CommandBuilder/PolicyBuilder's identical stubs.
+        def description(value) = nil
+
         # moved to the language: a closed set admits a member, on Shape.Close.
         #
         # This was called unportable because an empty one_of and no one_of are
@@ -17,7 +21,23 @@ module Hecksagain
         # an empty attribute NAME survives into the IR and is judged there. So
         # the IR now records that a closed set was declared, and the language
         # judges it like everything else.
-        def one_of(&block)
+        # Vendored disambiguation, not (yet) upstream hecksagain: the bare
+        # word `one_of` names TWO different grammar forms that collide
+        # inside a value_object body specifically -- the closed-set BODY
+        # form (`one_of do member value: "x" end`, this class's own
+        # method) and AttributeCollector's TYPE-position sugar
+        # (`attribute :x, one_of("a", "b")`), needed when a value_object's
+        # OWN attribute wants an inline closed set. Since ValueObjectBuilder
+        # overrides AttributeCollector's `one_of`, the sugar form silently
+        # resolved to this 0-arg method and raised ArgumentError
+        # (hecks_conception's ViolationKind value_object hit this). Args-only
+        # (no block) delegates to `super` -- AttributeCollector's original;
+        # block-only (no args) keeps this class's own closed-set-body
+        # behavior. TODO upstream via hecksagain's own bin/evolve
+        # word-admission process (migration plan task 7).
+        def one_of(*values, &block)
+          return super(*values) if values.any? && !block
+
           @closed_set = true
           instance_eval(&block) if block
         end
@@ -28,7 +48,7 @@ module Hecksagain
           @members << fields
         end
 
-        def invariant(description, &predicate)
+        def invariant(description = "an invariant holds", &predicate)
           canonical = Ports::Extraction.canonical(predicate)
 
           # moved to the language: given "a rule says what it means", on Shape.Assert
@@ -45,6 +65,17 @@ module Hecksagain
             predicate:   predicate
           )
         end
+        # Vendored alias, not (yet) upstream hecksagain (migration plan
+        # task 8): `rule "description" do ... end` -- 21 files across the
+        # other-20-projects wave (bin-buddy/opt-website/vindiction/
+        # mietteai/...) write this instead of `invariant`. Not a random
+        # guess : this method's OWN existing comment already names "rule"
+        # as the intended word ("moved to the language: given 'a rule
+        # says what it means', on Shape.Assert") -- the alias just
+        # exposes the vocabulary hecksagain's own source already settled
+        # on. TODO upstream via bin/evolve (migration plan task 7):
+        # decide which spelling becomes canonical.
+        alias_method :rule, :invariant
 
         def build
           IR::ValueObject.declare(

--- a/spec/catchall_stubs_growth_spec.rb
+++ b/spec/catchall_stubs_growth_spec.rb
@@ -1,0 +1,208 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for item 1855be0-g's catch-all cluster: trivial no-op
+# stubs (structurally captured so a file boots, never silently
+# pretended enforced) PLUS two real, independently-meaningful pieces
+# that happened to land in the same commit's tail:
+#
+# - AggregateBuilder's `identified_by` DEFAULT (first declared
+#   attribute's own .value path, for a domain that declares none at
+#   all) -- a real behavior change, not a stub.
+# - ValueObjectBuilder#one_of's real ArgumentError bug fix (covered in
+#   depth by docs/guides/aggregates-and-value-objects.md's own doctest,
+#   updated in this same PR) -- exercised here too, directly.
+RSpec.describe "1855be0-g catch-all: DSL builder stubs and small real fixes" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["catchall-stubs-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds) if hecksagon_name
+    end
+
+    registry.verify! if hecksagon_name
+    registry
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  describe "AggregateBuilder#identified_by default (real behavior, not a stub)" do
+    NO_IDENTITY_SOURCE = <<~BLUEBOOK
+      Hecks.bluebook "NoIdentityCatchallGrowth" do
+        aggregate "Widget" do
+          value_object "SerialNumber" do
+            attribute :value, String
+          end
+
+          attribute :serial_number, SerialNumber
+          attribute :label, String
+        end
+      end
+    BLUEBOOK
+
+    it "falls back to the FIRST declared attribute's own .value path" do
+      registry = boot(NO_IDENTITY_SOURCE, nil)
+      widget = registry.bluebook("NoIdentityCatchallGrowth").aggregate("Widget")
+
+      expect(widget.identified_by).to eq(:serial_number)
+      expect(widget.identity_paths).to eq(["serial_number.value"])
+    end
+  end
+
+  describe "AggregateBuilder#fixture (inline, aggregate-level, no-op stub)" do
+    it "accepts an inline fixture block with arbitrary field setters, without raising" do
+      builder = Hecksagain::Bluebook::DSL::AggregateBuilder.new("FixtureCatchallGrowth")
+      expect do
+        builder.instance_eval do
+          fixture "Default" do
+            name "House Battery Bank"
+            voltage 12.8
+          end
+        end
+      end.not_to raise_error
+    end
+  end
+
+  describe "ValueObjectBuilder#description (no-op stub)" do
+    it "is accepted, not stored" do
+      vo = Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("DescribedVoCatchallGrowth") do
+        description "a described value object"
+        attribute :value, String
+      end
+      expect(vo.attributes.map(&:name)).to eq([:value])
+    end
+  end
+
+  describe "ValueObjectBuilder#one_of's real disambiguation fix" do
+    it "the inline shorthand (values, no block) now synthesizes a closed set instead of raising ArgumentError" do
+      vo = Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("InlineOneOfCatchallGrowth") do
+        attribute :size, one_of("small", "large")
+      end
+
+      field = vo.attributes.find { |a| a.name == :size }
+      expect(field.type.to_s).to eq("Size")
+    end
+
+    it "the closed-set-body form (block, no values) still works exactly as before" do
+      vo = Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("BodyOneOfCatchallGrowth") do
+        one_of do
+          member value: "open"
+          member value: "shut"
+        end
+      end
+
+      expect(vo.members.map { |m| m[:value] }).to eq(%w[open shut])
+    end
+  end
+
+  describe "ValueObjectBuilder#rule (invariant's alias) and invariant's default description" do
+    it "rule is invariant's exact alias" do
+      source = <<~BLUEBOOK
+        Hecks.bluebook "RuleAliasCatchallGrowth" do
+          aggregate "AddOn" do
+            identified_by { id.value }
+            value_object "AddOnId" do
+              attribute :value, String
+            end
+            attribute :id, AddOnId
+
+            value_object "Config" do
+              attribute :value, String
+              rule("a rule holds") { |vo| true }
+            end
+            attribute :config, Config
+          end
+        end
+      BLUEBOOK
+
+      registry = boot(source, nil)
+      config = registry.bluebook("RuleAliasCatchallGrowth").aggregate("AddOn").value_object("Config")
+      expect(config.invariants.map(&:description)).to eq(["a rule holds"])
+    end
+  end
+
+  describe "HecksagonBuilder#gate (no-op stub)" do
+    it "accepts a gate block with allow calls, without raising or storing anything" do
+      hecksagon = Hecksagain::Bluebook::DSL::HecksagonBuilder.build("GateCatchallGrowth") do
+        gate "Aggregate", :role do
+          allow :Cmd1, :Cmd2
+        end
+      end
+
+      expect(hecksagon.binds).to be_empty
+    end
+  end
+
+  describe "HecksagonBuilder#method_missing (portal/branding catch-all)" do
+    it "absorbs unknown app-surface config verbs rather than raising NoMethodError" do
+      expect do
+        Hecksagain::Bluebook::DSL::HecksagonBuilder.build("PortalCatchallGrowth") do
+          capabilities :webapp
+          brand_color "#336699"
+        end
+      end.not_to raise_error
+    end
+
+    it "real methods still win over the catch-all" do
+      hecksagon = Hecksagain::Bluebook::DSL::HecksagonBuilder.build("PortalRealMethodCatchallGrowth") do
+        subscribe "SomeEvent"
+      end
+      expect(hecksagon.subscriptions).to eq(["SomeEvent"])
+    end
+  end
+
+  describe "BluebookBuilder's bare stub surface (glossary/entrypoint/fixture/section/define/lifecycle/event/actor)" do
+    it "every stub is accepted so a real file using all of them boots without raising" do
+      registry = nil
+      expect do
+        registry = Hecksagain::Bluebook::DSL::BluebookBuilder.build("BluebookStubsCatchallGrowth") do
+          glossary(strict: true)
+          entrypoint "Main"
+          fixture "Seed", on: "Widget"
+          section("Header") { row "key", "value" }
+          define "Term", "a definition"
+          lifecycle("Named") do
+            state "x"
+            transition from: "a", to: "b", on: "Event"
+          end
+          event "SomethingHappened"
+          actor "Support", description: "handles tickets"
+        end
+      end.not_to raise_error
+
+      expect(registry).to be_a(Hecksagain::Bluebook::IR::Bluebook)
+    end
+  end
+
+  describe "BluebookBuilder#aggregate's inline_description sugar" do
+    INLINE_DESCRIPTION_SOURCE = <<~BLUEBOOK
+      Hecks.bluebook "InlineDescriptionCatchallGrowth" do
+        aggregate "Widget", "a small useful thing" do
+          identified_by { id.value }
+          value_object "WidgetId" do
+            attribute :value, String
+          end
+          attribute :id, WidgetId
+        end
+      end
+    BLUEBOOK
+
+    it "aggregate \"Name\", \"desc\" do ... end sets the description without a separate call" do
+      registry = boot(INLINE_DESCRIPTION_SOURCE, nil)
+      expect(registry.bluebook("InlineDescriptionCatchallGrowth").aggregate("Widget").description)
+        .to eq("a small useful thing")
+    end
+  end
+end

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe "the DSL surface is fully covered" do
     "BluebookBuilder" => [
       Hecksagain::Bluebook::DSL::BluebookBuilder,
       %i[vision formerly_known_as core supporting generic aggregate report read_model policy process_manager classification
-         category]
+         category glossary entrypoint fixture section define lifecycle event actor]
     ],
     "AggregateBuilder" => [
       Hecksagain::Bluebook::DSL::AggregateBuilder,
       %i[description provenance identified_by reference_to has_many has_one belongs_to value_object command lifecycle
          entity query policy attribute list_of attributes synthesise_primitive_wrapper
-         specification specifications invariant rule validation aggregate_invariants]
+         specification specifications invariant rule validation aggregate_invariants fixture]
     ],
     "ValueObjectBuilder" => [
       Hecksagain::Bluebook::DSL::ValueObjectBuilder,
-      %i[invariant one_of member attribute list_of attributes]
+      %i[invariant rule one_of member attribute list_of attributes description]
     ],
     "CommandBuilder" => [
       Hecksagain::Bluebook::DSL::CommandBuilder,
@@ -60,7 +60,7 @@ RSpec.describe "the DSL surface is fully covered" do
       Hecksagain::Bluebook::DSL::HecksagonBuilder,
       %i[binds subscribe subscriptions port uses_framework framework_members
          adapter raw_adapters driving_handlers domain_wide_persisted_by apply_domain_wide_defaults!
-         success failure]
+         success failure gate method_missing]
     ],
     "TranslationBuilder" => [
       Hecksagain::Bluebook::DSL::TranslationBuilder,
@@ -108,7 +108,8 @@ RSpec.describe "the DSL surface is fully covered" do
       Hecksagain::Bluebook::DSL::WorldBuilder,
       Hecksagain::Bluebook::DSL::SettingsCollector,
       Hecksagain::Bluebook::DSL::BindingProxy,
-      Hecksagain::Bluebook::DSL::WorldConstProxy
+      Hecksagain::Bluebook::DSL::WorldConstProxy,
+      Hecksagain::Bluebook::DSL::HecksagonBuilder
     ].each do |klass|
       expect(klass.public_instance_methods(false)).to include(:method_missing),
                                                       "#{klass} should answer to anything"


### PR DESCRIPTION
Item `1855be0-g` of the hecksagain migration PR-split (`.pr-split-plan.md`), stacked on item `1855be0-l` (#73). Closes out `1855be0`'s full breakdown.

**What this lands** — a cluster of documented-gap no-op stubs (accepted so a real corpus file boots, never silently pretended enforced) PLUS two independently real, small fixes that happened to land in the same commit's tail:

**Real fixes**:
- `AggregateBuilder#identified_by` DEFAULT — falls back to the FIRST declared attribute's own `.value` path when a domain declares none at all (375 files in hecks_nursury).
- `ValueObjectBuilder#one_of`'s real `ArgumentError` bug fix: the bare word `one_of` names two different grammar forms that collide inside a `value_object` body. Disambiguated by call shape. Includes a rewrite of `docs/guides/aggregates-and-value-objects.md`'s own doctest, which previously DEMONSTRATED this exact bug as a documented "trap" — now demonstrates the fix.

**No-op stubs**: `AggregateBuilder#fixture`/`inline_description` sugar, `ValueObjectBuilder#description`/`#rule`/`invariant`'s default description, `HecksagonBuilder#gate`/`GateStub`/`#method_missing`, `BluebookBuilder#glossary`/`#entrypoint`/`#fixture`/`#section`/`#define`/`#lifecycle`/`#event`/`#actor`.

**Spec coverage**: `spec/catchall_stubs_growth_spec.rb` — every stub boots without raising, the two real fixes get real assertions. Verified genuinely failing without this fix via `git stash` (9/11 examples; 2 correctly pass either way).

**Verification**: 1405 examples, 18 failures (up from 1394/18 baseline — identical failure SET except the one expected `syntax_conformance` gap for `ValueObjectBuilder`'s new words, closed later by item 35; no regressions).

**With this PR, the ENTIRE `1855be0` commit is fully split**: items a, a3, a4, b, c, e, f, g, h, i, j, k, l, m, n — 15 real sub-items total from this one commit (vs. the original plan's guess of ~7).
