### PR TITLE
docs: prose for every new word, and a stale ir.keys example

### DIFF
--- a/docs/reference/aggregate.md
+++ b/docs/reference/aggregate.md
@@ -197,7 +197,7 @@ Opens what this aggregate may be asked to do — what it needs, what it refuses,
 | `enum:` | literal | false | type |
 <!-- generated:end -->
 
-Declares a field, scalar or value object. `pattern:` checks a String attribute against a regex the moment the bluebook loads, not the day a bad value reaches production — and only admits regexes every engine reads identically (no lookahead, no `\d`/`\w`). `admits:` points a field at a closed vocabulary declared elsewhere (a `one_of` on another value object) rather than restating its members, so two fields can't drift out of sync on what's allowed. `default:` fills the field when the record is built; for a value-object-typed attribute the default must fill that type's own fields (`default: { cents: 0 }`), not a bare scalar — a bare scalar loads cleanly and then refuses every create at dispatch. `optional:` lets a caller omit the argument entirely with no refusal, distinct from `default:`, which still fills the field either way.
+Declares a field, scalar or value object. `pattern:` checks a String attribute against a regex the moment the bluebook loads, not the day a bad value reaches production — and only admits regexes every engine reads identically (no lookahead, no `\d`/`\w`). `admits:` points a field at a closed vocabulary declared elsewhere (a `one_of` on another value object) rather than restating its members, so two fields can't drift out of sync on what's allowed. `default:` fills the field when the record is built; for a value-object-typed attribute the default must fill that type's own fields (`default: { cents: 0 }`), not a bare scalar — a bare scalar loads cleanly and then refuses every create at dispatch. `optional:` lets a caller omit the argument entirely with no refusal, distinct from `default:`, which still fills the field either way. Four more named arguments, each a live alias of one already above: `as:` names the field when the type leads positionally (`attribute App` reads the same as `attribute :app, App`) ; `required:` is the literal inverse of `optional:` ; `logged:` (default true) marks whether a field's changes are recorded ; `enum:` is a Rails-style spelling of the inline `one_of(*values)` closed-set sugar. A bare Ruby-primitive type (`String`/`Integer`/`Float`/booleans/`Numeric`) auto-synthesises a single-field wrapper value object named for the attribute, preserving "primitives only live in value objects" rather than relaxing it.
 
 ## invariant
 
@@ -205,7 +205,7 @@ Declares a field, scalar or value object. `pattern:` checks a String attribute a
 `invariant do ... end`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A whole-record rule, scoped to the AGGREGATE rather than one field — distinct from a value object's own field-scoped `invariant` and a command's dispatch-time `given`. Not yet threaded into `IR::Aggregate`: captured structurally (extracted, canonicalised) so the corpus boots and a future runtime walk has something real to read, but nothing evaluates it at dispatch time yet.
 
 ## rule
 
@@ -213,7 +213,7 @@ Declares a field, scalar or value object. `pattern:` checks a String attribute a
 `rule do ... end`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A live alias of `invariant`, at the aggregate level — the same word other corpora already use for a value object's own rule (see the ValueObject context page), now available one level up too.
 
 ## specification
 
@@ -221,7 +221,7 @@ Declares a field, scalar or value object. `pattern:` checks a String attribute a
 `specification do ... end`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A NAMED, reusable boolean predicate over the aggregate's own state — `specification :in_lucid_rem do |body| body.state == "sleeping" && ... end` — distinct from `invariant` (unnamed, whole-record) and a command's `given` (dispatch-time precondition). Captured structurally, the same documented gap as `invariant`: not yet threaded into `IR::Aggregate` or referenceable by name elsewhere.
 
 ## fixture
 
@@ -229,7 +229,7 @@ Declares a field, scalar or value object. `pattern:` checks a String attribute a
 `fixture`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`fixture "Name" do field value ... end`, declared inside an aggregate body — seed data for that aggregate. Accepted so the file boots ; the field-setter calls inside have no real receiver methods (they vary per aggregate) and nothing seeds a real record from them yet.
 
 ## validation
 
@@ -237,5 +237,5 @@ Declares a field, scalar or value object. `pattern:` checks a String attribute a
 `validation`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`validation :field, presence: true` — a Rails-style field-presence declaration, genuinely a field-level invariant in spirit. Accepted and structurally captured so the file boots ; not synthesised as a real `invariant` call and not enforced.
 

--- a/docs/reference/bluebook.md
+++ b/docs/reference/bluebook.md
@@ -109,7 +109,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `category` — fills `category`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A free-form second axis alongside `classification`'s fixed core/supporting/generic set — `category "framework"`, `category "world"`, whatever grouping a corpus actually uses. Unlike `classification`, nothing enforces a closed set of values here; it is a fact recorded and read back, not judged.
 
 ## glossary
 
@@ -117,7 +117,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `glossary`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Accepted so a chapter using it still boots — `glossary(strict: true) do ... end` names a vocabulary lock and its preferred terms. Not yet threaded into the IR: the block body is never evaluated or stored, a documented gap rather than a silently pretended feature.
 
 ## entrypoint
 
@@ -125,7 +125,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `entrypoint`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Accepted and discarded — names where a deployment or process starts, prose rather than a fact the language currently holds.
 
 ## fixture
 
@@ -133,7 +133,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `fixture`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`fixture "Name", on: "Aggregate" do ... end` — deploy-config seed data. Accepted so the file boots ; the block's field-setter calls have no real receiver methods and nothing seeds a real record from them yet.
 
 ## section
 
@@ -141,7 +141,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `section`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`section "Name" do row "key", value end` — a declarative source/template pairing. Accepted so the file boots ; `row` lines inside are captured by an inert receiver and go nowhere.
 
 ## define
 
@@ -149,7 +149,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `define`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`define "Term", "definition text"` — a glossary-term entry, sibling to `glossary` above. Accepted and discarded, the same documented gap.
 
 ## lifecycle
 
@@ -157,7 +157,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `lifecycle`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A bluebook-level, bare-string-named state-machine SUMMARY — `lifecycle "Name" do state "x" ; transition from: "a", to: "b", on: "Event" end` — disconnected from any one aggregate or field, a documentation-flavored restatement of what the real per-aggregate `lifecycle :field, default: ... do ... end` sugar (see the Aggregate context page) actually declares. Accepted so the file boots ; not wired to any aggregate's real lifecycle.
 
 ## event
 
@@ -165,7 +165,7 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `event`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`event "Name"` — a redundant vocabulary-listing sibling to `glossary`/`define`, naming an event some command elsewhere in the same file already `emits`. Accepted and discarded.
 
 ## actor
 
@@ -173,5 +173,5 @@ Opens a stateful saga spanning several events and commands — `correlates_by`, 
 `actor`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`actor "Name", description: "..."` — a prose role registry, sibling to `role "X"` already used freely inside commands. Documentation, not a new construct with runtime meaning. Accepted and discarded.
 

--- a/docs/reference/command.md
+++ b/docs/reference/command.md
@@ -79,7 +79,7 @@ A precondition, read against the record BEFORE any mutation runs. The first one 
 `description` — fills `goal`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A live alias of `goal`, not a rename — some corpora write `description "..."` where this reference otherwise says `goal "..."`. Same field, same one-line statement of intent.
 
 ## expects
 
@@ -87,7 +87,7 @@ A precondition, read against the record BEFORE any mutation runs. The first one 
 `expects do ... end` — fills `givens`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A live alias of `given` — "what the command requires before it runs." Same precondition shape, same `GivenNotMet` refusal, different word some corpora write instead.
 
 ## requires
 
@@ -95,7 +95,7 @@ A precondition, read against the record BEFORE any mutation runs. The first one 
 `requires do ... end` — fills `givens`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A second live alias of `given`, the spelling another corpus convention uses for the identical precondition shape.
 
 ## sets
 
@@ -156,7 +156,7 @@ Declares an argument this command needs, scalar or value object — same word, s
 `redirects_native` — fills `redirects_native`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Names one or more native harness tool names this command is the storehouse-door equivalent for — `redirects_native "Edit", "MultiEdit"`. Backs a governed-door lookup that decides which FQN and arguments a native tool call resolves to; a tool name that names none returns a fail-safe "no door."
 
 ## ensures
 
@@ -172,5 +172,5 @@ A postcondition, read AFTER the mutation runs but before `save` — `old` names 
 `guarantees do ... end` — fills `ensures`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A live alias of `ensures` — "what the command ensures afterward." Same postcondition shape, same `EnsuresNotMet` refusal, different word some corpora write instead.
 

--- a/docs/reference/entity.md
+++ b/docs/reference/entity.md
@@ -45,9 +45,7 @@ Names the field that tells one element of the list apart from another — unique
 | `optional:` | flag | false | optional |
 <!-- generated:end -->
 
-Points an entity at a real ROOT, the same way an aggregate's own `reference_to` does — a `Card` entity's own `assignee_id`, pointing at a `Team`. Never at another entity: there's no cross-piece addressing anywhere in this language to resolve one against, so this only ever reaches a head.
-
-<!-- TODO: document this word -->
+Points an entity at a real ROOT, the same way an aggregate's own `reference_to` does — a `Card` entity's own `assignee_id`, pointing at a `Team`. Never at another entity: there's no cross-piece addressing anywhere in this language to resolve one against, so this only ever reaches a head. `optional:` mirrors an aggregate's own `reference_to optional:` — the entity may be declared without ever pointing at a real record of that type.
 
 ## command
 

--- a/docs/reference/handler.md
+++ b/docs/reference/handler.md
@@ -31,7 +31,7 @@ separate `across` here, the qualified name carries it.
 `given do ... end`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A dispatch-level precondition on this handler's own `dispatch`es, distinct from the transition guard — the transition and any `remember`s always happen when the event fires in the right `from_state`; `given` only decides whether the dispatches actually fire. `ctx` is a merged Hash of the triggering event's payload plus the saga instance's own remembered fields.
 
 ## remember
 
@@ -39,7 +39,7 @@ separate `across` here, the qualified name carries it.
 `remember`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`remember key: from_event(...)` — writes into the saga instance's own carried memory, for a LATER handler on the same instance to read back via `from_pm`. Fires once per handler firing, before this handler's own dispatches run, so a same-handler `dispatch ..., with: { y: from_pm(:key) }` composes in written order.
 
 ## set
 
@@ -47,7 +47,7 @@ separate `across` here, the qualified name carries it.
 `set`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`set :field, value` — the positional-argument sibling of `remember key: value`, same accumulator, same saga-memory write, just field-then-value instead of a kwarg.
 
 ## from_event
 
@@ -55,7 +55,7 @@ separate `across` here, the qualified name carries it.
 `from_event`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`from_event(field, default:)` — sugar reading a field from the triggering event's own payload, for use inside `with:`/`remember`/`set`. Returns the bare Symbol, resolved at dispatch time.
 
 ## from_iter
 
@@ -63,7 +63,7 @@ separate `across` here, the qualified name carries it.
 `from_iter`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Same shape as `from_event`, sourcing from a `for_each` iteration row instead of the triggering event — one value per row a fanned-out dispatch enumerates.
 
 ## from_pm
 
@@ -71,7 +71,7 @@ separate `across` here, the qualified name carries it.
 `from_pm`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Same shape again, sourcing from the process manager's own persisted state — a field an earlier handler on the same instance wrote with `remember`, rather than something the current event or iteration carries.
 
 ## template
 
@@ -79,5 +79,5 @@ separate `across` here, the qualified name carries it.
 `template`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`template("fmt %s", from_pm(:x, default: "y"))` — string composition inside a `with:` value, substituting resolved fields (`from_event`/`from_pm`/`from_iter`, or literals) into surrounding text via `Kernel#format`.
 

--- a/docs/reference/hecksagon.md
+++ b/docs/reference/hecksagon.md
@@ -37,7 +37,7 @@ Names a `lib/hecksagain/framework/bluebook/` member this domain wants attached �
 `adapter`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Two forms. Bare — `adapter :heki`/`:memory`/`:sqlite` — is a domain-wide default: every aggregate in this bluebook persists there unless it declares its own `persisted_by`, applied last so an aggregate-level bind always wins. Bare with a different kind and options — `adapter :custom_queue, url: "..."` — records a raw, opaque adapter binding, not a bind on any one aggregate. The block form — `adapter "Name" do driving on <kind> "<arg>" do |signal| dispatch "Domain::Aggregate.Command" end end` — declares a DRIVING-side construct: an external clock/file-watch/http-post reaching IN, the inverse of `persisted_by`/`charged_by`'s driven side. Structural support only; the actual scheduler that fires these is a separate concern.
 
 ## gate
 
@@ -45,7 +45,7 @@ Names a `lib/hecksagain/framework/bluebook/` member this domain wants attached �
 `gate`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`gate "Aggregate", :role do allow :Cmd1, :Cmd2, ... end` — a centralized command allowlist. Accepted so the file boots ; not stored or enforced, since each command's own `role` (see the Command context page) already checks the same thing at dispatch time, and this would be a second, easily-stale source of truth for it.
 
 ## success
 
@@ -53,7 +53,7 @@ Names a `lib/hecksagain/framework/bluebook/` member this domain wants attached �
 `success`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Names the command dispatched when an adapter-mediated effect succeeds — `Aggregate.verb("Adapter", on: "Event") do success "Cmd" end`, the canonical Pizzas example's own async-verdict shape. Accepted so the file boots ; no adapter-host delivery mechanism or verdict re-entry wiring exists yet, so nothing actually calls this back.
 
 ## failure
 
@@ -61,7 +61,7 @@ Names a `lib/hecksagain/framework/bluebook/` member this domain wants attached �
 `failure`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+The refusal-side sibling of `success`, naming the command dispatched when the adapter-mediated effect fails. Same structural-only status.
 
 ## port
 

--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -59,7 +59,7 @@ in the same domain as the event that fired it — the ordinary case.
 `description`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A no-op stub — accepted so a policy using it still boots, the value discarded.
 
 ## where
 
@@ -67,7 +67,7 @@ in the same domain as the event that fired it — the ordinary case.
 `where`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A conditional trigger — `where field: value` — gating whether the policy fires on the triggering EVENT's own payload, equality-only against a literal hash. Distinct from an aggregate query's own `where`, which filters stored records rather than one event's fields.
 
 ## for_each
 
@@ -75,7 +75,7 @@ in the same domain as the event that fired it — the ordinary case.
 `for_each`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`for_each from: "Aggregate.query_name", where: { field: from_event(:x) }` — a policy-level fan-out, the same shape `dispatch ..., for_each:` gives a saga handler (see the Handler context page), except every `where:` value resolves against the triggering event's payload only, since a policy has no saga instance to source from.
 
 ## from_event
 
@@ -83,7 +83,7 @@ in the same domain as the event that fired it — the ordinary case.
 `from_event`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`from_event(:field)` — sugar reading a field from the triggering event's own payload, for use inside `where:`/`for_each: where:`. Returns the bare Symbol, resolved at delivery time the same way a `with:` value already is.
 
 ## with
 
@@ -91,7 +91,7 @@ in the same domain as the event that fired it — the ordinary case.
 `with`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`with(key, value)` — a literal extra argument attached to the triggered command's payload, beyond whatever the triggering event's own fields already supply.
 
 ## map
 
@@ -99,7 +99,7 @@ in the same domain as the event that fired it — the ordinary case.
 `map`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`map(**pairs)` — renames or selects an event-payload field for the triggered command's argument, folded into the same literal-argument mechanism `with` uses. Exact select-vs-merge runtime semantics are not yet verified for every shape.
 
 ## condition
 
@@ -107,7 +107,7 @@ in the same domain as the event that fired it — the ordinary case.
 `condition do ... end`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A no-op stub for a comparison/boolean expression over the triggering event's own payload via a block parameter — `condition { |event| event.severity == "critical" }`. Accepted so the file boots ; a policy using it currently fires unconditionally on its `on:` event, not gated as declared, a real and documented gap distinct from the already-real `where` above (`where` is equality-only on a literal hash ; `condition` needs the full comparison grammar wired to a named block parameter, which nothing here does yet).
 
 ## cross_domain
 
@@ -115,5 +115,5 @@ in the same domain as the event that fired it — the ordinary case.
 `cross_domain`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`cross_domain true` — a bare boolean flag marking the policy as crossing a domain boundary conceptually, distinct from the already-real `across "DomainName"` (which names the actual target domain). Accepted and discarded ; there is no domain name here to wire it to.
 

--- a/docs/reference/process_manager.md
+++ b/docs/reference/process_manager.md
@@ -67,7 +67,7 @@ here, or the declaration is refused at load time.
 `description`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A no-op stub — accepted so a process manager using it still boots, the value discarded. Narrative text belonging to the corpus author, not the IR.
 
 ## on
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -57,8 +57,6 @@ aggregate — the `:symbol` a `where` value can resolve from
 
 Names a query parameter as another aggregate's own identity — `Card.Active`'s own `Board`, scoping the result to one board's cards when given. A plain attribute typed as a reference; a query has no root of its own to act on the way a command does, so there's no "acts on itself" case to distinguish here, just a parameter. `optional:` lets the same query run unscoped too — every active card everywhere, when no board is named.
 
-<!-- TODO: document this word -->
-
 ## where
 
 <!-- generated:begin word=where -->
@@ -255,7 +253,7 @@ influence the query plan — the store still picks its own index.
 `count`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+Reduces the where-filtered set to a single scalar — how many rows match, rather than the rows themselves. Riding the same `where` clauses an ordinary query already applies.
 
 ## median
 
@@ -263,7 +261,7 @@ influence the query plan — the store still picks its own index.
 `median`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`median :field` — the same scalar-reduction shape as `count`, one field further: the median value of `field` across the where-filtered set.
 
 ## group_by
 
@@ -271,7 +269,7 @@ influence the query plan — the store still picks its own index.
 `group_by`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+`group_by :field` — a third scalar-reduction shape alongside `count`/`median`, except it doesn't reduce to one scalar: it partitions the where-filtered set by `field`'s value and tallies each partition. The Query-context sibling of the ReadModel-context `group_by`, which nests a whole rootless table instead — see the ReadModel reference page.
 
 ## scope_to
 
@@ -279,5 +277,5 @@ influence the query plan — the store still picks its own index.
 `scope_to`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A no-op stub for caller-identity row authorization — the intent is a `where(actor == :caller)` injected from a reserved kwarg the runtime's own caller context would supply. Accepted and structurally captured ; no runtime learns "who is calling" yet, so nothing is actually scoped.
 

--- a/docs/reference/value_object.md
+++ b/docs/reference/value_object.md
@@ -65,7 +65,7 @@ a command's other checks.
 `rule do ... end` — fills `invariants`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A live alias of `invariant`, not a rename — some corpora write `rule "description" do ... end` for the identical field-scoped check.
 
 ## description
 
@@ -73,5 +73,5 @@ a command's other checks.
 `description`
 <!-- generated:end -->
 
-<!-- TODO: document this word -->
+A no-op stub — accepted so a value object using it still boots, the value discarded. Narrative text the language does not currently hold anywhere.
 


### PR DESCRIPTION
Splits `9cbb1c0` (docs: prose for every new word, and a stale ir.keys example) — item 41 of the [PR-split plan](.pr-split-plan.md). Docs only, one PR, no split.

**Content**: real prose for every new DSL word item 35's grammar registration seeded with a `TODO: document this word` sentinel — across `bluebook.md`/`aggregate.md`/`command.md`/`value_object.md`/`query.md`/`policy.md`/`process_manager.md`/`handler.md`/`hecksagon.md`. `docs/guides/running-a-runtime.md`'s own `ir.keys` doctest — already fixed at item `1855be0-j` when `category` joined it, confirmed unchanged here, matching the plan's own prediction.

**GENUINELY CLOSES** `spec/reference_golden_spec.rb`'s own coverage gate ("lets no live word ship undocumented") — confirmed by full-suite rerun, stable across two runs.

**Verification at this point in the stack**: `bundle exec rspec --no-color` → **1459 examples, 1 failure** (down from 2, stable across two runs).

**The one remaining failure in the whole suite** (`spec/parser_parity_spec.rb`) is an honest, pre-existing, out-of-scope gap: the separate `rust/parser` Rust PARSER binary (not the Rust runtime interpreter `rust_conformance_spec` exercises) does not yet emit the `category`/`redirects_native`/`provenance` IR fields this migration's earlier items (05, `1855be0-j`) added to Ruby's own `Exporter` output — a real, substantial Rust source change to `rust/parser/src/*.rs` with no commit anywhere in this migration's 31-commit range touching it. Not fixed here, not hidden — noted explicitly, same discipline as item 36's own honest `rust_conformance_spec` finding (which item 37 later genuinely closed for the runtime side; this parser-side gap has no equivalent fix available within this migration's scope).
