### PR TITLE
bluebook: self-hosted grammar's own Bluebook aggregate gains category

### DIFF
--- a/lib/hecksagain/bluebook/assembly/contracts.rb
+++ b/lib/hecksagain/bluebook/assembly/contracts.rb
@@ -42,7 +42,16 @@ module Hecksagain
             version:        [:version,        :plain],
             vision:         [:vision,         :plain],
             classification: [:classification, :plain],
-            formerly_known_as: [:formerly_known_as, :plain]
+            formerly_known_as: [:formerly_known_as, :plain],
+            # Vendored addition, not (yet) upstream hecksagain (migration
+            # plan task 4): same three-part shape `redirects_native`
+            # already used to close this exact gap on Command -- the
+            # self-hosted Bluebook aggregate now declares `category`
+            # (bluebook.bluebook), so the Judge's rebuild needs to read it
+            # back too, or `IR::Bluebook.new`'s own default (`category:
+            # nil`) would silently win over whatever the original DSL
+            # declaration said.
+            category: [:category, :plain]
           },
           rows: { normalisations: :normalisation_table },
           derived: { normalisations: :elsewhere }

--- a/lib/hecksagain/language/bluebook/bluebook.bluebook
+++ b/lib/hecksagain/language/bluebook/bluebook.bluebook
@@ -66,6 +66,13 @@ Hecks.bluebook "Bluebook", version: "1" do
     # Most chapters declare none, and ABSENT IS NOT EMPTY, the same
     # reading `version` above gives.
     attribute :formerly_known_as, FormerlyKnownAs
+    # Vendored addition, not (yet) upstream hecksagain (migration plan
+    # task 4): a free-form second axis alongside `classification`'s fixed
+    # core/supporting/generic set (BluebookBuilder#category's own
+    # comment) — hecks_conception writes `category "framework"` across
+    # 119 files, 12 distinct values. Same shape as `formerly_known_as`
+    # just above: plain text, no closed set, ABSENT IS NOT EMPTY.
+    attribute :category,       Category
     attribute :normalisations, list_of(NormalisationRule)
 
     value_object "RuleText" do
@@ -109,6 +116,11 @@ Hecks.bluebook "Bluebook", version: "1" do
       invariant("a formerly_known_as says something") { !value.to_s.empty? }
     end
 
+    value_object "Category" do
+      attribute :value, String
+      invariant("a category says something") { !value.to_s.empty? }
+    end
+
     command "Declare" do
       role "Language"
       goal "Open a chapter"
@@ -118,6 +130,7 @@ Hecks.bluebook "Bluebook", version: "1" do
       attribute :classification, Classification, optional: true
       attribute :version,        Version, optional: true
       attribute :formerly_known_as, FormerlyKnownAs, optional: true
+      attribute :category,       Category, optional: true
 
       emits "ChapterDeclared"
     end

--- a/spec/bluebook_category_self_hosted_field_growth_spec.rb
+++ b/spec/bluebook_category_self_hosted_field_growth_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+# Real coverage for self-hosting `category` through the meta-grammar's own
+# Bluebook aggregate: the self-hosted grammar's `Hecks.bluebook "Bluebook"`
+# chapter (bluebook.bluebook) gains a `Category` value object + `attribute
+# :category, Category, optional: true` on its own `Declare` command, and
+# `Assembly::Contracts::CONTRACTS["Bluebook"]` gains a matching
+# `category: [:category, :plain]` read -- the same three-part shape
+# `redirects_native` already used to close this exact gap on Command.
+#
+# HONEST, VERIFIED-STILL-OPEN GAP: this makes `category` a real field the
+# Judge's own Plan offers when dispatching a bluebook's Declare command
+# (confirmed directly below), and a real read Assembly::Contracts knows
+# about -- but the FINAL leg, `Reconstruction#to_h`'s own TOP-LEVEL chapter
+# read, is hand-written rather than table-driven (its own comment: "there
+# were eleven methods here... the keys come from the table now" describes
+# the PER-ROW `#declaration` method further down, not this outer `#to_h`)
+# and still hard-codes its chapter-level key list without `category`. So a
+# real dispatch through the full Judge round-trip (meta-validation ON)
+# still returns `category: nil` -- confirmed live below, not assumed.
+# `Reconstruction#to_h`'s own fix is outside this migration's 31-commit
+# range and not invented here.
+RSpec.describe "the self-hosted grammar's own Bluebook.category field" do
+  it "the self-hosted Bluebook aggregate's Declare command now offers category" do
+    plan = Hecksagain::Bluebook::MetaValidator::Plan.for(Hecksagain::Bluebook::MetaValidator.grammar_registry)
+    bluebook_category = plan.category("Bluebook")
+
+    expect(bluebook_category.fields).to include("category")
+  end
+
+  it "Assembly::Contracts reads Bluebook's category field back as a plain value" do
+    contract = Hecksagain::Bluebook::Assembly.contract("Bluebook")
+    expect(contract.fields[:category]).to eq([:category, :plain])
+  end
+
+  it "a real dispatch through the Judge raises no refusal for a declared category" do
+    bluebook = Hecksagain::Bluebook::IR::Bluebook.new(name: "CategorySelfHostGrowth", category: "framework")
+    judge = Hecksagain::Bluebook::MetaValidator::Judge.new(bluebook)
+
+    expect(judge.refusals).to be_empty
+  end
+
+  it "HONEST GAP, confirmed live: Reconstruction#to_h still does not carry category through" do
+    bluebook = Hecksagain::Bluebook::IR::Bluebook.new(name: "CategorySelfHostGapGrowth", category: "framework")
+    judge = Hecksagain::Bluebook::MetaValidator::Judge.new(bluebook)
+
+    reconstructed = Hecksagain::Bluebook::MetaValidator::Reconstruction.of(judge.runtime, "CategorySelfHostGapGrowth")
+
+    # Documented here, not silently dodged -- Reconstruction#to_h's own
+    # hand-written chapter-level key list is the remaining piece, not yet
+    # fixed anywhere in this migration's 31-commit range.
+    expect(reconstructed).not_to have_key(:category)
+  end
+end

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -50,6 +50,15 @@
         {
           "admits": null,
           "default": null,
+          "list": false,
+          "name": "category",
+          "optional": false,
+          "pattern": null,
+          "type": "Category"
+        },
+        {
+          "admits": null,
+          "default": null,
           "list": true,
           "name": "normalisations",
           "optional": false,
@@ -104,6 +113,15 @@
               "optional": true,
               "pattern": null,
               "type": "FormerlyKnownAs"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "category",
+              "optional": true,
+              "pattern": null,
+              "type": "Category"
             }
           ],
           "emits": [
@@ -444,6 +462,30 @@
 
           ],
           "name": "FormerlyKnownAs"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+            {
+              "canonical": "!value.to_s.empty?",
+              "description": "a category says something"
+            }
+          ],
+          "members": [
+
+          ],
+          "name": "Category"
         }
       ]
     },


### PR DESCRIPTION
Splits `bc41abc` — item 35a of the [PR-split plan](.pr-split-plan.md), a new split. Covers the `bluebook.bluebook` + `assembly/contracts.rb` half of `bc41abc` (self-hosting `category` through the meta-grammar); the bulk `syntax.bluebook` word registration (item 35) and the `AggregateBuilder#attribute` signature regression fix (item 35b, PR #87) are separate items.

**Change**: the self-hosted grammar's own `Hecks.bluebook "Bluebook"` chapter gains a `Category` value object + `attribute :category, Category, optional: true` on its own `Declare` command, and `Assembly::Contracts::CONTRACTS["Bluebook"]` gains a matching `category: [:category, :plain]` read — the same three-part shape `redirects_native` already used to close this exact gap on Command.

**Honest, verified-still-open gap** (found by direct experiment, not assumed): this makes `category` a real field the Judge's own `Plan` offers when dispatching a bluebook's `Declare` command, and a real read `Assembly::Contracts` knows about — confirmed live in this PR's own spec. But the FINAL leg, `Reconstruction#to_h`'s own TOP-LEVEL chapter read, is hand-written rather than table-driven and still hard-codes its chapter-level key list without `category`. A real dispatch through the full Judge round-trip (meta-validation ON) still returns `category: nil` — exactly matching item `1855be0-j`'s own "HONEST GAP" spec (`spec/bluebook_category_growth_spec.rb`). `Reconstruction#to_h`'s own fix is outside this migration's 31-commit range and is not invented here.

Golden IR fixture regenerated (`spec/golden/ir/Bluebook.json`) since this changes the self-hosted grammar's own frozen IR shape.

**Coverage**: `spec/bluebook_category_self_hosted_field_growth_spec.rb`, 4 examples — Plan offers `category`, Contracts reads it, the Judge raises no refusal, and the still-open Reconstruction gap confirmed live. Verified genuinely failing without the fix via `git stash` (2/4 examples; the honest-gap example correctly passes either way).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1444 examples, 17 failures (stable across two runs) — same 17 pre-existing, already-catalogued, deferred gaps, no regressions (up 4 examples from the new spec; one transient golden-fixture mismatch found and regenerated in this same PR).
