### PR TITLE
rendering: Rendering.describe no longer leaks a Value's raw object pointer

### DIFF
--- a/lib/hecksagain/rendering.rb
+++ b/lib/hecksagain/rendering.rb
@@ -21,7 +21,30 @@ module Hecksagain
       case value
       when nil then "nil"
       when Hash, Array then JSON.generate(value)
-      else value.inspect
+      else
+        # Vendored fix, not (yet) upstream hecksagain: a
+        # Hecksagain::Runtime::Value reaching a refusal message
+        # (MutationApplier's own increment/decrement/multiply `amount`,
+        # an Admissibility `current`, ...) had no case here, falling
+        # straight through to Ruby's own #inspect and leaking a raw
+        # object pointer ("#<Hecksagain::Runtime::Value:0x...>") into an
+        # otherwise-correct domain refusal. Duck-typed on
+        # `respond_to?(:to_h)` rather than a `require`d `Runtime::Value`
+        # constant -- `Runtime::Value` itself requires THIS file
+        # (`runtime/value.rb`'s own `require_relative "../rendering"`),
+        # so naming it here would be circular -- the same guard
+        # Resolver#unwrap_scalar already uses for the identical reason.
+        # A single-field wrapper (the overwhelming common case here -- an
+        # amount, an id, a lifecycle field) unwraps to its bare scalar,
+        # described recursively ; a genuinely multi-field value renders
+        # as its fields' JSON, same as a bare Hash already does two
+        # lines up.
+        if value.respond_to?(:to_h) && !value.is_a?(Hash) && !value.is_a?(Array)
+          fields = value.to_h
+          fields.size == 1 ? describe(fields.values.first) : JSON.generate(fields)
+        else
+          value.inspect
+        end
       end
     end
   end

--- a/spec/rendering_describe_value_case_growth_spec.rb
+++ b/spec/rendering_describe_value_case_growth_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+# Real coverage for Rendering#describe's missing Runtime::Value case: a
+# Value reaching a refusal message (MutationApplier's own
+# increment/decrement/multiply `amount`, an Admissibility `current`, ...)
+# had no case here, falling straight through to Ruby's own #inspect and
+# leaking a raw object pointer ("#<Hecksagain::Runtime::Value:0x...>")
+# into an otherwise-correct domain refusal.
+RSpec.describe "Rendering.describe with a Runtime::Value" do
+  VALUE_OBJECT_DOUBLE = Struct.new(:hecks_name) do
+    def to_h = { name: hecks_name }
+  end
+
+  def single_field_value(scalar)
+    vo = VALUE_OBJECT_DOUBLE.new("SingleFieldGrowth")
+    Hecksagain::Runtime::Value.new(vo, value: scalar)
+  end
+
+  def multi_field_value(fields)
+    vo = VALUE_OBJECT_DOUBLE.new("MultiFieldGrowth")
+    Hecksagain::Runtime::Value.new(vo, fields)
+  end
+
+  it "unwraps a single-field value object to its bare scalar, not an object pointer" do
+    expect(Hecksagain::Rendering.describe(single_field_value("alive"))).to eq('"alive"')
+  end
+
+  it "renders a multi-field value object as its fields' JSON" do
+    described = Hecksagain::Rendering.describe(multi_field_value(cents: 500, currency: "USD"))
+    expect(described).to eq(JSON.generate(cents: 500, currency: "USD"))
+  end
+
+  it "never falls through to Ruby's raw #inspect (no object pointer leaks)" do
+    expect(Hecksagain::Rendering.describe(single_field_value(42))).not_to match(/#<Hecksagain::Runtime::Value/)
+    expect(Hecksagain::Rendering.describe(multi_field_value(a: 1, b: 2))).not_to match(/#<Hecksagain::Runtime::Value/)
+  end
+
+  it "still describes an ordinary scalar the same as before" do
+    expect(Hecksagain::Rendering.describe(42)).to eq("42")
+    expect(Hecksagain::Rendering.describe("plain")).to eq('"plain"')
+  end
+end


### PR DESCRIPTION
Splits `03b5ffc` — item 32 of the [PR-split plan](.pr-split-plan.md), the final piece of that source commit (items 29/`category` and 31/`with_literals` are already landed at `1855be0-j` and `07b`; item 30/PR #83 covers the `for_binding` fix). Resolves the plan's own flagged ambiguity: this is confirmed **distinct** from item 17b's `Value.scalar` unwrap fix.

**Finding**: `Rendering#describe` left a `Runtime::Value` with no case, falling straight through to Ruby's own `#inspect` and leaking a raw object pointer (`"#<Hecksagain::Runtime::Value:0x...>"`) into an otherwise-correct domain refusal message — MutationApplier's own increment/decrement/multiply `amount`, an Admissibility `current`, and any other refusal wording that routes through `Rendering.describe`. Item 17b's fix was a completely different call site (`command_rules/admissibility.rb`'s lifecycle-transition matcher's own bare `.to_s`) — this is the shared, central refusal-message formatter every OTHER refusal routes through.

**Fix**: duck-typed on `respond_to?(:to_h)` (avoids a circular require on `Runtime::Value` itself, which requires this file) — the same guard `Resolver#unwrap_scalar` already uses. A single-field wrapper unwraps to its bare scalar, described recursively; a genuinely multi-field value renders as its fields' JSON, same as a bare `Hash` already does.

**Coverage**: `spec/rendering_describe_value_case_growth_spec.rb`, 4 examples — single-field unwrap, multi-field JSON, no-pointer-leak assertion, and the ordinary-scalar case unaffected. Verified genuinely failing without the fix via `git stash` (3/4 examples — the exact leaked object-pointer string).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1433 examples, 18 failures — same 18 pre-existing, already-catalogued, deferred gaps, no regressions (up 4 examples from the new spec).
