### PR TITLE
runtime: Ports::Query::InMemory none_in_state now works on aggregate-level Memory queries

### DIFF
--- a/lib/hecksagain/adapters/driven/memory.rb
+++ b/lib/hecksagain/adapters/driven/memory.rb
@@ -23,7 +23,7 @@ module Hecksagain
       end
 
       def query(specification, args = {}, context: {})
-        Ports::Query::InMemory.execute(all, specification, args)
+        Ports::Query::InMemory.execute(all, specification, args, registry: context[:registry])
       end
 
       def append(entry)

--- a/lib/hecksagain/ports/query/in_memory.rb
+++ b/lib/hecksagain/ports/query/in_memory.rb
@@ -10,9 +10,9 @@ module Hecksagain
 
         module_function
 
-        def execute(records, declared, args = {})
+        def execute(records, declared, args = {}, registry: nil)
           matched = records.select do |record|
-            declared.wheres.all? { |clause| holds?(clause, comparable(FieldPath.dig(record, clause.field)), args) }
+            declared.wheres.all? { |clause| holds?(clause, comparable(FieldPath.dig(record, clause.field)), args, registry: registry) }
           end
           field   = declared.order_by&.field
           matched = Ordering.apply(matched, declared.order_by, declared.null_semantics,
@@ -23,10 +23,18 @@ module Hecksagain
         end
 
         # The same 8 comparators QuerySpecification::Common::COMPARATORS
-        # declares. This is the path that actually runs for a memory- or
-        # heki-backed aggregate query ; QueryInterpreter#holds? only runs for
-        # entity/sub-list queries, or when no adapter implements :query at all.
-        def holds?(clause, held, args)
+        # declares, plus `none_in_state` (a 9th, vendored addition — see
+        # Runtime::QueryInterpreter#none_in_state?'s own comment). This is
+        # the path that actually runs for a memory- or heki-backed
+        # aggregate query ; QueryInterpreter#holds? only runs for
+        # entity/sub-list queries, or when no adapter implements :query at
+        # all. `none_in_state` had ONLY ever been added to that other
+        # copy of this same case statement — an ordinary aggregate-level
+        # Memory query's own `none_in_state` where-clause fell to the
+        # `else` branch below (`held == want`, an id string against
+        # "Aggregate:state", never equal) and silently excluded every
+        # row, every time.
+        def holds?(clause, held, args, registry: nil)
           want = comparable(resolve(clause.value, args))
 
           case clause.op.to_s
@@ -38,8 +46,40 @@ module Hecksagain
           when "gte"      then ordered?(held, want) && held >= want
           when "in"       then members(want).include?(held.to_s)
           when "contains" then contains?(held, want)
+          when "none_in_state" then none_in_state?(held, want, registry)
           else                 held == want
           end
+        end
+
+        # `want` is "Aggregate:state" (a literal), `held` is this row's
+        # own field value (already unwrapped by `comparable`) — the exact
+        # same reading as `Runtime::QueryInterpreter#none_in_state?`,
+        # mirrored here because this module has no `@registry` of its own
+        # to close over (a stateless, `module_function` comparator table)
+        # and takes one as an explicit argument instead. No registry — no
+        # way to look the target up — reads as "not excluded", the same
+        # graceful default `registry.repository(...).find` missing a
+        # record already falls back to below.
+        def none_in_state?(held, want, registry)
+          return true unless registry
+
+          aggregate_name, state = want.to_s.split(":", 2)
+          target = find_aggregate_by_name(registry, aggregate_name)
+          return true unless target
+
+          target_domain, target_ir = target
+          record = registry.repository(target_domain, target_ir).find(held)
+          return true unless record
+
+          comparable(record.state[:state]) != state
+        end
+
+        def find_aggregate_by_name(registry, name)
+          registry.bluebooks.each do |domain, bluebook|
+            aggregate = bluebook.aggregates.find { |a| a.hecks_name == name }
+            return [domain, aggregate] if aggregate
+          end
+          nil
         end
 
         def ordered?(held, want) = held.is_a?(Numeric) && want.is_a?(Numeric)

--- a/lib/hecksagain/runtime/query_interpreter.rb
+++ b/lib/hecksagain/runtime/query_interpreter.rb
@@ -84,7 +84,7 @@ module Hecksagain
                        .sort_by { |row| [-row[:count], row[field].to_s] }
         end
 
-        if (native = Ports::Query.execute(repository, declared, args, context: { domain: domain, aggregate: aggregate }))
+        if (native = Ports::Query.execute(repository, declared, args, context: { domain: domain, aggregate: aggregate, registry: @registry }))
           records = native
           # `record.state.merge(id: record.id)` — id LAST, not first. See
           # Instance#to_h's own comment: an aggregate free to declare its

--- a/spec/query_none_in_state_aggregate_level_growth_spec.rb
+++ b/spec/query_none_in_state_aggregate_level_growth_spec.rb
@@ -1,0 +1,116 @@
+require "spec_helper"
+require "tempfile"
+
+# Real dispatch coverage for the aggregate-level none_in_state gap:
+# Runtime::QueryInterpreter#holds? (the entity/sub-list query path, and
+# the fallback when no adapter implements :query) already had
+# none_in_state -- Ports::Query::InMemory#holds? ("the path that
+# actually runs for a memory- or heki-backed aggregate query" per its
+# own existing comment) never had a matching case, so an ORDINARY
+# aggregate-level none_in_state where-clause against a Memory-backed
+# aggregate silently fell to the else branch (held == want, an id
+# string against "Aggregate:state", never equal) and excluded every
+# row, every time. Distinct from spec/query_none_in_state_growth_spec.rb,
+# which exercises the entity-level path this gap does not touch.
+RSpec.describe "none_in_state on an ordinary AGGREGATE-level Memory query" do
+  def boot(source, hecksagon_name, &binds)
+    file = Tempfile.new(["anti-join-aggregate-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    previous = ENV["HECKSAGAIN_META_VALIDATION"]
+    ENV["HECKSAGAIN_META_VALIDATION"] = "off"
+
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      Hecks.hecksagon(hecksagon_name, &binds)
+    end
+
+    registry.verify!
+    Hecksagain::Runtime::Loader.bind_runtime(
+      Hecksagain::Runtime::Dispatcher.new(registry)
+    )
+  ensure
+    ENV["HECKSAGAIN_META_VALIDATION"] = previous
+    file&.close!
+  end
+
+  AGGREGATE_ANTI_JOIN_SOURCE = <<~BLUEBOOK
+    Hecks.bluebook "AggregateAntiJoinGrowth" do
+      aggregate "Claim" do
+        identified_by { id.value }
+
+        value_object "ClaimId" do
+          attribute :value, String
+        end
+
+        value_object "ClaimState" do
+          attribute :value, String, default: "held"
+        end
+
+        attribute :id,    ClaimId
+        attribute :state, ClaimState
+
+        command "File" do
+          attribute :id, ClaimId
+          emits "Filed"
+        end
+
+        command "Release" do
+          reference_to Claim
+          then_set :state, to: { value: "released" }
+        end
+      end
+
+      aggregate "Board" do
+        identified_by { id.value }
+
+        value_object "BoardId" do
+          attribute :value, String
+        end
+
+        attribute :id,       BoardId
+        attribute :claim_id, String
+
+        command "Open" do
+          attribute :id,       BoardId
+          attribute :claim_id, String
+          emits "Opened"
+        end
+
+        query "Unclaimed" do
+          where claim_id: { none_in_state: "Claim:held" }
+        end
+      end
+    end
+  BLUEBOOK
+
+  def boot_aggregate_anti_join
+    boot(AGGREGATE_ANTI_JOIN_SOURCE, "AggregateAntiJoinGrowth") do
+      ::AggregateAntiJoinGrowth::Claim.persisted_by("Memory")
+      ::AggregateAntiJoinGrowth::Board.persisted_by("Memory")
+    end
+  end
+
+  it "excludes an aggregate-level row whose claim IS in the named state, and keeps the rest" do
+    runtime = boot_aggregate_anti_join
+    runtime.dispatch("AggregateAntiJoinGrowth::Claim.File", id: { value: "c1" }) # stays "held"
+    runtime.dispatch("AggregateAntiJoinGrowth::Claim.File", id: { value: "c2" })
+    runtime.dispatch("AggregateAntiJoinGrowth::Claim.Release", id: "c2")         # no longer "held"
+
+    runtime.dispatch("AggregateAntiJoinGrowth::Board.Open", id: { value: "b1" }, claim_id: "c1")
+    runtime.dispatch("AggregateAntiJoinGrowth::Board.Open", id: { value: "b2" }, claim_id: "c2")
+    # A claim that was never filed at all — "no record in that state" reads
+    # the same as "a record, but not in that state".
+    runtime.dispatch("AggregateAntiJoinGrowth::Board.Open", id: { value: "b3" }, claim_id: "nonexistent")
+
+    rows = runtime.query("AggregateAntiJoinGrowth::Board.Unclaimed")
+
+    expect(rows.map { |row| row[:id] }).to contain_exactly("b2", "b3")
+  end
+end


### PR DESCRIPTION
Splits `0087768` (Ports::Query::InMemory: none_in_state now works on aggregate-level Memory queries) — item 47 of the [PR-split plan](.pr-split-plan.md).

**Finding**: `Runtime::QueryInterpreter#holds?` (the entity/sub-list query path, and the fallback when no adapter implements `:query`) already had `none_in_state`. `Ports::Query::InMemory#holds?` — "the path that actually runs for a memory- or heki-backed aggregate query" per its own existing comment — never had a matching case, so an ordinary aggregate-level `none_in_state` where-clause against a Memory-backed aggregate silently fell to the `else` branch (`held == want`, an id string against `"Aggregate:state"`, never equal) and excluded every row, every time.

**Fix**: mirrors `Runtime::QueryInterpreter#none_in_state?` exactly, with one difference forced by this module's own shape: `Ports::Query::InMemory` is a stateless `module_function` table with no `@registry` of its own to close over, so it takes one as an explicit optional argument instead, threaded from `QueryInterpreter#call`'s own `context:` hash through `Adapters::Memory#query`.

**Coverage**: `spec/query_none_in_state_aggregate_level_growth_spec.rb`, 1 example (distinct from `spec/query_none_in_state_growth_spec.rb`, item 07's own coverage, which exercises the entity-level path this gap does not touch). Verified genuinely failing without the fix via `git stash` (every row silently excluded, `[]` where `["b2", "b3"]` was expected).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1464 examples, 1 failure (stable) — no regressions; only the already-documented, out-of-scope `parser_parity_spec` remains.
