### PR TITLE
runtime: era_check.rb matches a domain's own file by declared name, not filename

### DIFF
--- a/lib/hecksagain/runtime/era_check.rb
+++ b/lib/hecksagain/runtime/era_check.rb
@@ -69,7 +69,44 @@ module Hecksagain
       # `uses_framework`.
       def source_text_for(bluebook, directory)
         domain_files = Dir[File.join(directory, "*.bluebook")]
-        own = domain_files.find { |path| Naming.pascal(File.basename(path, ".bluebook")) == bluebook.name }
+        # Vendored addition, not (yet) upstream hecksagain (migration plan
+        # task 8, embryonautfoundersapp finding): content match FIRST, not
+        # basename match -- `stage_flat_corpus` flattens a whole project
+        # into ONE numeric-prefixed directory (`042_foo.bluebook`), so
+        # `File.basename(path, ".bluebook") == bluebook.name` (pascal-
+        # cased) can never hit -- the prefix always sits in front of it.
+        # Stripping the prefix wouldn't have been enough either: a real
+        # corpus file is free to be named in a way that doesn't
+        # round-trip through `Naming.pascal` at all (found live:
+        # `embryonautfoundersapp.bluebook`, an all-lowercase, no-
+        # separator filename, pascal-cases to "Embryonautfoundersapp",
+        # never "EmbryonautFoundersApp" -- the declared domain name's own
+        # internal capitalization is lost the moment the filename has no
+        # word boundaries to carry it). The flatten also copies a
+        # domain's `translations/*.bluebook` era-history siblings
+        # (`Hecks.data_translation ...`, a different top-level construct
+        # entirely) into the SAME directory as the real bluebook, which
+        # used to be invisible to this glob (non-recursive, and
+        # `translations/` sits one level down) before staging made it
+        # recursive-by-copy -- inflating `domain_files.size` past 1 and
+        # silently defeating the single-file fallback below, which is
+        # what actually broke this case (the ORIGINAL, un-staged
+        # directory has exactly one top-level `.bluebook` file, so the
+        # fallback already covered it fine).
+        # The fix: read each candidate file's OWN `Hecks.bluebook "Name"`
+        # declaration line and match it directly against bluebook.name --
+        # the exact fact this function is trying to establish, rather
+        # than inferring it from a filename convention. Same regex
+        # `hecksagain_runtime.rb`'s `domain_name_of` already uses for
+        # topo-sort ordering, so this is a second, independent consumer
+        # of an already-proven-reliable signal, not a new heuristic.
+        # Immune to numeric prefixing, disambiguation-prefixing, and
+        # non-word-boundary filenames alike, since it never reads the
+        # filename at all. Falls through to the old basename heuristic
+        # and single-file fallback unchanged, so nothing that used to
+        # match stops matching.
+        own = domain_files.find { |path| File.read(path)[/^Hecks\.bluebook\s+"([^"]+)"/, 1] == bluebook.name }
+        own ||= domain_files.find { |path| Naming.pascal(File.basename(path, ".bluebook")) == bluebook.name }
         own ||= domain_files.first if domain_files.size == 1 && !Framework.members.key?(bluebook.name)
         path = own || Framework.members[bluebook.name]
         path && File.read(path)

--- a/spec/runtime/era_check_content_matching_growth_spec.rb
+++ b/spec/runtime/era_check_content_matching_growth_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "tmpdir"
+
+# Real coverage for EraCheck#source_text_for's content-matching fix: a
+# domain's own bluebook file used to be found by FILENAME
+# (Naming.pascal(basename) == bluebook.name), which breaks once a corpus is
+# flattened into one numeric-prefixed staging directory (042_foo.bluebook)
+# or has a filename that doesn't round-trip through Naming.pascal at all
+# (embryonautfoundersapp.bluebook pascal-cases to "Embryonautfoundersapp",
+# never "EmbryonautFoundersApp" -- the declared name's own internal
+# capitalization is lost the moment the filename has no word boundaries to
+# carry it). Fixed by reading each candidate file's own
+# `Hecks.bluebook "Name"` declaration line and matching it directly.
+RSpec.describe "EraCheck#source_text_for matches by declared name, not filename" do
+  def bluebook_named(name)
+    Hecksagain::Bluebook::IR::Bluebook.new(name: name)
+  end
+
+  it "finds a file whose name never round-trips through Naming.pascal" do
+    Dir.mktmpdir do |dir|
+      own_path = File.join(dir, "embryonautfoundersapp.bluebook")
+      File.write(own_path, "Hecks.bluebook \"EmbryonautFoundersApp\" do\nend\n")
+
+      # a second file in the same directory defeats the single-file
+      # fallback, forcing a real match to be found
+      File.write(File.join(dir, "translations.bluebook"), "Hecks.data_translation(\"Other\", from: \"1\", to: \"2\") do\nend\n")
+
+      bluebook = bluebook_named("EmbryonautFoundersApp")
+
+      text = Hecksagain::Runtime::EraCheck.source_text_for(bluebook, dir)
+      expect(text).to eq(File.read(own_path))
+    end
+  end
+
+  it "finds a file flattened into a numeric-prefixed staging directory" do
+    Dir.mktmpdir do |dir|
+      own_path = File.join(dir, "042_shaped_growth.bluebook")
+      File.write(own_path, "Hecks.bluebook \"ShapedGrowth\" do\nend\n")
+
+      File.write(File.join(dir, "999_other_growth.bluebook"), "Hecks.bluebook \"OtherGrowth\" do\nend\n")
+
+      bluebook = bluebook_named("ShapedGrowth")
+
+      text = Hecksagain::Runtime::EraCheck.source_text_for(bluebook, dir)
+      expect(text).to eq(File.read(own_path))
+    end
+  end
+
+  it "still falls through to the basename heuristic when content-match misses" do
+    Dir.mktmpdir do |dir|
+      # no `Hecks.bluebook "Name"` line at all on this one -- an edge case
+      # the content match cannot resolve, so the old heuristic must still
+      # catch it
+      own_path = File.join(dir, "legacy_growth.bluebook")
+      File.write(own_path, "# no declaration line here\n")
+
+      File.write(File.join(dir, "other_growth.bluebook"), "Hecks.bluebook \"OtherGrowth\" do\nend\n")
+
+      bluebook = bluebook_named("LegacyGrowth")
+
+      text = Hecksagain::Runtime::EraCheck.source_text_for(bluebook, dir)
+      expect(text).to eq(File.read(own_path))
+    end
+  end
+end


### PR DESCRIPTION
Splits `1b77379` (era_check + registry: real fixes for a flattened, multi-file corpus) — item 24 of the [PR-split plan](.pr-split-plan.md). This PR covers only the `era_check.rb` half; the `Registry#add_hecksagon` half is a separate, independent finding stacked on top (item 25).

**Finding**: `EraCheck#source_text_for` matched a domain's own bluebook file by filename (`Naming.pascal(basename) == bluebook.name`), which breaks once a corpus is flattened into one numeric-prefixed staging directory (`042_foo.bluebook`, prefix always sits in front of the round-trippable part) or has a filename that doesn't round-trip through `Naming.pascal` at all (`embryonautfoundersapp.bluebook` pascal-cases to `Embryonautfoundersapp`, never `EmbryonautFoundersApp` — no word boundaries to carry the internal capitalization). The single-file directory fallback also silently stopped covering this once a flattened directory legitimately holds more than one `.bluebook` file (translation siblings included).

**Fix**: read each candidate file's own `Hecks.bluebook "Name"` declaration line and match it directly against `bluebook.name` — the same signal `hecksagain_runtime.rb`'s `domain_name_of` already uses for topo-sort ordering — falling through to the old filename heuristic unchanged for files with no declaration line.

**Coverage**: `spec/runtime/era_check_content_matching_growth_spec.rb`, 3 examples — a non-round-tripping filename, a numeric-prefixed flattened-corpus filename, and a fallback-to-basename-heuristic case when content match cannot resolve. Verified genuinely failing without the fix via `git stash` (2/3 examples fail with `nil` where the file's content should have been returned).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1408 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps as the parent branch (`split/1855be0-g-catchall-stubs`), no regressions (up 3 examples from the new spec).
