### PR TITLE
runtime: Registry#add_hecksagon merges multi-file hecksagon declarations

### DIFF
--- a/lib/hecksagain/runtime/registry.rb
+++ b/lib/hecksagain/runtime/registry.rb
@@ -40,7 +40,27 @@ module Hecksagain
       end
 
       def add_bluebook(item)  = @bluebooks[item.name]  = item
-      def add_hecksagon(item) = @hecksagons[item.domain] = item
+
+      # Vendored fix, not (yet) upstream hecksagain (migration plan task
+      # 4): a plain overwrite before this -- the SAME gap `bluebook_
+      # builder` right above already exists to solve for multi-file
+      # BLUEBOOKS ("needs its declarations to accumulate into ONE builder
+      # rather than each file minting its own and silently discarding the
+      # one before"), just never extended to hecksagons. A domain's
+      # `.hecksagon` binds routinely split across files one-per-aggregate
+      # (conductor/{merge_queue,lease,sweeper,claim,worker}.hecksagon, all
+      # `Hecks.hecksagon "Conductor"`) -- each call built a FRESH
+      # IR::Hecksagon and overwrote the one before, so only the LAST
+      # file's binds survived registry-wide ("Conductor::MergeQueue has
+      # no persisted_by bind" even though merge_queue.hecksagon plainly
+      # binds it -- lease.hecksagon just loaded after and clobbered it).
+      # Merges binds/subscriptions/framework_members/driving_handlers
+      # across every call for the same domain instead.
+      def add_hecksagon(item)
+        existing = @hecksagons[item.domain]
+        @hecksagons[item.domain] = existing ? merge_hecksagons(existing, item) : item
+      end
+
       def add_port(item)    = @ports[item.name]   = item
       def add_adapter(item)   = @adapters[item.name]   = item
       def add_world(item)     = @worlds[item.domain]   = item
@@ -78,6 +98,17 @@ module Hecksagain
         end)
         authoritative = repository(domain, aggregate)
         projection_current?(projection, authoritative) ? projection : authoritative
+      end
+
+      # See #add_hecksagon's own comment.
+      def merge_hecksagons(a, b)
+        Bluebook::IR::Hecksagon.new(
+          domain:            a.domain,
+          binds:             a.binds + b.binds,
+          subscriptions:     a.subscriptions + b.subscriptions,
+          framework_members: a.framework_members + b.framework_members,
+          driving_handlers:  a.driving_handlers + b.driving_handlers
+        )
       end
 
       def projection_current?(projection, authoritative)

--- a/spec/runtime/registry_add_hecksagon_merge_growth_spec.rb
+++ b/spec/runtime/registry_add_hecksagon_merge_growth_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+# Real coverage for Registry#add_hecksagon's multi-file accumulation fix:
+# before this, add_hecksagon was a plain hash overwrite, the same gap
+# add_bluebook already solves for multi-file bluebooks but never extended to
+# hecksagons. A domain's .hecksagon binds routinely split one-file-per-
+# aggregate (conductor/{merge_queue,lease,sweeper,claim,worker}.hecksagon,
+# all `Hecks.hecksagon "Conductor"`) -- each Declare built a fresh
+# IR::Hecksagon and overwrote the one before, so only the LAST-loaded
+# file's binds survived registry-wide. Now merges binds/subscriptions/
+# framework_members/driving_handlers across every call for the same domain.
+RSpec.describe "Registry#add_hecksagon merges multi-file hecksagon declarations" do
+  def bind_for(aggregate)
+    Hecksagain::Bluebook::IR::Bind.new(aggregate: aggregate, verb: "persisted_by", adapter: "Memory", role: nil)
+  end
+
+  def hecksagon_for(domain, *binds)
+    Hecksagain::Bluebook::IR::Hecksagon.new(domain: domain, binds: binds)
+  end
+
+  it "merges a second file's binds into the first, rather than overwriting them" do
+    registry = Hecksagain::Runtime::Registry.new
+
+    registry.add_hecksagon(hecksagon_for("Conductor", bind_for("Conductor::MergeQueue")))
+    registry.add_hecksagon(hecksagon_for("Conductor", bind_for("Conductor::Lease")))
+    registry.add_hecksagon(hecksagon_for("Conductor", bind_for("Conductor::Sweeper")))
+
+    merged = registry.hecksagons["Conductor"]
+    expect(merged.binds.map(&:aggregate_name)).to contain_exactly("MergeQueue", "Lease", "Sweeper")
+
+    # the whole point: the FIRST file's own bind must still be resolvable
+    # after later files load, not just the last one
+    expect(merged.bind_for("MergeQueue", "persisted_by")).not_to be_nil
+  end
+
+  it "merges subscriptions, framework_members, and driving_handlers too" do
+    registry = Hecksagain::Runtime::Registry.new
+
+    first = Hecksagain::Bluebook::IR::Hecksagon.new(
+      domain: "Conductor", binds: [], subscriptions: ["Sub1"], framework_members: ["Fw1"], driving_handlers: []
+    )
+    second = Hecksagain::Bluebook::IR::Hecksagon.new(
+      domain: "Conductor", binds: [], subscriptions: ["Sub2"], framework_members: [], driving_handlers: ["Dh1"]
+    )
+
+    registry.add_hecksagon(first)
+    registry.add_hecksagon(second)
+
+    merged = registry.hecksagons["Conductor"]
+    expect(merged.subscriptions).to eq(%w[Sub1 Sub2])
+    expect(merged.framework_members).to eq(%w[Fw1])
+    expect(merged.driving_handlers).to eq(%w[Dh1])
+  end
+
+  it "does not merge across different domains" do
+    registry = Hecksagain::Runtime::Registry.new
+
+    registry.add_hecksagon(hecksagon_for("Conductor", bind_for("Conductor::MergeQueue")))
+    registry.add_hecksagon(hecksagon_for("OtherDomain", bind_for("OtherDomain::Thing")))
+
+    expect(registry.hecksagons["Conductor"].binds.map(&:aggregate_name)).to eq(["MergeQueue"])
+    expect(registry.hecksagons["OtherDomain"].binds.map(&:aggregate_name)).to eq(["Thing"])
+  end
+end


### PR DESCRIPTION
Splits `1b77379` (era_check + registry: real fixes for a flattened, multi-file corpus) — item 25 of the [PR-split plan](.pr-split-plan.md). This PR covers only the `Registry#add_hecksagon` half; the `era_check.rb` half is a separate, independent finding at the base of this branch (item 24, PR #76).

**Finding**: `Registry#add_hecksagon` was a plain hash overwrite — the same gap `add_bluebook` already solves for multi-file bluebooks (`@bluebook_builders` accumulates across files, per that method's own comment), but never extended to hecksagons. A domain's `.hecksagon` binds routinely split one-file-per-aggregate (`conductor/{merge_queue,lease,sweeper,claim,worker}.hecksagon`, all `Hecks.hecksagon "Conductor"`) — each `Declare` built a fresh `IR::Hecksagon` and overwrote the one before, so only the LAST-loaded file's binds survived registry-wide.

**Fix**: `add_hecksagon` now merges `binds`/`subscriptions`/`framework_members`/`driving_handlers` across every call for the same domain, via a new `merge_hecksagons` helper.

**Coverage**: `spec/runtime/registry_add_hecksagon_merge_growth_spec.rb`, 3 examples — sequential multi-file binds all surviving, all four merged collections, and cross-domain isolation. Verified genuinely failing without the fix via `git stash` (2/3 examples — only the LAST file's binds/subscriptions/etc. survive).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1411 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps, no regressions (up 3 examples from the new spec).
