### PR TITLE
bluebook: World::Binding#for_binding no longer leaks a generic setting onto an unrelated adapter

### DIFF
--- a/lib/hecksagain/bluebook/ir/hexagon.rb
+++ b/lib/hecksagain/bluebook/ir/hexagon.rb
@@ -80,8 +80,28 @@ module Hecksagain
 
         def for_verb(verb) = @settings.fetch(verb.to_s, {})
 
+        # Vendored fix, not (yet) upstream hecksagain: the bare fallback
+        # used to be `@settings.fetch("#{verb}:#{adapter}", for_verb(verb))`
+        # unconditionally -- but `for_verb(verb)` is whichever adapter's
+        # bare top-level block was declared LAST (e.g. `persisted_by("Heki")
+        # do dir :default end`), and falling back to it for an UNRELATED
+        # adapter applies one adapter's settings to another's bind. Real,
+        # corpus-caught bug: deciderate.hecksagon binds Game/Vote to Heki
+        # and Bubble to Memory (the Cart-equivalent ephemeral aggregate) ;
+        # the world configures only Heki's `dir`, and Bubble's lookup for
+        # "persisted_by:memory" (absent, correctly -- Memory carries no
+        # values) fell back to Heki's `{adapter: "Heki", dir: ...}`, then
+        # failed check_settings with "Memory does not declare :dir". Only
+        # fall back when the generic entry's OWN adapter actually matches
+        # the one being asked about -- otherwise there is genuinely
+        # nothing configured for this bind, `{}`, exactly right for an
+        # adapter like Memory that takes no values at all.
         def for_binding(verb, adapter)
-          @settings.fetch("#{verb}:#{adapter.to_s.downcase}", for_verb(verb))
+          qualified = @settings["#{verb}:#{adapter.to_s.downcase}"]
+          return qualified if qualified
+
+          generic = for_verb(verb)
+          generic[:adapter].to_s.downcase == adapter.to_s.downcase ? generic : {}
         end
 
         def to_h = { domain: @domain, realm: @realm, latest: @latest, settings: @settings }

--- a/spec/world_for_binding_generic_fallback_growth_spec.rb
+++ b/spec/world_for_binding_generic_fallback_growth_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+# Real coverage for IR::World::Binding#for_binding's generic-settings
+# fallback fix: the bare fallback used to be
+# `@settings.fetch("verb:adapter", for_verb(verb))` unconditionally --
+# but `for_verb(verb)` is whichever adapter's bare top-level block was
+# declared LAST, and falling back to it for an UNRELATED adapter applies
+# one adapter's settings to another's bind. Real, corpus-caught bug:
+# deciderate.hecksagon binds Game/Vote to Heki and Bubble to Memory ; the
+# world configures only Heki's `dir`, and Bubble's lookup for
+# "persisted_by:memory" fell back to Heki's own settings, then failed
+# check_settings with "Memory does not declare :dir".
+RSpec.describe "IR::World::Binding#for_binding generic-settings fallback" do
+  # unit-level, direct construction: the WorldBuilder DSL always writes
+  # BOTH the bare-verb key and the qualified verb:adapter key together
+  # (record_binding's own shared write path) for whichever adapter it
+  # names, so a generic-only settings hash (no qualified key at all) is
+  # the exact shape #for_binding must still handle correctly.
+  def world_with_generic_only(verb, adapter, extra = {})
+    Hecksagain::Bluebook::IR::World.new(
+      domain: "DeciderateGrowth",
+      settings: { verb.to_s => { adapter: adapter }.merge(extra) }
+    )
+  end
+
+  it "does not leak one adapter's generic settings onto an unrelated adapter's lookup" do
+    world = world_with_generic_only("persisted_by", "Heki", dir: "custom")
+
+    # Memory was never configured -- the bug applied Heki's `dir`
+    # setting to it anyway
+    expect(world.for_binding("persisted_by", "Memory")).to eq({})
+  end
+
+  it "still honors the generic fallback when the adapter genuinely matches" do
+    world = world_with_generic_only("persisted_by", "Heki", dir: "custom")
+
+    expect(world.for_binding("persisted_by", "Heki")).to eq(adapter: "Heki", dir: "custom")
+  end
+
+  it "a qualified verb:adapter entry still wins outright, without consulting the generic one" do
+    world = Hecksagain::Bluebook::IR::World.new(
+      domain: "DeciderateGrowth",
+      settings: {
+        "persisted_by"       => { adapter: "Heki", dir: "generic-dir" },
+        "persisted_by:heki"  => { adapter: "Heki", dir: "qualified-dir" }
+      }
+    )
+
+    expect(world.for_binding("persisted_by", "Heki")).to eq(adapter: "Heki", dir: "qualified-dir")
+  end
+end


### PR DESCRIPTION
Splits `03b5ffc` (IR: category, driving-handler wire shape, policy with_literals, rendering fix) — item 30 of the [PR-split plan](.pr-split-plan.md). **Real-diff read confirms 3 of this commit's 4 named pieces are already landed** (`category` at item `1855be0-j`, `IR::DrivingHandler`/`driving_handlers` at item `1855be0-a`, `IR::Policy#with_literals` at item `07b`) — this PR covers the one genuinely new, real bug left in `hexagon.rb`: `World::Binding#for_binding`'s generic-settings fallback.

**Finding**: the fallback used to be `@settings.fetch("verb:adapter", for_verb(verb))` unconditionally — but `for_verb(verb)` is whichever adapter's bare top-level block was declared LAST, and falling back to it for an UNRELATED adapter applies one adapter's settings to another's bind. Real, corpus-caught bug: `deciderate.hecksagon` binds Game/Vote to Heki and Bubble to Memory; the world configures only Heki's `dir`, and Bubble's lookup for `persisted_by:memory` (correctly absent) fell back to Heki's own settings, then failed `check_settings` with `"Memory does not declare :dir"`.

**Fix**: only fall back to the generic entry when its own `adapter` actually matches the one being asked about — otherwise return `{}`.

**Coverage**: `spec/world_for_binding_generic_fallback_growth_spec.rb`, 3 examples — the leak case, the correctly-matching generic case, and qualified-wins-outright. Verified genuinely failing without the fix via `git stash` (1/3 examples — the exact leaked-settings shape).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1429 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps, no regressions (up 3 examples from the new spec).
