### PR TITLE
adapters: Heki#resolve_path no longer crashes on a bare dir: :default

### DIFF
--- a/lib/hecksagain/adapters/driven/heki.rb
+++ b/lib/hecksagain/adapters/driven/heki.rb
@@ -106,8 +106,17 @@ module Hecksagain
         replay_journal(snapshot)
       end
 
+      # Vendored fix, not (yet) upstream hecksagain: `dir :default` (a
+      # bare Symbol, hecks_conception/miette's own convention -- "a
+      # DECLARED value that resolves by convention, never a silent
+      # fallback") crashed File.join outright (TypeError: no implicit
+      # conversion of Symbol into String). Treated the same as no
+      # setting at all -- falls back to the existing "data" default,
+      # not a new special case. TODO upstream via bin/evolve (migration
+      # plan task 7).
       def resolve_path(settings, root)
-        declared = settings[:dir] || settings["dir"] || "data"
+        raw      = settings[:dir] || settings["dir"]
+        declared = (raw.nil? || raw == :default) ? "data" : raw.to_s
         dir      = declared.start_with?("/") ? declared : File.join(root || Dir.pwd, declared)
 
         File.join(dir, "#{@aggregate.storage_name}.heki")

--- a/spec/heki_dir_default_symbol_growth_spec.rb
+++ b/spec/heki_dir_default_symbol_growth_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+require "tmpdir"
+
+# Real coverage for Heki#resolve_path's dir: :default fix: a bare Symbol
+# `dir: :default` setting -- hecks_conception/miette's own convention for
+# "a declared value that resolves by convention, never a silent
+# fallback" -- crashed File.join outright (TypeError: no implicit
+# conversion of Symbol into String), because resolve_path only ever
+# checked for a MISSING setting, never a Symbol one. Treated the same as
+# no setting at all now, falling back to the existing "data" default.
+RSpec.describe "Heki#resolve_path with a bare Symbol dir: :default setting" do
+  let(:aggregate) do
+    boot_in_memory.registry.bluebook("Pizzas").aggregate("Order")
+  end
+
+  it "falls back to the 'data' default instead of crashing on a Symbol" do
+    Dir.mktmpdir do |root|
+      adapter = Hecksagain::Adapters::Heki.new(aggregate: aggregate, settings: { dir: :default }, root: root)
+
+      expect(adapter.path).to eq(File.join(root, "data", "order.heki"))
+    end
+  end
+
+  it "still honors a real declared string path" do
+    Dir.mktmpdir do |root|
+      adapter = Hecksagain::Adapters::Heki.new(aggregate: aggregate, settings: { dir: "custom" }, root: root)
+
+      expect(adapter.path).to eq(File.join(root, "custom", "order.heki"))
+    end
+  end
+
+  it "still falls back to 'data' when no dir setting is given at all" do
+    Dir.mktmpdir do |root|
+      adapter = Hecksagain::Adapters::Heki.new(aggregate: aggregate, settings: {}, root: root)
+
+      expect(adapter.path).to eq(File.join(root, "data", "order.heki"))
+    end
+  end
+end


### PR DESCRIPTION
Splits `f212750` — item 28a of the [PR-split plan](.pr-split-plan.md), a new split from the original plan's item 28 ("Stripe adapter registration + `dir::default` fix") — this bug is unrelated to Stripe/`payment`, bundled in the same source commit only by coincidence of touching adjacent adapter files. This closes out `f212750`'s full 5-piece breakdown (items 26-28a).

**Finding**: `dir: :default` (a bare Symbol, hecks_conception/miette's own convention for "a DECLARED value that resolves by convention, never a silent fallback") crashed `File.join` outright — `TypeError: no implicit conversion of Symbol into String` — because `resolve_path` only ever checked for a MISSING `dir` setting, never a Symbol one.

**Fix**: treated the same as no setting at all — falls back to the existing `"data"` default, not a new special case.

**Coverage**: `spec/heki_dir_default_symbol_growth_spec.rb`, 3 examples — the Symbol crash case, a real declared string path (unaffected), and the true-absent case (unaffected). Verified genuinely failing without the fix via `git stash` (1/3 examples — the exact `TypeError`).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1426 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps, no regressions (up 3 examples from the new spec).
