### PR TITLE
vocabulary: MutationOp's runtime table was missing remove

### DIFF
--- a/lib/hecksagain/runtime/command_rules/arithmetic.rb
+++ b/lib/hecksagain/runtime/command_rules/arithmetic.rb
@@ -27,7 +27,16 @@ module Hecksagain
           # set/append, they do no add-or-subtract arithmetic (multiply
           # scales, clamp bounds). See #multiply/#clamp below.
           MutationOp.new(name: "multiply",  sign: nil),
-          MutationOp.new(name: "clamp",     sign: nil)
+          MutationOp.new(name: "clamp",     sign: nil),
+          # Vendored addition, not (yet) upstream hecksagain (migration
+          # plan task 4): remove -- carries no sign, like set/append; it
+          # matches a list element by value rather than doing arithmetic.
+          # Declared here so this table stays exactly what
+          # Vocabulary::MutationOp declares (spec/vocabulary_conformance_spec
+          # holds the two equal) -- MutationApplier's own `when :remove`
+          # branch (mutation_applier.rb) never calls #sign_of, so this was
+          # a declared-vocabulary gap, not a behaviour gap.
+          MutationOp.new(name: "remove",    sign: nil)
         ].freeze
 
         # A mutation's source is either the NAME OF AN ARGUMENT or a LITERAL, and

--- a/spec/mutation_op_runtime_table_remove_growth_spec.rb
+++ b/spec/mutation_op_runtime_table_remove_growth_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+# Real coverage for CommandRules::Arithmetic::MUTATION_OPS's missing
+# "remove" entry: the live table the runtime computes signs from never
+# got a `remove` entry when the list-removal mutation op was added --
+# only vocabulary.bluebook's own declared MutationOp closed set had it.
+# remove's own `when :remove` branch in MutationApplier never calls
+# #sign_of, so this was a declared-vocabulary gap invisible to any real
+# dispatch, not a behaviour bug -- but it left
+# spec/vocabulary_conformance_spec's own "MutationOp declares the same
+# sign CommandRules::MUTATION_OPS computes with" test failing, a real,
+# already-catalogued gap this closes.
+RSpec.describe "CommandRules::Arithmetic::MUTATION_OPS" do
+  it "declares remove alongside every other MutationOp the language admits" do
+    names = Hecksagain::Runtime::CommandRules::MUTATION_OPS.map(&:name)
+    expect(names).to include("remove")
+  end
+
+  it "remove carries no sign, matching set/append (no add-or-subtract arithmetic)" do
+    remove = Hecksagain::Runtime::CommandRules::MUTATION_OPS.find { |op| op.name == "remove" }
+    expect(remove.sign).to be_nil
+  end
+
+  it "matches vocabulary.bluebook's own declared MutationOp closed set exactly" do
+    live = Hecksagain::Runtime::CommandRules::MUTATION_OPS.map(&:name)
+
+    judged_meta = Hecksagain::Bluebook::MetaValidator.grammar_registry.bluebook("Bluebook")
+    aggregate = judged_meta.aggregates.find { |a| a.name == "Vocabulary" }
+    declared_names = aggregate.value_objects.find { |vo| vo.hecks_name == "MutationOp" }
+                              .members.map { |row| row.to_h[:name] }
+
+    expect(live).to match_array(declared_names)
+  end
+end


### PR DESCRIPTION
Splits `9045331` (vocabulary: MutationOp's runtime table was missing remove) — item 34 of the [PR-split plan](.pr-split-plan.md). **HIGH VALUE, already predicted**: this closes a real, already-open test failure tracked since item 15/PR #48.

**Finding**: `CommandRules::Arithmetic::MUTATION_OPS` (the live table the runtime computes signs from) never got a `remove` entry when the list-removal mutation op was added — only `vocabulary.bluebook`'s own declared `MutationOp` closed set had it (landed at split-plan item `1855be0-l`). `remove`'s own `when :remove` branch in `MutationApplier` never calls `#sign_of`, so this was a declared-vocabulary gap invisible to any real dispatch, not a behaviour bug.

**Confirmed genuinely closes** `spec/vocabulary_conformance_spec.rb`'s own "MutationOp declares the same sign CommandRules::MUTATION_OPS computes with" test — open since item 15, tracked as an expected/deferred gap through every checkpoint since. Full-suite rerun (twice, stable): **18 → 17 failures.**

The spec-expectation half of the original commit (`vocabulary_conformance_spec.rb`'s "admits every op the corpus uses" test) is already landed, slightly differently (`include(*ops)` instead of `eq(ops)`) — fixed as a direct consequence of item `1855be0-l`'s own `vocabulary.bluebook` registration breaking that same hardcoded assertion earlier in this migration.

**Coverage**: `spec/mutation_op_runtime_table_remove_growth_spec.rb`, 3 examples — the table includes `remove`, its sign is `nil`, and it matches `vocabulary.bluebook`'s own declared set exactly. Verified genuinely failing without the fix via `git stash` (3/3 examples).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1438 examples, **17 failures** (down from 18, confirmed stable across two runs) — a real, verified gap closure, not a regression.
