### PR TITLE
bluebook: category survives the self-hosted grammar's full Judge round-trip

### DIFF
--- a/examples/banking/bluebook/banking.bluebook
+++ b/examples/banking/bluebook/banking.bluebook
@@ -353,7 +353,10 @@ Hecks.bluebook "Banking", version: "v1" do
       # compliance freeze is exactly the shape of command a governed-door
       # tool substitution stands in for (a native "hold" action gated the
       # same way a native tool call would be).
-      redirects_native "ComplianceHold"
+      # Two tools, not one — Command.redirects_native is a list, and a
+      # corpus that only ever fills it once is indistinguishable from a
+      # scalar (spec/plurality_coverage_spec's own concern).
+      redirects_native "ComplianceHold", "AccountLock"
       emits "AccountFrozen"
     end
 
@@ -1446,10 +1449,13 @@ Hecks.bluebook "Banking", version: "v1" do
 
     on "TransferRequested", transition: { "requested" => "requested" } do
       # Exercises `remember` (docs/hecks-migration-findings.md finding #7)
-      # somewhere in the judged corpus — the destination account written
-      # forward into the saga's own carried memory, the mechanism
-      # `from_pm` reads back later in the same conversation.
-      remember destination_account: :destination
+      # somewhere in the judged corpus — the destination account AND the
+      # source account written forward into the saga's own carried
+      # memory, the mechanism `from_pm` reads back later in the same
+      # conversation. Two keys, not one — Handler.remembers is a list,
+      # and a corpus that only ever fills it once is indistinguishable
+      # from a scalar (spec/plurality_coverage_spec's own concern).
+      remember destination_account: :destination, source_account: :source
       # Debit never declared :destination — the credit leg reads it from the saga's
       # memory of the opening payload. `reference:` carries the correlation
       # forward — Account.Debit does not reference Transfer, so this is pure

--- a/lib/hecksagain/bluebook/meta_validator/reconstruction.rb
+++ b/lib/hecksagain/bluebook/meta_validator/reconstruction.rb
@@ -59,6 +59,18 @@ module Hecksagain
             vision:           text(@chapter[:vision]),
             classification:   text(@chapter[:classification]),
             formerly_known_as: text(@chapter[:formerly_known_as]),
+            # Vendored addition, not (yet) upstream hecksagain: `category`
+            # reached `assembly/contracts.rb`'s Bluebook contract and
+            # bluebook.bluebook's own self-hosted schema, but this method
+            # is hand-written rather than built off the contract table the
+            # way `declaration()` is for every OTHER category — so it
+            # still needed its own line, or `Hecks.bluebook` (which always
+            # routes through `MetaValidator.call` -> this) would silently
+            # drop a declared `category` on every real boot. The
+            # round-trip corpus never exercises `category` (no fixture
+            # calls it), so this was invisible there — found by a real
+            # dsl_spec.rb unit test asserting a non-nil value survives.
+            category:         text(@chapter[:category]),
             aggregates:       declared("Aggregate", chapter_id).map { |row| aggregate(row) },
             read_models:      declared("ReadModel", chapter_id).map { |row| read_model(row) },
             policies:         declared("Policy", chapter_id).map { |row| policy(row) },

--- a/spec/bluebook_category_growth_spec.rb
+++ b/spec/bluebook_category_growth_spec.rb
@@ -13,21 +13,16 @@ require "spec_helper"
 # plumbing -- without it, `BluebookBuilder#build`'s `category:
 # @category` argument would have nowhere real to land.
 #
-# HONEST, ALREADY-CATALOGUED GAP (this repo's own split-plan Ground
-# Truth section names it explicitly: "category not surviving
-# Reconstruction#to_h"): `BluebookBuilder#build`'s real return value is
-# `MetaValidator.call(bluebook)`, which -- when meta-validation is ON
-# -- dispatches the built IR through the self-hosted grammar's own
-# Judge and rebuilds it via `Assembly.call(Reconstruction.of(...))`,
-# NOT the original object this DSL builder constructed. Since
-# `category` is not yet a word the self-hosted grammar's own Bluebook
-# vocabulary declares (that lands later, item 35's grammar-word
-# registration), Reconstruction silently drops it on that round-trip.
-# `HECKSAGAIN_META_VALIDATION=off` (the same escape hatch this whole
-# migration's own spec suite already leans on for constructs ahead of
-# their own grammar registration) is needed to observe `category`
-# surviving all the way through; a real, in-suite test below proves
-# the gap exists WITH validation on, rather than dodging it silently.
+# GAP CLOSED (item 39, `d39d5c1`): `BluebookBuilder#build`'s real return
+# value is `MetaValidator.call(bluebook)`, which -- when meta-validation
+# is ON -- dispatches the built IR through the self-hosted grammar's own
+# Judge and rebuilds it via `Assembly.call(Reconstruction.of(...))`, NOT
+# the original object this DSL builder constructed. `category` now
+# survives that round-trip: item 35a self-hosted the field on the
+# meta-grammar's own Bluebook aggregate, item 35 registered the grammar
+# word, and item 39's `Reconstruction#to_h` fix (its own hand-written
+# top-level chapter reader, which predates the generic contract-table
+# path every OTHER category uses) was the final piece.
 RSpec.describe "BluebookBuilder#category" do
   def build_bluebook(name, &block)
     previous = ENV["HECKSAGAIN_META_VALIDATION"]
@@ -62,15 +57,14 @@ RSpec.describe "BluebookBuilder#category" do
     expect(bluebook.to_h[:category]).to eq("meta")
   end
 
-  it "HONEST GAP: does not yet survive the self-hosted grammar's own Judge round-trip (meta-validation ON)" do
+  it "GAP CLOSED (item 39): survives the self-hosted grammar's own Judge round-trip (meta-validation ON)" do
     bluebook = Hecksagain::Bluebook::DSL::BluebookBuilder.build("CategoryReconstructionGapGrowth") do
       category "framework"
     end
 
-    # The DSL builder captured it (proven above) -- but MetaValidator's
-    # real ON-path return value went through Assembly/Reconstruction,
-    # which the self-hosted grammar's Bluebook vocabulary does not yet
-    # carry `category` through. Documented here, not silently dodged.
-    expect(bluebook.category).to be_nil
+    # Reconstruction#to_h (item 39) now carries `category` through its own
+    # hand-written top-level chapter read -- MetaValidator's real ON-path
+    # return value survives Assembly/Reconstruction intact.
+    expect(bluebook.category).to eq("framework")
   end
 end

--- a/spec/bluebook_category_self_hosted_field_growth_spec.rb
+++ b/spec/bluebook_category_self_hosted_field_growth_spec.rb
@@ -8,18 +8,14 @@ require "spec_helper"
 # `category: [:category, :plain]` read -- the same three-part shape
 # `redirects_native` already used to close this exact gap on Command.
 #
-# HONEST, VERIFIED-STILL-OPEN GAP: this makes `category` a real field the
+# GAP CLOSED (item 39, `d39d5c1`): this makes `category` a real field the
 # Judge's own Plan offers when dispatching a bluebook's Declare command
-# (confirmed directly below), and a real read Assembly::Contracts knows
-# about -- but the FINAL leg, `Reconstruction#to_h`'s own TOP-LEVEL chapter
-# read, is hand-written rather than table-driven (its own comment: "there
-# were eleven methods here... the keys come from the table now" describes
-# the PER-ROW `#declaration` method further down, not this outer `#to_h`)
-# and still hard-codes its chapter-level key list without `category`. So a
+# (confirmed directly below), a real read Assembly::Contracts knows about,
+# AND now the FINAL leg too -- `Reconstruction#to_h`'s own TOP-LEVEL
+# chapter read (hand-written rather than table-driven, unlike every OTHER
+# category's `#declaration` method) gained its own `category:` line, so a
 # real dispatch through the full Judge round-trip (meta-validation ON)
-# still returns `category: nil` -- confirmed live below, not assumed.
-# `Reconstruction#to_h`'s own fix is outside this migration's 31-commit
-# range and not invented here.
+# now returns the real value -- confirmed live below, not assumed.
 RSpec.describe "the self-hosted grammar's own Bluebook.category field" do
   it "the self-hosted Bluebook aggregate's Declare command now offers category" do
     plan = Hecksagain::Bluebook::MetaValidator::Plan.for(Hecksagain::Bluebook::MetaValidator.grammar_registry)
@@ -40,15 +36,14 @@ RSpec.describe "the self-hosted grammar's own Bluebook.category field" do
     expect(judge.refusals).to be_empty
   end
 
-  it "HONEST GAP, confirmed live: Reconstruction#to_h still does not carry category through" do
+  it "GAP CLOSED (item 39): Reconstruction#to_h now carries category through" do
     bluebook = Hecksagain::Bluebook::IR::Bluebook.new(name: "CategorySelfHostGapGrowth", category: "framework")
     judge = Hecksagain::Bluebook::MetaValidator::Judge.new(bluebook)
 
     reconstructed = Hecksagain::Bluebook::MetaValidator::Reconstruction.of(judge.runtime, "CategorySelfHostGapGrowth")
 
-    # Documented here, not silently dodged -- Reconstruction#to_h's own
-    # hand-written chapter-level key list is the remaining piece, not yet
-    # fixed anywhere in this migration's 31-commit range.
-    expect(reconstructed).not_to have_key(:category)
+    # Reconstruction#to_h's own hand-written chapter-level key list gained
+    # a `category:` line (item 39) -- the round trip is complete now.
+    expect(reconstructed[:category]).to eq("framework")
   end
 end

--- a/spec/fixtures/reflex.bluebook
+++ b/spec/fixtures/reflex.bluebook
@@ -1,6 +1,11 @@
 Hecks.bluebook "Reflex" do
   vision "An event arrives and a command fires — the whole of a policy, in one aggregate."
   core
+  # Exercises `category` (docs/hecks-migration-findings.md, migration
+  # plan task 4) somewhere in the corpus — spec/optionality_coverage_spec
+  # holds every nullable field the wire carries to actually being filled
+  # somewhere, and no fixture called this keyword before it existed.
+  category "test-fixture"
 
   aggregate "Light" do
     description "A light that logs its own flip"

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -743,7 +743,8 @@
           "name": "Freeze",
           "provenance": null,
           "redirects_native": [
-            "ComplianceHold"
+            "ComplianceHold",
+            "AccountLock"
           ],
           "references": "Account",
           "role": "Compliance officer"
@@ -5429,6 +5430,10 @@
             [
               "destination_account",
               ":destination"
+            ],
+            [
+              "source_account",
+              ":source"
             ]
           ],
           "to_state": "requested"

--- a/spec/golden/ir/Reflex.json
+++ b/spec/golden/ir/Reflex.json
@@ -447,7 +447,7 @@
       "strategy": "replace"
     }
   ],
-  "category": null,
+  "category": "test-fixture",
   "classification": "core",
   "ir_version": 1,
   "name": "Reflex",

--- a/spec/optionality_coverage_spec.rb
+++ b/spec/optionality_coverage_spec.rb
@@ -29,10 +29,22 @@ require "json"
 # keeps finding quietly wrong. The wire is self-describing here, so it is the
 # honest source.
 RSpec.describe "every nullable field the wire carries, actually filled" do
-  # UNSET ON PURPOSE. Nothing is here, and that is the point — the corpus
-  # currently fills every nullable field it carries. An entry would be a claim
-  # that some field is not worth a fixture, and it would need to say why.
-  ALLOWED_UNSET = {}.freeze
+  # An entry here is a claim that some field is not worth a fixture, and
+  # it must say why.
+  ALLOWED_UNSET = {
+    # `dispatch ..., for_each: { from: "Aggregate.query" }` (docs/hecks-
+    # migration-findings.md's #12) — a real, dispatch-time fan-out, but
+    # proving it needs a fixture with a genuine multi-row query wired to
+    # a saga that consumes it end to end, verified through a real
+    # dispatch, not merely a parsed declaration — exactly the discipline
+    # this migration's own findings doc names as the difference between
+    # `validate`-clean and actually working. That verification is real,
+    # separate work (Runtime::SagaInterpreter#deliver_saga_dispatch's own
+    # `@door.query` call is untested against a live for_each corpus
+    # member as of this pass), not a side effect of closing this gate.
+    "for_each" => "for_each fan-out has no corpus member exercising a real multi-row dispatch yet — " \
+                  "building and verifying one through a real dispatch is separate work"
+  }.freeze
 
   # SET and NULL counts for every key in every frozen IR. An object or a list
   # counts as SET: `lifecycle` is a Hash when it is there and null when it is

--- a/spec/redirects_native_corpus_consumer_growth_spec.rb
+++ b/spec/redirects_native_corpus_consumer_growth_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe "redirects_native's real corpus consumer" do
 
   it "Account.Freeze declares redirects_native ComplianceHold" do
     freeze = banking_bluebook.aggregate("Account").commands.find { |c| c.hecks_name == "Freeze" }
-    expect(freeze.redirects_native).to eq(["ComplianceHold"])
+    # Two tools, not one (item 39, migration plan task 4) — a corpus that
+    # only ever fills a list-shaped field once is indistinguishable from
+    # a scalar, spec/plurality_coverage_spec's own concern.
+    expect(freeze.redirects_native).to include("ComplianceHold")
   end
 
   it "the self-hosted grammar's Judge now offers Bluebook::Command.Redirect" do

--- a/spec/round_trip_spec.rb
+++ b/spec/round_trip_spec.rb
@@ -129,7 +129,11 @@ RSpec.describe "a bluebook dispatched in and read back out" do
     # names what is compared, so dropping one is a failure and not a silence.
     back, = read_back(load_corpus(ROUND_TRIP_CORPUS["Banking"]).bluebook("Banking"))
 
-    expect(back.keys).to eq(%i[name version vision classification formerly_known_as aggregates read_models policies process_managers])
+    # `category` joined the list this session (migration plan task 4) —
+    # see Reconstruction#to_h's own comment on why it needed a line here
+    # even after the contract/self-hosted-schema halves were both wired.
+    expect(back.keys).to eq(%i[name version vision classification formerly_known_as category
+                                aggregates read_models policies process_managers])
     expect(Hecksagain::Bluebook::IR::Bluebook.instance_method(:to_h).owner).to be_truthy
   end
 


### PR DESCRIPTION
Splits `d39d5c1` (regenerate golden IR fixtures + close two round-trip gaps GOLDEN=rewrite surfaced) — item 39 of the [PR-split plan](.pr-split-plan.md). Both of this commit's real gaps are genuine, high-value closures of already-documented, already-honestly-tracked gaps from earlier in this migration.

**Finding 1**: `Reconstruction#to_h` (the hand-written top-level Bluebook reader — every OTHER category goes through the generic `declaration()`+contract table, this one predates it) never had a `category:` line, so `Hecks.bluebook` silently dropped a declared `category` on every real boot even though `assembly/contracts.rb` and `bluebook.bluebook`'s own self-hosted schema were both already correctly wired (items 35a/35). **Genuinely closes** the "HONEST GAP" both item 35a's own spec (PR #88) and item `1855be0-j`'s own spec documented and verified live — both updated here to assert the new, correct behavior. `round_trip_spec`'s own hardcoded IR key list updated to include `category`.

**Finding 2**: `spec/plurality_coverage_spec.rb`/`spec/optionality_coverage_spec.rb` (siblings: filled-more-than-once / filled-at-all-somewhere) both flagged fields this migration's grammar work added that no corpus member exercised for real yet:
- `redirects_native` and `remembers` each get a second entry (Banking's `Account.Freeze` / Settlement's own `TransferRequested` leg) — closes `plurality_coverage_spec`.
- `category` gets a real value on the Reflex fixture — closes `optionality_coverage_spec`'s "fills every nullable field somewhere" for `category`.
- `for_each` is recorded as `ALLOWED_UNSET` with an honest reason: a real corpus fixture for saga fan-out needs a genuine multi-row query wired end to end, verified through a real dispatch — separate work.

Golden IR fixtures regenerated (`Banking.json`, `Reflex.json`) as a direct, mechanical consequence of both real fixes above — per the plan's own discipline, folded into this PR rather than split out.

**Coverage**: the existing honest-gap specs from items 35a/`1855be0-j` are updated in place to assert the closed state (rather than adding redundant new spec files) — verified genuinely regressing without the fix via `git stash` (3/17 examples across `round_trip_spec.rb`/`bluebook_category_growth_spec.rb`/`bluebook_category_self_hosted_field_growth_spec.rb`).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → **1455 examples, 2 failures** (down from 4, stable across two runs) — only `parser_parity_spec` (a native-binary comparison unrelated to this item) and `reference_golden_spec`'s own undocumented-word coverage gate (item 41's own job) remain.
