### PR TITLE
self-hosted grammar: Handler's remembers/guard_count round-trip through the Judge

### DIFF
--- a/examples/banking/bluebook/banking.bluebook
+++ b/examples/banking/bluebook/banking.bluebook
@@ -1445,6 +1445,11 @@ Hecks.bluebook "Banking", version: "v1" do
     state "reversed"
 
     on "TransferRequested", transition: { "requested" => "requested" } do
+      # Exercises `remember` (docs/hecks-migration-findings.md finding #7)
+      # somewhere in the judged corpus — the destination account written
+      # forward into the saga's own carried memory, the mechanism
+      # `from_pm` reads back later in the same conversation.
+      remember destination_account: :destination
       # Debit never declared :destination — the credit leg reads it from the saga's
       # memory of the opening payload. `reference:` carries the correlation
       # forward — Account.Debit does not reference Transfer, so this is pure

--- a/lib/hecksagain/bluebook/assembly/contracts.rb
+++ b/lib/hecksagain/bluebook/assembly/contracts.rb
@@ -221,8 +221,21 @@ module Hecksagain
           fields: {
             event_type: [:event_type, :plain],
             from_state: [:from_state, :plain],
-            to_state:   [:to_state,   :plain]
+            to_state:   [:to_state,   :plain],
+            # Vendored addition, not (yet) upstream hecksagain (migration
+            # plan task 4): same open-map shape Dispatch's own `with_spec`
+            # already is — `remember key: from_event(...)` has no value
+            # object that can hold it, so it rides as rows.
+            remembers:  [:remembers,  :bindings],
+            # `guard_count` is now a real seventh member of IR::
+            # ProcessManagerHandler (its own comment explains why) — only
+            # the COUNT survives the round trip, never the predicates
+            # themselves (raw Procs). `:plain`, the same as every other
+            # scalar here.
+            guard_count: [:guard_count, :plain]
           },
+          rows: { remembers: :remembers_rows },
+          reads: { remembers: [:from, :remembers] },
           derived: { position: :walk }
         ),
 

--- a/lib/hecksagain/bluebook/ir/process_manager.rb
+++ b/lib/hecksagain/bluebook/ir/process_manager.rb
@@ -55,8 +55,25 @@ module Hecksagain
       # either (Proc isn't JSON-shaped); only their PRESENCE is exported,
       # as a count, so the IR still says a guard exists without claiming
       # to describe it. See DSL::ProcessManagerBuilder::HandlerBuilder#given.
+      # `guard_count` is a SEVENTH member, not just a computed reader —
+      # the self-hosted "Handler" aggregate (reaction.bluebook) declares
+      # it as a real attribute (guards themselves, raw Procs, are not
+      # storable), so Assembly's reconstruction needs a real keyword to
+      # hand the count back through. The everyday DSL::
+      # ProcessManagerBuilder path never sets it (only `guards`, real
+      # predicates) — `guard_count` stays nil there, and the reader below
+      # falls back to counting them, so ordinary dispatch is unchanged.
       ProcessManagerHandler = Struct.new(:event_type, :from_state, :to_state,
-                                         :dispatches, :remembers, :guards, keyword_init: true) do
+                                         :dispatches, :remembers, :guards, :guard_count,
+                                         keyword_init: true) do
+        # OVERRIDES the plain Struct accessor: an EXPLICIT guard_count (set
+        # only by Assembly's reconstruction, which cannot rebuild the raw
+        # Procs `guards` normally holds) wins ; otherwise it is computed
+        # the way it always was. `self[:guard_count]`, not `guard_count`,
+        # reads the underlying member slot directly — calling the accessor
+        # here would recurse.
+        def guard_count = self[:guard_count] || (guards || []).size
+
         def to_h
           {
             event_type: event_type.to_s,
@@ -64,7 +81,7 @@ module Hecksagain
             to_state:   to_state.to_s,
             dispatches: dispatches.map(&:to_h),
             remembers:  (remembers || []).map { |k, v| [k.to_s, IR.render_value(v)] },
-            guard_count: (guards || []).size
+            guard_count: guard_count
           }
         end
       end

--- a/lib/hecksagain/bluebook/meta_validator/readings.rb
+++ b/lib/hecksagain/bluebook/meta_validator/readings.rb
@@ -53,6 +53,12 @@ module Hecksagain
         # argument became indistinguishable from one carrying a literal string.
         def with_spec_rows(node) = pair_rows(node.to_h[:with_spec])
 
+        # Same shape as `with_spec_rows` above, one construct up — a
+        # handler's own remembered key/value pairs, through `to_h` for the
+        # same reason (`IR.render_value` spells a symbol argument with its
+        # leading colon, which the raw `remembers` array does not).
+        def remembers_rows(node) = pair_rows(node.to_h[:remembers])
+
         # A read model carries the same options an ask does, plus its filters — see
         # option_rows.
         def read_model_option_rows(node) = option_rows(node, filters: true)

--- a/lib/hecksagain/language/bluebook/reaction.bluebook
+++ b/lib/hecksagain/language/bluebook/reaction.bluebook
@@ -190,9 +190,33 @@ Hecks.bluebook "Bluebook" do
     attribute :event_type, HandlerText
     attribute :from_state, HandlerText
     attribute :to_state,   HandlerText
+    # Vendored addition, not (yet) upstream hecksagain (migration plan
+    # task 4): `remember key: from_event(...)` writes forward into the
+    # saga instance's own carried memory — see IR::ProcessManagerHandler's
+    # own comment. An OPEN MAP, the same shape `Dispatch`'s own
+    # `with_spec` already is (a value object cannot hold it), so it rides
+    # as rows the same way.
+    attribute :remembers,   list_of(Remembered)
+    # `given { |ctx| ... }` — a dispatch-level precondition. The predicate
+    # ITSELF is a raw Proc, never rendered into `to_h` (same reason a
+    # command's own `given`/`ensures` predicates are not) — only its
+    # PRESENCE is exported, as a count, so the self-hosted grammar holds
+    # exactly what the wire holds: a number, not a claim to describe the
+    # predicate.
+    attribute :guard_count, GuardCount
 
     value_object "HandlerText" do
       attribute :value, String
+    end
+
+    value_object "Remembered" do
+      attribute :key,   String
+      attribute :value, String
+    end
+
+    value_object "GuardCount" do
+      attribute :value, Integer
+      invariant("a guard count is never negative") { value >= 0 }
     end
 
     # The way back: everything DECLARED IN the process manager above. The parent
@@ -229,9 +253,31 @@ Hecks.bluebook "Bluebook" do
       # the language admitting a leg the runtime cannot parse.
       attribute :from_state, HandlerText
       attribute :to_state,   HandlerText
+      # KNOWN IN FULL BY THE TIME `on(...)`'s BLOCK FINISHES, the same as
+      # `event_type`/`from_state`/`to_state` — a scalar, so it rides as a
+      # Declare-time attribute rather than a sub-command the way
+      # `remembers` (an open map) needs to.
+      attribute :guard_count, GuardCount, optional: true
 
       attribute :position, Position, optional: true
       emits "LegDeclared"
+    end
+
+    # `remember key: from_event(...)` / `set :key, value` — vendored
+    # addition, not (yet) upstream hecksagain (migration plan task 4):
+    # the list-append counterpart to `Dispatch.Bind`'s own with_spec
+    # binding, same open-map shape (a value object cannot hold it).
+    command "Remember" do
+      role "Language"
+      goal "Attach one remembered key/value pair to the handler"
+
+      reference_to Handler
+      attribute :key,   HandlerText
+      attribute :value, HandlerText
+
+      then_set :remembers, append: { key: :key, value: :value }
+
+      emits "RememberedAttached"
     end
   end
 

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -5426,7 +5426,10 @@
           "from_state": "requested",
           "guard_count": 0,
           "remembers": [
-
+            [
+              "destination_account",
+              ":destination"
+            ]
           ],
           "to_state": "requested"
         },

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -5635,6 +5635,24 @@
         {
           "admits": null,
           "default": null,
+          "list": true,
+          "name": "remembers",
+          "optional": false,
+          "pattern": null,
+          "type": "Remembered"
+        },
+        {
+          "admits": null,
+          "default": null,
+          "list": false,
+          "name": "guard_count",
+          "optional": false,
+          "pattern": null,
+          "type": "GuardCount"
+        },
+        {
+          "admits": null,
+          "default": null,
           "list": false,
           "name": "position",
           "optional": false,
@@ -5685,6 +5703,15 @@
               "admits": null,
               "default": null,
               "list": false,
+              "name": "guard_count",
+              "optional": true,
+              "pattern": null,
+              "type": "GuardCount"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
               "name": "position",
               "optional": true,
               "pattern": null,
@@ -5710,6 +5737,55 @@
 
           ],
           "references": null,
+          "role": "Language"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "key",
+              "optional": false,
+              "pattern": null,
+              "type": "HandlerText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "HandlerText"
+            }
+          ],
+          "emits": [
+            "RememberedAttached"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+
+          ],
+          "goal": "Attach one remembered key/value pair to the handler",
+          "mutations": [
+            {
+              "fields": {
+                "key": ":key",
+                "value": ":value"
+              },
+              "op": "append",
+              "target": "remembers"
+            }
+          ],
+          "name": "Remember",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": "Handler",
           "role": "Language"
         }
       ],
@@ -5778,6 +5854,60 @@
 
           ],
           "name": "HandlerText"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "key",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "Remembered"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "Integer"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+            {
+              "canonical": "value >= 0",
+              "description": "a guard count is never negative"
+            }
+          ],
+          "members": [
+
+          ],
+          "name": "GuardCount"
         },
         {
           "attributes": [

--- a/spec/saga_handler_remembers_guard_count_round_trip_growth_spec.rb
+++ b/spec/saga_handler_remembers_guard_count_round_trip_growth_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for Handler's remembers/guard_count self-hosted round-trip:
+# reaction.bluebook's own "Handler" aggregate never declared `remembers` or
+# `guard_count`, so `remember key: from_event(...)` and a handler-level
+# `given` had nowhere for the meta-validator's Judge/Reconstruction to
+# write or read them back -- round_trip_spec caught it directly (Banking/
+# Wire both diffed on `.handlers[N].remembers`/`.guard_count`, "declared
+# [], read back nil").
+RSpec.describe "Handler remembers/guard_count survive the Judge round-trip" do
+  SAGA_REMEMBER_ROUND_TRIP_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "SagaRememberRoundTripGrowth" do
+      aggregate "Widget" do
+        identified_by { id.value }
+        value_object "WidgetId" do
+          attribute :value, String
+        end
+        attribute :id, WidgetId
+
+        command "Open" do
+          attribute :id, WidgetId
+          emits "Opened"
+        end
+        command "Close" do
+          reference_to Widget
+          emits "Closed"
+        end
+      end
+
+      process_manager "RememberGuardSaga" do
+        correlates_by :"id.value"
+        starts_on "Opened"
+        ends_on "Closed"
+
+        state "none"
+        state "open"
+
+        on "Opened", transition: { "none" => "open" } do
+          remember owner: :id
+          given { !id.to_s.empty? }
+          dispatch "SagaRememberRoundTripGrowth::Widget.Close", with: { id: :id }
+        end
+      end
+    end
+  BLUEBOOK
+
+  def build_bluebook
+    file = Tempfile.new(["saga-remember-round-trip-growth-", ".bluebook"])
+    file.write(SAGA_REMEMBER_ROUND_TRIP_SOURCE)
+    file.flush
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(SAGA_REMEMBER_ROUND_TRIP_SOURCE, TOPLEVEL_BINDING, file.path, 1)
+    end
+    registry.bluebook("SagaRememberRoundTripGrowth")
+  ensure
+    file&.close!
+  end
+
+  # `Hecksagain.bluebook`'s own `BluebookBuilder#build` already routes
+  # through `MetaValidator.call` internally (meta-validation defaults ON)
+  # -- so this is ALREADY a full Judge/Reconstruction round-trip, not a
+  # bare DSL capture. Before the fix: declared non-empty, read back [] /
+  # guard_count 0 -- "declared [], read back nil" is round_trip_spec's
+  # own wording for this exact regression.
+  it "the judged bluebook carries the handler's own remembers and guard_count" do
+    bluebook = build_bluebook
+    handler = bluebook.process_managers.first.handlers.first
+
+    expect(handler.remembers).to eq(owner: :id)
+    expect(handler.guard_count).to eq(1)
+  end
+
+  it "re-judging an already-judged bluebook is stable (idempotent round-trip)" do
+    once = build_bluebook
+    twice = Hecksagain::Bluebook::MetaValidator.call(once)
+    handler = twice.process_managers.first.handlers.first
+
+    expect(handler.remembers).to eq(owner: :id)
+    expect(handler.guard_count).to eq(1)
+  end
+end

--- a/spec/specializer_spec.rb
+++ b/spec/specializer_spec.rb
@@ -1,7 +1,18 @@
 require "spec_helper"
 
 RSpec.describe "the first specializer" do
-  %w[Policy Handler].each do |category|
+  # Handler swapped for Bluebook (migration plan task 4): Handler grew a
+  # real `list_of` field (`remembers`, the saga-memory open map — see
+  # reaction.bluebook's own comment), which the specializer deliberately
+  # never claims ("ONE CASE, PROVEN, NOT THE WHOLE TABLE" — Specializer#
+  # fields_for's own header). Handler's hand-written contract and the
+  # specializer's derived one can no longer agree field-for-field, which
+  # is not a regression — it is exactly what "not the whole table" always
+  # meant, now actually exercised. Bluebook is the next category whose
+  # own `fields:` table is ALL plain scalars (no lists, no references,
+  # including the `category` field this migration added), so it takes
+  # Handler's place as the second independently-checked category.
+  %w[Policy Bluebook].each do |category|
     it "derives #{category}'s fields exactly as hand-written" do
       derived = Hecksagain::Bluebook::Assembly::Specializer.fields_for(category)
       hand    = Hecksagain::Bluebook::Assembly.contract(category).fields


### PR DESCRIPTION
Splits `70169fc` (self-hosted grammar: Handler's remembers/guard_count round-trip through the Judge) — item 36 of the [PR-split plan](.pr-split-plan.md). The `redirects_native` corpus-consumer piece of the same source commit already landed separately at item 36a (PR #90), per this plan's own note recorded back at item 05.

**Finding**: `reaction.bluebook`'s self-hosted "Handler" aggregate never declared `remembers` or `guard_count`, so `remember key: from_event(...)` and a handler-level `given` had nowhere for the meta-validator's Judge/Reconstruction to write or read them back — `round_trip_spec` caught it directly (Banking/Wire both diffed on `.handlers[N].remembers`/`.guard_count`, "declared [], read back nil").

**Closed with**: `attribute :remembers, list_of(Remembered)` + a `Handler.Remember` sub-command mirroring `Dispatch.Bind`'s own open-map shape; `attribute :guard_count, GuardCount` on `Handler.Declare`; `IR::ProcessManagerHandler` grows a real seventh member `guard_count` (explicit override wins, falls back to counting `guards`); `assembly/contracts.rb`'s "Handler" contract + `readings.rb`'s new `remembers_rows` shaper, mirroring `Dispatch`'s own `with_spec` handling line for line. `spec/specializer_spec.rb` swapped Handler for Bluebook as its second proven category (Handler legitimately grew a real list field, not a regression). `banking.bluebook` gained `remember destination_account: :destination` on Settlement's own `TransferRequested` leg, exercising `Handler.Remember` for real in the judged corpus.

**GENUINELY CLOSES** `round_trip_spec`'s Banking AND Wire failures — confirmed by full-suite rerun, stable across two runs.

**Honest, newly-exposed, out-of-scope gap found**: exercising `remember` for real in `banking.bluebook` (required to close `judge_coverage_spec`) also exposes a genuine, deterministic Ruby/Rust parity gap in `rust_conformance_spec` (2 examples) — the native Rust binary does not implement saga-memory `remember` writes at all, a capability gap that predates this PR (item 10/`25cf543`, Ruby-only, landed early in this migration with no corresponding Rust-side work anywhere in the 31 commits this migration splits). Confirmed deterministic (not a race) via two isolated reruns of just those two examples. Implementing Rust's own `remember` support is a substantial undertaking with no commit in this migration's range touching Rust source — out of scope for this split, not fixed here, and not hidden. **Net effect on the failure count is zero** (2 genuinely closed, 2 newly exposed) — not claimed as an improvement it isn't.

**Coverage**: `spec/saga_handler_remembers_guard_count_round_trip_growth_spec.rb`, 2 examples. Verified genuinely failing without the fix via `git stash` (2/2 — `remembers` reads back `nil`).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1453 examples, 6 failures (stable across two runs, same count as the base branch with different composition as explained above).
