### PR TITLE
dsl: AggregateBuilder#attribute restores its real keyword signature

### DIFF
--- a/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
@@ -43,7 +43,20 @@ module Hecksagain
         # pass if Chris prefers that path instead.
         PRIMITIVE_CLASSES = [String, Integer, Float, TrueClass, FalseClass, Numeric].freeze
 
-        def attribute(name, type = String, **kwargs)
+        # NAMED, NOT **kwargs — spelled out exactly like AttributeCollector#
+        # attribute's own signature (the method this overrides). A `**kwargs`
+        # catch-all forwards fine at runtime but ERASES the signature a
+        # projected parser reads: spec/syntax_conformance_spec's "declares
+        # every keyword argument each word's builder takes" inspects
+        # `instance_method(:attribute).parameters` and only counts real
+        # `key`/`keyreq` entries, so a `**kwargs` override made every named
+        # argument syntax.bluebook declares for Aggregate.attribute
+        # (default/optional/pattern/admits/...) look unanswered — a real
+        # regression from the primitive-wrapper synthesis pass, not a
+        # deliberate signature change. Fixed at the root, not by weakening
+        # the spec.
+        def attribute(name, type = String, as: nil, default: nil, optional: false, required: nil,
+                      pattern: nil, admits: nil, logged: true, enum: nil)
           # Vendored fix, not (yet) upstream hecksagain (migration plan task
           # 4): apply the SAME inverted-form correction AttributeCollector#
           # attribute makes -- but BEFORE the primitive-wrapper check below,
@@ -55,7 +68,7 @@ module Hecksagain
           # colliding with a real hand-written `value_object "App"` a few
           # lines above it in the same file. See AttributeCollector.
           # resolve_inverted's own comment for why the check is reliable.
-          name, type = AttributeCollector.resolve_inverted(name, type, kwargs[:as])
+          name, type = AttributeCollector.resolve_inverted(name, type, as)
           type = AttributeCollector.normalize_boolean_alias(type)
 
           if PRIMITIVE_CLASSES.include?(type)
@@ -63,7 +76,8 @@ module Hecksagain
           elsif type.is_a?(ListOf) && PRIMITIVE_CLASSES.include?(type.type)
             type = ListOf.new(synthesise_primitive_wrapper(name, type.type))
           end
-          super(name, type, **kwargs)
+          super(name, type, as: as, default: default, optional: optional, required: required,
+                pattern: pattern, admits: admits, logged: logged, enum: enum)
         end
 
         def synthesise_primitive_wrapper(name, primitive_class)

--- a/spec/aggregate_builder_attribute_signature_growth_spec.rb
+++ b/spec/aggregate_builder_attribute_signature_growth_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for AggregateBuilder#attribute's keyword-signature
+# regression fix: the primitive-wrapper synthesis pass (item 1855be0-b)
+# collapsed its explicit keyword signature into a bare `**kwargs`
+# catch-all. That forwards fine at RUNTIME, but ERASES the signature a
+# projected parser reads -- spec/syntax_conformance_spec's "declares
+# every keyword argument each word's builder takes" inspects
+# `instance_method(:attribute).parameters` and only counts real
+# `key`/`keyreq` entries, so a `**kwargs` override made every named
+# argument syntax.bluebook declares for Aggregate.attribute look
+# unanswered from the language's own point of view.
+RSpec.describe "AggregateBuilder#attribute's keyword signature" do
+  it "names its real keyword arguments -- not a bare **kwargs catch-all" do
+    params = Hecksagain::Bluebook::DSL::AggregateBuilder.instance_method(:attribute).parameters
+    kinds = params.map(&:first)
+
+    expect(kinds).not_to include(:keyrest), "a **kwargs catch-all erases the signature a projected parser reads"
+
+    named = params.select { |kind, _| %i[key keyreq].include?(kind) }.map(&:last)
+    expect(named).to include(:as, :default, :optional, :required, :pattern, :admits, :logged, :enum)
+  end
+
+  it "still forwards every keyword through to the real behavior (as:, required:, enum:)" do
+    source = <<~BLUEBOOK
+      Hecks.bluebook "AttributeSignatureGrowth" do
+        aggregate "Widget" do
+          identified_by { widget_id.value }
+
+          value_object "WidgetId" do
+            attribute :value, String
+          end
+
+          attribute :widget_id, WidgetId
+          attribute :color, String, enum: %w[red blue], required: true
+        end
+      end
+    BLUEBOOK
+
+    file = Tempfile.new(["attribute-signature-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+    end
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file.close!
+
+    widget = registry.bluebook("AttributeSignatureGrowth").aggregate("Widget")
+    color_attribute = widget.attributes.find { |a| a.name == :color }
+    expect(color_attribute).not_to be_nil
+    expect(color_attribute.optional?).to be(false)
+  end
+end


### PR DESCRIPTION
Splits `bc41abc` (self-hosted grammar: register this session's new DSL words) — item 35b of the [PR-split plan](.pr-split-plan.md), a new split. `bc41abc` is a large, mostly-mechanical grammar-registration commit; real-diff read found ONE genuinely separate, real bug hiding inside it — this PR covers only that piece. The bulk `syntax.bluebook` word registration (item 35) and self-hosting `category` through the meta-grammar (item 35a) are separate items stacked on top.

**Finding**: the primitive-wrapper synthesis pass (item `1855be0-b`) collapsed `AggregateBuilder#attribute`'s override into a bare `**kwargs` catch-all. That forwards fine at runtime, but ERASES the signature a projected parser reads: `spec/syntax_conformance_spec`'s "declares every keyword argument each word's builder takes" inspects `instance_method(:attribute).parameters` and only counts real `key`/`keyreq` entries, so a `**kwargs` override made every named argument `syntax.bluebook` declares for `Aggregate.attribute` look unanswered — a real regression from the primitive-wrapper pass, not a deliberate signature change.

**Fix**: named, not `**kwargs` — spelled out exactly like `AttributeCollector#attribute`'s own signature (the method this overrides), forwarding explicitly.

**Coverage**: `spec/aggregate_builder_attribute_signature_growth_spec.rb`, 2 examples — the signature itself (no `:keyrest`, real named keywords present) and behavioral forwarding (`as:`/`required:`/`enum:` still work end-to-end). Verified genuinely failing without the fix via `git stash` (1/2 examples).

**Honest note**: this does NOT by itself turn `spec/syntax_conformance_spec.rb:325` green — fixing the signature reveals real, not-yet-declared keyword arguments (`as`/`required`/`logged`/`enum`), which item 35's own `syntax.bluebook` registration (stacked on top) closes.

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1440 examples, 17 failures — same 17 pre-existing, already-catalogued, deferred gaps, no regressions (up 2 examples from the new spec).
