### PR TITLE
adapters: Stripe + payment port registration

### DIFF
--- a/lib/hecksagain/adapters/driven/stripe.adapter
+++ b/lib/hecksagain/adapters/driven/stripe.adapter
@@ -1,0 +1,9 @@
+# Vendored addition, not (yet) upstream hecksagain (migration plan task
+# 8): "Stripe" -- registers the adapter the canonical Pizzas example's own
+# `Order.charged_by("Stripe", on: "OrderPlaced")` names, so wiring
+# resolves. The actual charge call is real, external, off-core handler
+# machinery this bind only declares the contract for -- see payment.port's
+# own comment.
+Hecks.adapter "Stripe" do
+  port "payment"
+end

--- a/lib/hecksagain/ports/payment.port
+++ b/lib/hecksagain/ports/payment.port
@@ -1,0 +1,14 @@
+# Vendored addition, not (yet) upstream hecksagain (migration plan task
+# 8): the `charged_by` verb -- the CANONICAL PIZZAS EXAMPLE's own payment
+# edge (pizzeria/domain/pizzas.hecksagon: "Order.charged_by('Stripe', on:
+# 'OrderPlaced') do success 'Order.Authorize' failure 'Order.Decline' end").
+# hecks_conception's own `.family` files (payment.family included) are pure
+# prose -- confirmed earlier this migration : there is no `Hecks.family` DSL
+# method anywhere in hecksagain, so `.family` was never a parsed construct.
+# Same shape as screenshot_buffer.port/dream_image.port : an effect-family
+# async-verdict edge, still part of this migration's single biggest
+# confirmed-unimplemented gap (success/failure are structural no-op stubs).
+Hecks.port "payment" do
+  verb   "charged_by"
+  signal :effect
+end

--- a/spec/stripe_adapter_growth_spec.rb
+++ b/spec/stripe_adapter_growth_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+# Real coverage for the Stripe adapter registration: the CANONICAL
+# PIZZAS EXAMPLE's own payment edge
+# (pizzeria/domain/pizzas.hecksagon: "Order.charged_by('Stripe', on:
+# 'OrderPlaced') do success 'Order.Authorize' failure 'Order.Decline'
+# end"), but no `.port`/`.adapter` pair existed for it to resolve
+# against -- a real bind naming it failed the wiring gate with "unknown
+# adapter". Distinct from the pre-existing MockStripeAdapter (a
+# different adapter name, a different "checkout" port, used for
+# checkout-session smoke tests) -- this is the real payment/charged_by
+# edge the canonical example's own narrative describes. The actual
+# charge call is real, external, off-core handler machinery this
+# registration only DECLARES the contract for.
+RSpec.describe "the Stripe adapter and payment port" do
+  def registry_with_real_library
+    registry = Hecksagain::Runtime::Registry.new
+    loading = Hecksagain::Ports::Loading.bootstrap
+    Hecksagain.with_registry(registry) { loading.load_library }
+    registry
+  end
+
+  it "resolves a charged_by bind naming Stripe without a WiringError" do
+    registry = registry_with_real_library
+
+    bind = Hecksagain::Bluebook::IR::Bind.new(
+      aggregate: "Pizzas::Order", verb: "charged_by", adapter: "Stripe", role: nil
+    )
+
+    expect { registry.check_verb(bind) }.not_to raise_error
+  end
+
+  it "the payment port declares charged_by as an effect signal" do
+    registry = registry_with_real_library
+
+    port = registry.ports["payment"]
+    expect(port.verb).to eq("charged_by")
+    expect(port.effect?).to be(true)
+  end
+
+  it "does not collide with the pre-existing MockStripeAdapter/checkout port" do
+    registry = registry_with_real_library
+
+    expect(registry.ports["payment"]).not_to eq(registry.ports["checkout"])
+    expect(registry.adapters["Stripe"]).not_to eq(registry.adapters["MockStripeAdapter"])
+  end
+
+  it "refuses a bind naming Stripe for the wrong verb" do
+    registry = registry_with_real_library
+
+    bind = Hecksagain::Bluebook::IR::Bind.new(
+      aggregate: "Pizzas::Order", verb: "persisted_by", adapter: "Stripe", role: nil
+    )
+
+    expect { registry.check_verb(bind) }.to raise_error(
+      Hecksagain::Runtime::WiringError, /Stripe implements the payment port.*cannot satisfy persisted_by/m
+    )
+  end
+end


### PR DESCRIPTION
Splits `f212750` — item 28 of the [PR-split plan](.pr-split-plan.md). This PR covers only the Stripe/`payment` registration; the Heki `dir::default` fix is a separate, unrelated bug fix from the same source commit, gaining its own item stacked on top.

**Finding**: the canonical Pizzas example's own payment edge (`pizzeria/domain/pizzas.hecksagon`: `Order.charged_by("Stripe", on: "OrderPlaced") do success "Order.Authorize" failure "Order.Decline" end`), but no `.port`/`.adapter` pair existed for it to resolve against — a real bind naming it failed the wiring gate with `unknown adapter "Stripe"`. Distinct from the pre-existing `MockStripeAdapter` (a different adapter name, a different `checkout` port used for checkout-session smoke tests) — this is the real payment/`charged_by` edge the canonical example's own narrative describes.

hecks_conception's own `.family` files (`payment.family` included) are pure prose — confirmed on real-diff read: there is no `Hecks.family` DSL method anywhere in hecksagain, so `.family` was never a parsed construct. The actual charge call is real, external, off-core handler machinery; this registration only DECLARES the contract.

**Coverage**: `spec/stripe_adapter_growth_spec.rb`, 4 examples — wiring resolves for a real `charged_by` bind, the port's own shape, no collision with the pre-existing `MockStripeAdapter`/`checkout`, and the verb-mismatch refusal still fires. Verified genuinely failing without the fix via `git stash` (4/4 examples).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1423 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps, no regressions (up 4 examples from the new spec).
