### PR TITLE
corpus: banking.bluebook exercises redirects_native for real

### DIFF
--- a/examples/banking/bluebook/banking.bluebook
+++ b/examples/banking/bluebook/banking.bluebook
@@ -347,6 +347,13 @@ Hecks.bluebook "Banking", version: "v1" do
       goal "Stop an account moving while something is investigated"
 
       reference_to Account
+      # Exercises `redirects_native` (docs/hecks-migration-findings.md
+      # finding #1) somewhere in the judged corpus — Banking is the one
+      # flagship domain that carries every category at once, and a
+      # compliance freeze is exactly the shape of command a governed-door
+      # tool substitution stands in for (a native "hold" action gated the
+      # same way a native tool call would be).
+      redirects_native "ComplianceHold"
       emits "AccountFrozen"
     end
 

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -743,7 +743,7 @@
           "name": "Freeze",
           "provenance": null,
           "redirects_native": [
-
+            "ComplianceHold"
           ],
           "references": "Account",
           "role": "Compliance officer"

--- a/spec/plan_spec.rb
+++ b/spec/plan_spec.rb
@@ -50,7 +50,13 @@ RSpec.describe Hecksagain::Bluebook::MetaValidator::Plan do
       # is not a name the walk ever has to match.
       appends = plan.category("Command").appends
 
-      expect(appends.keys).to match_array(%w[attributes givens ensures mutations emits])
+      # `redirects_native` joined the other five once behavior.bluebook
+      # declared `Command.Redirect` (docs/hecks-migration-findings.md
+      # finding #1) — the append table is DERIVED from the grammar's own
+      # `then_set ..., append:` declarations, so a sixth appendable list
+      # shows up here automatically, not by a hand-kept map falling out of
+      # sync.
+      expect(appends.keys).to match_array(%w[attributes givens ensures mutations emits redirects_native])
       expect(appends["attributes"].verb).to eq("Argument")
       expect(appends["givens"].verb).to eq("Rule")
       expect(appends["ensures"].verb).to eq("Ensure")

--- a/spec/redirects_native_corpus_consumer_growth_spec.rb
+++ b/spec/redirects_native_corpus_consumer_growth_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+# Real coverage for redirects_native's own corpus consumer: the DSL
+# builder (item 1855be0-m) and the IR/contracts/self-hosted-grammar side
+# (item 05) both landed with nothing in the judged corpus actually
+# CALLING redirects_native -- "a verb the judge is never OFFERED cannot
+# prove the mechanism works, only that it parses" (docs/hecks-migration-
+# findings.md). Banking's Account.Freeze now carries `redirects_native
+# "ComplianceHold"`, closing spec/judge_coverage_spec's "offers every verb
+# the language declares" (Bluebook::Command.Redirect was declared but
+# never offered) and spec/plan_spec's own append-table assertion (a sixth
+# appendable list, derived automatically from the grammar, not hand-kept).
+RSpec.describe "redirects_native's real corpus consumer" do
+  def banking_bluebook
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.load(File.join(InMemoryDomain::ROOT, "examples/banking/bluebook/banking.bluebook"))
+    end
+    registry.bluebook("Banking")
+  end
+
+  it "Account.Freeze declares redirects_native ComplianceHold" do
+    freeze = banking_bluebook.aggregate("Account").commands.find { |c| c.hecks_name == "Freeze" }
+    expect(freeze.redirects_native).to eq(["ComplianceHold"])
+  end
+
+  it "the self-hosted grammar's Judge now offers Bluebook::Command.Redirect" do
+    plan = Hecksagain::Bluebook::MetaValidator::Plan.for(Hecksagain::Bluebook::MetaValidator.grammar_registry)
+    expect(plan.verbs).to include("Bluebook::Command.Redirect")
+  end
+
+  it "the append table includes redirects_native alongside the other five appendable lists" do
+    plan = Hecksagain::Bluebook::MetaValidator::Plan.for(Hecksagain::Bluebook::MetaValidator.grammar_registry)
+    appends = plan.category("Command").appends
+    expect(appends.keys).to include("redirects_native")
+  end
+end


### PR DESCRIPTION
Pulled out of `70169fc` — item 36a of the [PR-split plan](.pr-split-plan.md), per this plan's own note recorded back at item 05 (PR #22): `70169fc` bundles the `redirects_native` corpus-consumer line ALONGSIDE its real subject (Handler `remembers`/`guard_count`, item 36 proper). This PR pulls ONLY the `redirects_native` hunk + `plan_spec.rb`'s matching assertion, so item 36 stays scoped to its own real subject.

**Finding**: the DSL builder (item `1855be0-m`) and the IR/contracts/self-hosted-grammar side (item 05) both landed with nothing in the judged corpus actually CALLING `redirects_native` — "a verb the judge is never OFFERED cannot prove the mechanism works, only that it parses" (`docs/hecks-migration-findings.md`).

**Fix**: `Account.Freeze` now carries `redirects_native "ComplianceHold"` — Banking is the one flagship domain that carries every category at once, and a compliance freeze is exactly the shape of command a governed-door tool substitution stands in for.

**Genuinely closes** `spec/judge_coverage_spec`'s "offers every verb the language declares" (`Bluebook::Command.Redirect` was declared but never offered) and `spec/plan_spec`'s own append-table assertion (a sixth appendable list, derived automatically from the grammar, not hand-kept) — updated to match. Golden IR fixture regenerated (`spec/golden/ir/Banking.json`).

**Coverage**: `spec/redirects_native_corpus_consumer_growth_spec.rb`, 3 examples. Verified genuinely failing without the fix via `git stash` (1/3 — the corpus-specific assertion; the other two depend only on already-landed grammar work).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1451 examples, 6 failures (down from 8 at the base of this branch) — genuinely closes `plan_spec.rb:46` and `judge_coverage_spec.rb:89`, no regressions.
