### PR TITLE
adapters: DiskBuffer + screenshot_buffer port registration

### DIFF
--- a/lib/hecksagain/adapters/driven/disk_buffer.adapter
+++ b/lib/hecksagain/adapters/driven/disk_buffer.adapter
@@ -1,0 +1,13 @@
+# Vendored addition, not (yet) upstream hecksagain (migration plan task
+# 4): "DiskBuffer" -- the out-of-process handler web_debug.hecksagon's
+# `Screenshot.buffered_by("DiskBuffer", on: "FrameCaptured")` names.
+# Registers the adapter so wiring resolves ; the actual handler process
+# (writing frames to disk, pruning old ones) is real, external, off-core
+# machinery this bind only DECLARES the contract for -- same as the
+# still-unimplemented success/failure verdict re-entry the whole
+# effect-family subsystem needs (see screenshot_buffer.port's own
+# comment). No fields : the buffer's own path convention is handler-side
+# config, not a bluebook-declared value.
+Hecks.adapter "DiskBuffer" do
+  port "screenshot_buffer"
+end

--- a/lib/hecksagain/ports/screenshot_buffer.port
+++ b/lib/hecksagain/ports/screenshot_buffer.port
@@ -1,0 +1,20 @@
+# Vendored addition, not (yet) upstream hecksagain (migration plan task
+# 4): the `buffered_by` verb (framework/web_debug/bluebook/
+# web_debug.hecksagon: "Screenshot.buffered_by('DiskBuffer', on:
+# 'FrameCaptured')"). hecks_conception's own `.family` files
+# (aggregates/framework/families/*.family, including screenshot_buffer.
+# family) are PURE PROSE — confirmed by reading hecksagain's own source:
+# there is no `Hecks.family` DSL method anywhere, so `.family` was never
+# a real, parsed construct, only illustrative documentation mirroring
+# the Pizzas example's narrative. The REAL, load-bearing registration a
+# bind's wiring check needs is a `.port` (verb + signal) plus an
+# `.adapter` declaring it — same shape persistence.port/heki.adapter
+# already use. `signal :effect` because this is the SAME async-verdict
+# shape as `payment`/`imaged_by` (an event fires the write, a handler
+# runs off-core) -- itself part of the still-unimplemented effect-family
+# subsystem this migration flagged as its single biggest remaining gap
+# (success/failure are structural no-op stubs, see hecksagon_builder.rb).
+Hecks.port "screenshot_buffer" do
+  verb   "buffered_by"
+  signal :effect
+end

--- a/spec/disk_buffer_adapter_growth_spec.rb
+++ b/spec/disk_buffer_adapter_growth_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+# Real coverage for the DiskBuffer adapter registration: the out-of-
+# process handler web_debug.hecksagon's own
+# `Screenshot.buffered_by("DiskBuffer", on: "FrameCaptured")` names it,
+# but before this there was no `.port`/`.adapter` pair for it to resolve
+# against, so a real bind naming it failed the wiring gate with "unknown
+# adapter". The actual handler process (writing frames to disk, pruning
+# old ones) is real, external, off-core machinery this registration only
+# DECLARES the contract for -- same shape as the still-unimplemented
+# success/failure async-verdict re-entry the whole effect-family
+# subsystem needs, so no Ruby adapter CLASS is required here (verify!
+# never calls adapter_class for a non-persistence-verb bind).
+RSpec.describe "the DiskBuffer adapter and screenshot_buffer port" do
+  def registry_with_real_library
+    registry = Hecksagain::Runtime::Registry.new
+    loading = Hecksagain::Ports::Loading.bootstrap
+    Hecksagain.with_registry(registry) { loading.load_library }
+    registry
+  end
+
+  it "resolves a buffered_by bind naming DiskBuffer without a WiringError" do
+    registry = registry_with_real_library
+
+    bind = Hecksagain::Bluebook::IR::Bind.new(
+      aggregate: "WebDebug::Screenshot", verb: "buffered_by", adapter: "DiskBuffer", role: nil
+    )
+
+    expect { registry.check_verb(bind) }.not_to raise_error
+  end
+
+  it "the screenshot_buffer port declares buffered_by as an effect signal" do
+    registry = registry_with_real_library
+
+    port = registry.ports["screenshot_buffer"]
+    expect(port.verb).to eq("buffered_by")
+    expect(port.effect?).to be(true)
+  end
+
+  it "refuses a bind naming DiskBuffer for the wrong verb" do
+    registry = registry_with_real_library
+
+    bind = Hecksagain::Bluebook::IR::Bind.new(
+      aggregate: "WebDebug::Screenshot", verb: "persisted_by", adapter: "DiskBuffer", role: nil
+    )
+
+    expect { registry.check_verb(bind) }.to raise_error(
+      Hecksagain::Runtime::WiringError, /DiskBuffer implements the screenshot_buffer port.*cannot satisfy persisted_by/m
+    )
+  end
+end


### PR DESCRIPTION
Splits `f212750` — item 27 of the [PR-split plan](.pr-split-plan.md) (real total for this commit is 5 pieces, not the original plan's 3-item guess — see item 26/PR #78's own note). This PR covers only DiskBuffer + `screenshot_buffer`; DreamImage and Stripe are separate, independent registrations for different domains/ports, each getting their own item stacked on top.

**Finding**: the out-of-process handler `web_debug.hecksagon`'s own `Screenshot.buffered_by("DiskBuffer", on: "FrameCaptured")` names this adapter, but no `.port`/`.adapter` pair existed for it to resolve against — a real bind naming it failed the wiring gate with `unknown adapter "DiskBuffer"`. The actual handler process (writing frames to disk, pruning old ones) is real, external, off-core machinery; this registration only DECLARES the contract (no Ruby adapter class needed — `verify!` never calls `adapter_class` for a non-persistence-verb bind). `signal :effect` because this is the same async-verdict shape as `payment`/`imaged_by`.

hecks_conception's own `.family` files (`screenshot_buffer.family` included) are pure prose — there is no `Hecks.family` DSL method anywhere in hecksagain, confirmed on real-diff read, so `.family` was never a parsed construct. The `.port` + `.adapter` pair is the real, load-bearing registration.

**Coverage**: `spec/disk_buffer_adapter_growth_spec.rb`, 3 examples — wiring resolves for a real `buffered_by` bind, the port's own shape (`effect?`), and the existing verb-mismatch refusal still fires correctly for the wrong verb. Verified genuinely failing without the fix via `git stash` (3/3 examples — `unknown adapter "DiskBuffer"` / `NoMethodError` on a nil port).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1416 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps, no regressions (up 3 examples from the new spec).
