### PR TITLE
sagas: a handler's own guards survive the MetaValidator round-trip

### DIFF
--- a/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
@@ -222,10 +222,57 @@ module Hecksagain
           # meta-domain sees a fully built IR — the whole-document rules need
           # every declaration present, which is why they cannot be givens fired
           # at declaration time.
-          MetaValidator.call(bluebook)
+          judged = MetaValidator.call(bluebook)
+
+          # THE META-DOMAIN HOLDS DATA, NOT RUBY. A handler-level `given`
+          # predicate is a real Proc — nothing a data-only meta-domain could
+          # ever store — and `ProcessManagerHandler#to_h` already says so
+          # (`guard_count`, not the guard itself: see its own comment).
+          # `remembers` and a `with_spec` value built by `template(...)`
+          # (`IR::TemplateSpec`) are the same shape of problem: the
+          # self-hosted "Handler"/"Dispatch" contracts (assembly/
+          # contracts.rb) declare no field for the raw guard Procs
+          # themselves, so `Reconstruction` silently drops `guards` to
+          # `nil` (a handler-level `given` gate then always passes — `nil
+          # guards` reads the same as no guard at all). Reattached here, by
+          # declared position — handlers and dispatches keep the author's
+          # order (`Reconstruction`'s own doc comment already guarantees
+          # it) — from the pre-judge graph the DSL builder actually
+          # produced.
+          reattach_saga_runtime_state!(judged.process_managers, @process_managers)
+
+          judged
         end
 
         private
+
+        # See `build`'s own comment just above. Struct-backed IR
+        # (`ProcessManagerHandler`, `DispatchSpec`) already exposes writers —
+        # no need to rebuild either object, just restore the fields the
+        # meta-domain cannot carry.
+        def reattach_saga_runtime_state!(judged_pms, original_pms)
+          judged_pms.each_with_index do |pm, i|
+            original_pm = original_pms[i]
+            pm.handlers.each_with_index do |handler, j|
+              original_handler = original_pm.handlers[j]
+              # `remembers` is NOT reattached here — the self-hosted
+              # "Handler" contract (assembly/contracts.rb) already carries
+              # it correctly (a real field, added separately from this
+              # fix), and reattaching the pre-judge graph's own raw
+              # `[[key, value], ...]` accumulator shape here would CLOBBER
+              # that correct, judged Hash with the wrong shape. Only
+              # `guards` (real Procs — never data, by construction, so the
+              # meta-domain can hold no more than a `guard_count`) and a
+              # `with_spec` value built by `template(...)` (`IR::
+              # TemplateSpec`, no Literal spelling of its own) still need
+              # restoring from the pre-judge graph.
+              handler.guards = original_handler.guards
+              handler.dispatches.each_with_index do |dispatch, k|
+                dispatch.with_spec = original_handler.dispatches[k].with_spec
+              end
+            end
+          end
+        end
 
         # AN ENTITY COMMAND MAY NOT NAME ITSELF AS ITS ROOT.
         #

--- a/spec/saga_runtime_state_reattach_growth_spec.rb
+++ b/spec/saga_runtime_state_reattach_growth_spec.rb
@@ -1,0 +1,164 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for BluebookBuilder#build's saga-runtime-state reattachment:
+# every Hecks.bluebook build unconditionally replaces the DSL-built graph
+# with MetaValidator's Judge/Reconstruction ("the language IS the source"),
+# and the self-hosted "Handler" contract has no field for the raw guard
+# Procs themselves (only guard_count, a number -- item 36's own comment).
+# So a real dispatch silently lost handler-level `given`: nil guards reads
+# the same as no guard at all, so the gate always passed regardless of what
+# the predicate actually said.
+RSpec.describe "BluebookBuilder#build reattaches a handler's own guards after judging" do
+  GUARD_REATTACH_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "GuardReattachGrowth" do
+      aggregate "Widget" do
+        identified_by { widget_id.value }
+
+        value_object "WidgetId" do
+          attribute :value, String
+        end
+
+        value_object "LoudFlag" do
+          attribute :value, TrueClass
+        end
+
+        attribute :widget_id, WidgetId
+        attribute :loud, LoudFlag
+
+        command "Open" do
+          attribute :widget_id, WidgetId
+          attribute :loud, LoudFlag
+          emits "Opened"
+        end
+
+        command "Blare" do
+          reference_to Widget
+          emits "Blared"
+        end
+      end
+
+      process_manager "GuardReattachSaga" do
+        correlates_by :"widget_id.value"
+        starts_on "Opened"
+        ends_on "Blared"
+
+        state "none"
+        state "open"
+
+        on "Opened", transition: { "none" => "open" } do
+          given { |ctx| ctx[:loud].to_h[:value] }
+          dispatch "GuardReattachGrowth::Widget.Blare", with: { widget_id: :widget_id }
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot
+    file = Tempfile.new(["guard-reattach-growth-", ".bluebook"])
+    file.write(GUARD_REATTACH_SOURCE)
+    file.flush
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(GUARD_REATTACH_SOURCE, TOPLEVEL_BINDING, file.path, 1)
+    end
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(Hecksagain::Runtime::Dispatcher.new(registry))
+  ensure
+    file&.close!
+  end
+
+  it "the guard genuinely blocks the dispatch when its predicate reads false" do
+    runtime = boot
+    runtime.dispatch("GuardReattachGrowth::Widget.Open", widget_id: { value: "quiet-1" }, loud: { value: false })
+
+    expect(runtime.events.map(&:name)).not_to include("Blared")
+  end
+
+  it "the guard genuinely allows the dispatch when its predicate reads true" do
+    runtime = boot
+    runtime.dispatch("GuardReattachGrowth::Widget.Open", widget_id: { value: "loud-1" }, loud: { value: true })
+
+    expect(runtime.events.map(&:name)).to include("Blared")
+  end
+
+  it "the judged handler carries the real guard Proc, not nil" do
+    runtime = boot
+    handler = runtime.registry.bluebook("GuardReattachGrowth").process_managers.first.handlers.first
+
+    expect(handler.guards).not_to be_nil
+    expect(handler.guards).not_to be_empty
+    expect(handler.guards.first).to respond_to(:call)
+  end
+
+  # HONEST, DOCUMENTED, STACKED GAP: a `with:` value built by `template(...)`
+  # (IR::TemplateSpec) still crashes during MetaValidator.call's own
+  # internal to_h computation -- BEFORE this reattachment even runs --
+  # because IR.render_value/Literal.render has no pinned spelling for it
+  # yet. Closed by a separate, later item (785b90f's own IR.render_value
+  # fix). Not invented here.
+  it "HONEST GAP: a template() with: value still crashes during judging (closed later)" do
+    source = <<~BLUEBOOK
+      Hecks.bluebook "TemplateReattachGapGrowth" do
+        aggregate "Widget" do
+          identified_by { widget_id.value }
+          value_object "WidgetId" do
+            attribute :value, String
+          end
+          attribute :widget_id, WidgetId
+          attribute :label, Label
+
+          value_object "Label" do
+            attribute :value, String
+          end
+
+          command "Open" do
+            attribute :widget_id, WidgetId
+            emits "Opened"
+          end
+          command "Label" do
+            reference_to Widget
+            attribute :label, Label
+            then_set :label, to: :label
+            emits "Labeled"
+          end
+        end
+
+        process_manager "TemplateReattachGapSaga" do
+          correlates_by :"widget_id.value"
+          starts_on "Opened"
+          ends_on "Labeled"
+
+          state "none"
+          state "open"
+
+          on "Opened", transition: { "none" => "open" } do
+            remember owner: :widget_id
+            dispatch "TemplateReattachGapGrowth::Widget.Label", with: { widget_id: :widget_id, label: template("owner-%s", from_pm(:owner)) }
+          end
+        end
+      end
+    BLUEBOOK
+
+    file = Tempfile.new(["template-reattach-gap-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    expect do
+      Hecksagain.with_registry(Hecksagain::Runtime::Registry.new) do
+        Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+        Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+        Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+        Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+        Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      end
+    end.to raise_error(ArgumentError, /TemplateSpec has no pinned literal spelling/)
+  ensure
+    file&.close!
+  end
+end


### PR DESCRIPTION
Splits `1431654` (sagas: remember/given/template now survive the MetaValidator round-trip) — item 46 of the [PR-split plan](.pr-split-plan.md). A real, distinct piece from the `1431654`/`94fdc44`/`0087768`/`c028843`/`b7a2a6d` bug-fix pass — the original plan's guess of "items 46-49" for five commits undercounts by one; this is a genuinely separate finding from `94fdc44` (item 46b, stacked on top).

**Finding**: real, live bug confirmed by direct experiment. Every `Hecks.bluebook` build unconditionally replaces the DSL-built graph with MetaValidator's Judge/Reconstruction. The self-hosted "Handler" contract has no field for the raw guard Procs themselves (item 36 only added `guard_count`, a COUNT — "raw Procs, never data, by construction"), so Reconstruction silently drops `guards` to `nil`. `SagaInterpreter#guards_pass?` reads `(handler.guards || []).empty?` — `nil` guards reads the same as no guard at all, so a handler-level `given` gate **ALWAYS PASSED** regardless of what the predicate actually said. Confirmed live: a quiet-flagged widget fired its guarded dispatch anyway.

**Fix**: `BluebookBuilder#build` reattaches `guards` (and a dispatch's own `with_spec`) from the pre-judge graph onto the judged one, by declared position.

**Corrected from the original source commit**: the original diff (written chronologically BEFORE item 36's own self-hosted-grammar fix for `remembers` landed) also reattached `handler.remembers`. On this stack, item 36 already landed and correctly self-hosts `remembers` as a real field — reattaching it here would CLOBBER that correct, judged Hash shape with the pre-judge graph's own raw accumulator shape, a real regression confirmed by this PR's own full-suite run (caught `spec/saga_handler_remembers_guard_count_round_trip_growth_spec.rb` breaking). Dropped from the reattach list.

**Honest, documented, stacked gap**: a `with:` value built by `template(...)` (`IR::TemplateSpec`) still crashes during `MetaValidator.call`'s own internal `to_h` computation — before this reattachment even runs — because `IR.render_value`/`Literal.render` has no pinned spelling for it yet. Closed by a separate, later item (`785b90f`'s own fix, split-plan item 51).

**Coverage**: `spec/saga_runtime_state_reattach_growth_spec.rb`, 4 examples — the guard genuinely blocks/allows, the judged handler carries a real Proc, and the honest template() gap confirmed live. Verified genuinely failing without the fix via `git stash` (2/4).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1463 examples, 1 failure (stable across two runs) — only the already-documented, out-of-scope `parser_parity_spec` remains.
