### PR TITLE
adapters: DreamImage + dream_image port registration

### DIFF
--- a/lib/hecksagain/adapters/driven/dream_image.adapter
+++ b/lib/hecksagain/adapters/driven/dream_image.adapter
@@ -1,0 +1,8 @@
+# Vendored addition, not (yet) upstream hecksagain (migration plan task
+# 4): "DreamImage" -- registers the adapter dream.hecksagon's `imaged_by`
+# bind names, so wiring resolves. The actual image-generation call is
+# real, external, off-core handler machinery this bind only declares the
+# contract for -- see dream_image.port's own comment.
+Hecks.adapter "DreamImage" do
+  port "dream_image"
+end

--- a/lib/hecksagain/ports/dream_image.port
+++ b/lib/hecksagain/ports/dream_image.port
@@ -1,0 +1,12 @@
+# Vendored addition, not (yet) upstream hecksagain (migration plan task
+# 4): the `imaged_by` verb (miette's body/dream/bluebook/dream.hecksagon:
+# "BodyDream::Dream.imaged_by('DreamImage', on: 'DreamImageRequested')").
+# Same shape as screenshot_buffer.port's own comment — an effect-family
+# async-verdict edge (an event fires an external LLM image-generation
+# call, off-core, and its reading re-enters via success/failure — still
+# structurally stubbed, part of this migration's single biggest
+# confirmed-unimplemented gap).
+Hecks.port "dream_image" do
+  verb   "imaged_by"
+  signal :effect
+end

--- a/spec/dream_image_adapter_growth_spec.rb
+++ b/spec/dream_image_adapter_growth_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+# Real coverage for the DreamImage adapter registration: miette's own
+# body/dream/bluebook/dream.hecksagon declares
+# `BodyDream::Dream.imaged_by("DreamImage", on: "DreamImageRequested")`,
+# but no `.port`/`.adapter` pair existed for it to resolve against -- a
+# real bind naming it failed the wiring gate with "unknown adapter".
+# The actual image-generation call is real, external, off-core handler
+# machinery this registration only DECLARES the contract for -- same
+# shape as screenshot_buffer.port/payment.port, part of this migration's
+# single biggest confirmed-unimplemented gap (the effect-family
+# success/failure re-entry, still a structural stub).
+RSpec.describe "the DreamImage adapter and dream_image port" do
+  def registry_with_real_library
+    registry = Hecksagain::Runtime::Registry.new
+    loading = Hecksagain::Ports::Loading.bootstrap
+    Hecksagain.with_registry(registry) { loading.load_library }
+    registry
+  end
+
+  it "resolves an imaged_by bind naming DreamImage without a WiringError" do
+    registry = registry_with_real_library
+
+    bind = Hecksagain::Bluebook::IR::Bind.new(
+      aggregate: "BodyDream::Dream", verb: "imaged_by", adapter: "DreamImage", role: nil
+    )
+
+    expect { registry.check_verb(bind) }.not_to raise_error
+  end
+
+  it "the dream_image port declares imaged_by as an effect signal" do
+    registry = registry_with_real_library
+
+    port = registry.ports["dream_image"]
+    expect(port.verb).to eq("imaged_by")
+    expect(port.effect?).to be(true)
+  end
+
+  it "refuses a bind naming DreamImage for the wrong verb" do
+    registry = registry_with_real_library
+
+    bind = Hecksagain::Bluebook::IR::Bind.new(
+      aggregate: "BodyDream::Dream", verb: "persisted_by", adapter: "DreamImage", role: nil
+    )
+
+    expect { registry.check_verb(bind) }.to raise_error(
+      Hecksagain::Runtime::WiringError, /DreamImage implements the dream_image port.*cannot satisfy persisted_by/m
+    )
+  end
+end


### PR DESCRIPTION
Splits `f212750` — item 27a of the [PR-split plan](.pr-split-plan.md), a new split from the original plan's "27 — DiskBuffer/DreamImage adapters + ports" (real-diff read found these two genuinely independent — different domain, different port, different real-world consumer, see item 26/PR #78's own note on the real 5-piece breakdown).

**Finding**: miette's own `body/dream/bluebook/dream.hecksagon` declares `BodyDream::Dream.imaged_by("DreamImage", on: "DreamImageRequested")`, but no `.port`/`.adapter` pair existed for it to resolve against — a real bind naming it failed the wiring gate with `unknown adapter "DreamImage"`. The actual image-generation call is real, external, off-core handler machinery; this registration only DECLARES the contract. Same shape as `screenshot_buffer.port`/`payment.port` — part of this migration's single biggest confirmed-unimplemented gap (the effect-family success/failure re-entry, still a structural stub).

**Coverage**: `spec/dream_image_adapter_growth_spec.rb`, 3 examples — wiring resolves for a real `imaged_by` bind, the port's own shape, and the verb-mismatch refusal still fires for the wrong verb. Verified genuinely failing without the fix via `git stash` (3/3 examples).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1419 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps, no regressions (up 3 examples from the new spec).
