### PR TITLE
value objects: refuse an inline one_of they cannot actually nest

### DIFF
--- a/docs/guides/aggregates-and-value-objects.md
+++ b/docs/guides/aggregates-and-value-objects.md
@@ -391,23 +391,27 @@ Banking::SafeDepositBox.rent(customer_id: customer.id, branch_code: { value: "up
 Reach for this one when the set is small, local, and not worth a name
 anyone else will ever reuse.
 
-A onetime trap: the inline shorthand desugars by calling `one_of` on
+The trap: the inline shorthand desugars by calling `one_of` on
 whichever builder currently has `self` — and a nested `value_object`
-block already defines its own `one_of`, for closed-set members. Since
-both spellings share the bare word, `ValueObjectBuilder#one_of`
-disambiguates by call shape: values with no block is the inline
-shorthand (delegated to the same synthesis every other builder uses),
-a block with no values is the closed-set-body form. Writing the
-shorthand inside a `value_object` block now synthesizes a closed set
-correctly, the same as anywhere else:
+block already defines its own `one_of`, for closed-set members.
+`ValueObjectBuilder` tells the two calling shapes apart (arguments with
+no block reach the same type-position sugar an aggregate's own
+attribute uses ; a bare block keeps the closed-set-body form), so the
+shorthand no longer raises the wrong-arity crash it once did — but a
+value object still cannot HOLD a nested one: `IR::ValueObject` has no
+member for a value object inside a value object, only a flat list of
+attributes and members of its own. Writing the shorthand inside a
+`value_object` block still does not synthesize a usable closed set —
+the bluebook refuses to load, now with a message that says so plainly
+instead of a Ruby arity error:
 
 ```ruby
-def banking_nested_one_of
+def banking_bad_one_of
   Hecksagain.with_registry(Hecksagain::Runtime::Registry.new) do
     Kernel.load(InMemoryDomain::EXTRACTION_PORT)
     Kernel.load(InMemoryDomain::PRISM_ADAPTER)
     code = <<~RUBY
-      Hecks.bluebook("BankingNestedOneOf") do
+      Hecks.bluebook("BankingBadOneOf") do
         aggregate "Thing" do
           identified_by { thing_id.value }
           attribute :box, Box
@@ -418,7 +422,7 @@ def banking_nested_one_of
         end
       end
     RUBY
-    file = Tempfile.new(["banking-nested-one-of-", ".bluebook"])
+    file = Tempfile.new(["banking-bad-one-of-", ".bluebook"])
     file.write(code)
     file.flush
     Kernel.eval(code, TOPLEVEL_BINDING, file.path, 1)
@@ -426,7 +430,7 @@ def banking_nested_one_of
   true
 end
 
-banking_nested_one_of   # => true
+banking_bad_one_of   # ~> Malformed: value object cannot hold
 ```
 
 ## A field that grows

--- a/lib/hecksagain/bluebook/dsl/value_object_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/value_object_builder.rb
@@ -78,6 +78,27 @@ module Hecksagain
         alias_method :rule, :invariant
 
         def build
+          # `attribute :size, one_of("small", "large")` INSIDE a value_object
+          # body reaches AttributeCollector#synthesise_closed_set (via the
+          # one_of/#one_of disambiguation this class's own `one_of` method
+          # already fixed — no more ArgumentError on the wrong arity) and
+          # pushes a real closed-set ValueObject onto `closed_sets` — but
+          # `IR::ValueObject.declare` has no member to hold a NESTED value
+          # object at all (unlike IR::Aggregate, which merges its own
+          # `closed_sets` into `value_objects`). Silently dropping it here
+          # left `:size` typed as a reference to a shape that was never
+          # registered anywhere — no crash, no refusal, and `aggregate.
+          # value_object("Size")` simply returned nil the first time anyone
+          # actually looked. Refused here instead, honestly, until value
+          # objects can really nest one (a structural change well beyond
+          # this fix's scope).
+          if closed_sets.any?
+            raise Malformed,
+                  "#{@name}'s attribute #{closed_sets.first.hecks_name.inspect} names an inline " \
+                  "one_of, which a value object cannot hold — value objects do not nest. " \
+                  "Declare the closed set as its own value_object instead."
+          end
+
           IR::ValueObject.declare(
             name: @name, attributes: attributes,
             invariants: @invariants, members: @members,

--- a/spec/catchall_stubs_growth_spec.rb
+++ b/spec/catchall_stubs_growth_spec.rb
@@ -86,13 +86,34 @@ RSpec.describe "1855be0-g catch-all: DSL builder stubs and small real fixes" do
   end
 
   describe "ValueObjectBuilder#one_of's real disambiguation fix" do
-    it "the inline shorthand (values, no block) now synthesizes a closed set instead of raising ArgumentError" do
-      vo = Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("InlineOneOfCatchallGrowth") do
-        attribute :size, one_of("small", "large")
+    it "the inline shorthand (values, no block) no longer raises the wrong-arity ArgumentError" do
+      error = begin
+        Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("InlineOneOfCatchallGrowth") do
+          attribute :size, one_of("small", "large")
+        end
+        nil
+      rescue StandardError => e
+        e
       end
 
-      field = vo.attributes.find { |a| a.name == :size }
-      expect(field.type.to_s).to eq("Size")
+      expect(error).not_to be_a(ArgumentError)
+    end
+
+    # GAP CLOSED (item 40, `bfbd513`): the disambiguation fix above no
+    # longer raises the wrong-arity ArgumentError, but a value object
+    # still cannot HOLD a nested one -- IR::ValueObject has no member for
+    # a value object inside a value object. Silently dropping the
+    # synthesised closed set left `:size` typed as a reference to a shape
+    # that was NEVER REGISTERED anywhere ("field.type.to_s == 'Size'"
+    # looked correct while `aggregate.value_object("Size")` returned nil
+    # the first time anything looked) -- loads clean, silently broken,
+    # worse than the ArgumentError it replaced. Refused honestly now.
+    it "still refuses honestly -- a value object cannot hold an inline one_of" do
+      expect do
+        Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("InlineOneOfNestingCatchallGrowth") do
+          attribute :size, one_of("small", "large")
+        end
+      end.to raise_error(Hecksagain::Bluebook::DSL::Malformed, /value objects do not nest/)
     end
 
     it "the closed-set-body form (block, no values) still works exactly as before" do

--- a/spec/value_object_inline_one_of_nesting_growth_spec.rb
+++ b/spec/value_object_inline_one_of_nesting_growth_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for a newly-discovered correctness bug in the one_of
+# disambiguation fix (item 1855be0-g): `attribute :size, one_of("small",
+# "large")` inside a `value_object do ... end` body no longer raises the
+# wrong-arity ArgumentError, but the value object it synthesises has
+# nowhere to go -- IR::ValueObject.declare has no member for a NESTED
+# value object at all (unlike IR::Aggregate, which merges its own
+# closed_sets into value_objects). The synthesised shape was silently
+# dropped: no crash, no refusal, and the attribute stayed typed as a
+# reference to a value object that was never registered --
+# `aggregate.value_object("Size")` simply returned nil the first time
+# anything looked.
+RSpec.describe "ValueObjectBuilder#build refuses an inline one_of it cannot nest" do
+  it "refuses with a clear, honest Malformed message instead of silently dropping the shape" do
+    expect do
+      Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("InlineOneOfNestingGrowth") do
+        attribute :size, one_of("small", "large")
+      end
+    end.to raise_error(
+      Hecksagain::Bluebook::DSL::Malformed,
+      /InlineOneOfNestingGrowth's attribute "Size" names an inline one_of.*value objects do not nest/
+    )
+  end
+
+  it "a real aggregate using this shape refuses to load, not silently boots broken" do
+    registry = Hecksagain::Runtime::Registry.new
+    source = <<~BLUEBOOK
+      Hecks.bluebook("InlineOneOfNestingAggregateGrowth") do
+        aggregate "Thing" do
+          identified_by { thing_id.value }
+
+          value_object "ThingId" do
+            attribute :value, String
+          end
+
+          attribute :thing_id, ThingId
+          attribute :box, Box
+
+          value_object "Box" do
+            attribute :size, one_of("small", "large")
+          end
+        end
+      end
+    BLUEBOOK
+
+    file = Tempfile.new(["inline-one-of-nesting-aggregate-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    expect do
+      Hecksagain.with_registry(registry) do
+        Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+        Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+        Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      end
+    end.to raise_error(Hecksagain::Bluebook::DSL::Malformed, /value objects do not nest/)
+  ensure
+    file&.close!
+  end
+
+  it "the closed-set-body form (block, no values) still works -- unaffected by this fix" do
+    vo = Hecksagain::Bluebook::DSL::ValueObjectBuilder.build("ClosedSetBodyNestingGrowth") do
+      one_of do
+        member value: "open"
+        member value: "shut"
+      end
+    end
+
+    expect(vo.members.map { |m| m[:value] }).to eq(%w[open shut])
+  end
+end


### PR DESCRIPTION
Splits `bfbd513` (value objects: refuse an inline one_of they cannot actually nest) — item 40 of the [PR-split plan](.pr-split-plan.md).

**Finding**: a real, newly-discovered correctness bug in the one_of disambiguation fix (item `1855be0-g`): `attribute :size, one_of("small", "large")` inside a `value_object do ... end` body no longer raises the wrong-arity `ArgumentError` the disambiguation was meant to fix, but the value object it synthesises has nowhere to go — `IR::ValueObject.declare` has no member for a NESTED value object at all (unlike `IR::Aggregate`, which merges its own `closed_sets` into `value_objects`). The synthesised shape was silently dropped: no crash, no refusal, and the attribute stayed typed as a reference to a value object that was never registered.

**Fix**: `ValueObjectBuilder#build` now refuses with a clear, honest `Malformed` message when its own `closed_sets` collected anything, instead of quietly discarding it.

**Two real, in-scope regressions found and fixed in this same PR** (both introduced by item `1855be0-g`'s own optimistic rewrite):
- `docs/guides/aggregates-and-value-objects.md`'s own doctest had swung from "raises `ArgumentError`" all the way to "loads clean and works" — worse, not fixed. Rewritten to demonstrate the real, honest refusal, matching the original commit's own intent.
- `spec/catchall_stubs_growth_spec.rb`'s own test asserted the silently-broken shape as if it were correct (a type-name string match, papering over the never-registered value object). Split into two honest assertions: the `ArgumentError` is genuinely gone, AND the nesting refusal fires.

**Coverage**: `spec/value_object_inline_one_of_nesting_growth_spec.rb`, 3 examples — the direct builder refusal, a real aggregate boot refusing to load, and the unaffected closed-set-body form. Verified genuinely failing (silently boots broken, exactly the original bug) without the fix via `git stash` (2/3 examples).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1459 examples, 2 failures (stable) — no regressions; only `parser_parity_spec` (native-binary, unrelated) and `reference_golden_spec` (item 41's own job) remain.
