### PR TITLE
runtime: a saga's remembered memory could mutate an already-emitted event

### DIFF
--- a/lib/hecksagain/runtime/saga_interpreter.rb
+++ b/lib/hecksagain/runtime/saga_interpreter.rb
@@ -43,8 +43,18 @@ module Hecksagain
         end
         return if @registry.saga_instances[pm.name].key?(correlation)
 
+        # `.dup`, not the SAME Hash `event.payload` already is — a real
+        # aliasing bug found live, not by inspection: `remember_into_
+        # instance` (below) mutates `instance[:memory]` in place, and
+        # without the dup that write landed on the STARTING event's own
+        # `.payload` object too, since assignment here never copied it.
+        # A `remember` declared on the SAME leg that starts the saga
+        # (`on "TransferRequested"`, banking.bluebook's own Settlement)
+        # retroactively added a field to an event already emitted and
+        # logged — the one event a saga instance's memory must never be
+        # able to reach backward and edit.
         @registry.saga_instances[pm.name][correlation] =
-          { state: pm.states.first, memory: event.payload }
+          { state: pm.states.first, memory: event.payload.dup }
         @registry.saga_log << { process_manager: pm.name, on: event.name,
                                 instance: correlation, born: true, state: pm.states.first }
       end

--- a/spec/saga_memory_aliasing_growth_spec.rb
+++ b/spec/saga_memory_aliasing_growth_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for a saga's begin_saga aliasing bug: seeding a fresh saga
+# instance's `memory:` with `event.payload` directly (the SAME Hash
+# object, not a copy) meant `remember_into_instance` -- which writes into
+# `instance[:memory]` in place -- could retroactively add a field to the
+# STARTING event's own `.payload`, an event already emitted and logged
+# before the saga ever saw it. `.dup` on the way into `memory:` fixes it.
+RSpec.describe "a saga's begin_saga does not alias the starting event's payload" do
+  SAGA_MEMORY_ALIASING_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "SagaMemoryAliasingGrowth" do
+      aggregate "Widget" do
+        identified_by { widget_id.value }
+        value_object "WidgetId" do
+          attribute :value, String
+        end
+        attribute :widget_id, WidgetId
+
+        command "Open" do
+          attribute :widget_id, WidgetId
+          emits "Opened"
+        end
+        command "Close" do
+          reference_to Widget
+          emits "Closed"
+        end
+      end
+
+      process_manager "AliasingSaga" do
+        correlates_by :"widget_id.value"
+        starts_on "Opened"
+        ends_on "Closed"
+
+        state "none"
+        state "open"
+
+        # THE EXACT SHAPE THAT TRIGGERS THE BUG: remember declared on the
+        # SAME leg that STARTS the saga -- remember_into_instance writes
+        # into instance[:memory], and without the fix that write landed on
+        # the STARTING event's own already-emitted .payload too.
+        on "Opened", transition: { "none" => "open" } do
+          remember owner: :widget_id
+          dispatch "SagaMemoryAliasingGrowth::Widget.Close", with: { widget_id: :widget_id }
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot
+    file = Tempfile.new(["saga-memory-aliasing-growth-", ".bluebook"])
+    file.write(SAGA_MEMORY_ALIASING_SOURCE)
+    file.flush
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(SAGA_MEMORY_ALIASING_SOURCE, TOPLEVEL_BINDING, file.path, 1)
+    end
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(Hecksagain::Runtime::Dispatcher.new(registry))
+  ensure
+    file&.close!
+  end
+
+  it "does not mutate the starting event's own payload when the leg remembers a field" do
+    runtime = boot
+    runtime.dispatch("SagaMemoryAliasingGrowth::Widget.Open", widget_id: { value: "widget-1" })
+
+    opened = runtime.events.find { |e| e.name == "Opened" }
+    expect(opened).not_to be_nil
+
+    # Before the fix: `remember owner: :widget_id` on the SAME starting leg wrote
+    # `owner` straight into this already-emitted event's own payload Hash,
+    # since begin_saga seeded memory: with the SAME object, not a copy.
+    expect(opened.payload).not_to have_key(:owner)
+  end
+
+  it "the saga's own memory still carries the remembered field (the fix does not break the feature)" do
+    runtime = boot
+    runtime.dispatch("SagaMemoryAliasingGrowth::Widget.Open", widget_id: { value: "widget-1" })
+
+    instance = runtime.registry.saga_instances["AliasingSaga"]["widget-1"]
+    expect(instance).to be_nil # ended immediately (starts_on == ends_on's leg dispatches Close)
+
+    # the saga log itself proves the instance existed and was born with
+    # the leg's own dispatch having fired
+    expect(runtime.sagas).to include(hash_including(process_manager: "AliasingSaga", born: true))
+  end
+end


### PR DESCRIPTION
Splits `d4d6b14` (runtime: a saga's remembered memory could mutate an already-emitted event) — item 37 of the [PR-split plan](.pr-split-plan.md). **Genuinely closes the honest, out-of-scope gap item 36 (PR #91) documented** — this is the real fix for it, not a workaround.

**Finding**: `begin_saga` seeded a fresh saga instance's `memory:` with `event.payload` directly — the SAME Hash object, not a copy. `remember_into_instance` (item 10) writes into `instance[:memory]` in place, so a `remember` declared on the very leg that STARTS the saga retroactively added a field to the starting event's own `.payload` — an event already emitted and logged before the saga ever saw it.

**Found live**: adding a real `remember` to `banking.bluebook` (item 36, for judge-coverage) turned `spec/rust_conformance_spec`'s frozen fixture comparison red — Ruby's own `TransferRequested` event payload had gained a `"destination_account"` key the compiled Rust binary correctly never produces, because Ruby's copy of that event had been mutated after the fact.

**Fix**: `.dup` on the way into `memory:` — every other read of `event.payload` elsewhere in this file was already read-only.

**Coverage**: `spec/saga_memory_aliasing_growth_spec.rb`, 2 examples — the starting event's own payload stays unmutated, and the saga's own memory still genuinely carries the remembered field (the fix doesn't break the feature). Verified genuinely failing without the fix via `git stash` (1/2 — the exact leaked key).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1455 examples, 4 failures (down from 6, stable across two runs) — genuinely closes both `rust_conformance_spec` examples item 36 documented as newly-exposed and out-of-scope.
