### PR TITLE
runtime: PolicyInterpreter#deliver_for_each resolves the aggregate it queries, fixes record scoping

### DIFF
--- a/lib/hecksagain/runtime/policy_interpreter.rb
+++ b/lib/hecksagain/runtime/policy_interpreter.rb
@@ -1,6 +1,7 @@
 require_relative "../naming"
 require_relative "errors"
 require_relative "query_interpreter"
+require_relative "refusal_wording"
 
 
 module Hecksagain
@@ -57,10 +58,19 @@ module Hecksagain
       end
 
       def deliver(policy, event, domain)
-        return deliver_for_each(policy, event, domain) if policy.for_each
-
+        # `record` ASSIGNED BEFORE THE for_each BRANCH, not after — both
+        # rescue clauses below call `.merge` on it, and a `return` early
+        # (the for_each fan-out has no single record of its own; it
+        # rescues its OWN failures per-row, below) used to leave `record`
+        # unassigned, so a genuine defect inside `deliver_for_each` was
+        # caught here only to raise a SECOND, different `NoMethodError`
+        # (`undefined method 'merge' for nil`) trying to record the
+        # first one. Computing it unconditionally, first, means this
+        # method's own defect handling can never fail that second way.
         target = "#{policy.target_domain || domain}::#{policy.trigger_command}"
         record = { policy: policy.name, on: event.name, trigger: target }
+
+        return deliver_for_each(policy, event, domain) if policy.for_each
 
         if @door.reaction_depth_reached?
           return record.merge(delivered: false,
@@ -125,13 +135,20 @@ module Hecksagain
       def deliver_for_each(policy, event, domain)
         spec = policy.for_each
         aggregate_name, query_name = spec[:from].split(".", 2)
+        # THE SAME target_domain-OR-domain CONVENTION `trigger` USES,
+        # applied here too — a for_each source and its trigger are the
+        # same saga step (PolicyBuilder#for_each's own comment), so the
+        # query resolves against whichever domain the trigger will fire
+        # into, not unconditionally the event's own domain.
+        source_domain = policy.target_domain || domain
+        aggregate = resolve_for_each_aggregate(source_domain, aggregate_name, spec[:from])
         payload = event.payload.transform_keys(&:to_sym)
         resolved_where = (spec[:where] || {}).transform_values do |v|
           v.is_a?(Symbol) ? payload[v] : v
         end
 
-        rows = QueryInterpreter.new(@registry).call(domain, aggregate_name, query_name, resolved_where)
-        target = "#{policy.target_domain || domain}::#{policy.trigger_command}"
+        rows = QueryInterpreter.new(@registry).call(source_domain, aggregate, query_name, resolved_where)
+        target = "#{source_domain}::#{policy.trigger_command}"
         literals = (policy.with_literals || {}).transform_keys(&:to_sym)
 
         Array(rows).map do |row|
@@ -148,6 +165,23 @@ module Hecksagain
             record.merge(delivered: false, reason: error.message)
           end
         end
+      end
+
+      # THE SAME RESOLUTION `Dispatcher#resolve_aggregate` performs — a
+      # bare aggregate NAME split out of `for_each from:` is not what
+      # `QueryInterpreter#call` needs: `declared_query` calls `.query` on
+      # whatever it is handed, and a String has no such method. Mirrored
+      # here rather than reused (that method is private on Dispatcher, and
+      # this interpreter only ever sees it as `@door`) — an UnknownVerb
+      # refusal, the same class `resolve_aggregate` raises, so a for_each
+      # naming a domain or aggregate that is not loaded is recorded as an
+      # undelivered reaction, not a defect (see DOMAIN_REFUSALS).
+      def resolve_for_each_aggregate(domain, aggregate_name, verb)
+        bluebook = @registry.bluebook(domain) ||
+                   raise(UnknownVerb, RefusalWording.render("UnknownVerb", "no_domain", domain: domain.inspect, verb: verb))
+        bluebook.aggregate(aggregate_name) ||
+          raise(UnknownVerb, RefusalWording.render("UnknownVerb", "no_aggregate",
+                                                    domain: domain, aggregate: aggregate_name.inspect))
       end
     end
   end

--- a/spec/policy_for_each_growth_spec.rb
+++ b/spec/policy_for_each_growth_spec.rb
@@ -10,23 +10,21 @@ require "tempfile"
 # the shape `PolicyInterpreter#deliver_for_each` reads, independent of
 # whether a real dispatch can reach that shape at all.
 #
-# A REAL dispatch finds two further, separate, genuine runtime gaps,
-# both fixed by a later-landing item in this split:
+# GAPS CLOSED (item 48, `c028843`): a real dispatch used to find two
+# further, separate, genuine runtime gaps.
 # `PolicyInterpreter#deliver_for_each` hands `QueryInterpreter#call` the
 # bare aggregate NAME it split out of `from:`, never resolved to the
 # aggregate object `#call` needs (`Dispatcher#resolve_aggregate` always
-# does this resolution first for an ordinary query) -- that alone raises
+# does this resolution first for an ordinary query) -- that alone raised
 # a plain `NoMethodError: undefined method 'query' for a String`. But
-# `deliver`'s own `return deliver_for_each(...) if policy.for_each` runs
+# `deliver`'s own `return deliver_for_each(...) if policy.for_each` ran
 # BEFORE `record` (the reaction-log entry both of `deliver`'s own rescue
-# clauses call `.merge` on) is assigned, so the SAME method's own defect
-# handling then raises a SECOND, different `NoMethodError: undefined
-# method 'merge' for nil` trying to record the first one -- the one this
-# example actually observes and pins, since Ruby's own exception-in-
-# rescue replaces the original. Pinned here as the current, real
-# behaviour -- the later fix should turn this red, which is the point:
-# it is the signal to replace this example with the positive one (one
-# dispatch per matching row) this construct is actually meant to prove.
+# clauses call `.merge` on) was assigned, so the SAME method's own defect
+# handling then raised a SECOND, different `NoMethodError: undefined
+# method 'merge' for nil` trying to record the first one. Both fixed at
+# the root -- the examples below now prove the positive shape (one
+# dispatch per matching row) this construct is actually meant to prove,
+# plus the honest undelivered-reaction case for an unloaded target.
 RSpec.describe "a policy's own for_each fan-out" do
   def boot(source, hecksagon_name, &binds)
     file = Tempfile.new(["policy-for-each-growth-", ".bluebook"])
@@ -118,14 +116,39 @@ RSpec.describe "a policy's own for_each fan-out" do
     end
   BLUEBOOK
 
-  it "currently crashes on dispatch -- deliver_for_each never resolves the aggregate it queries" do
+  # GAP CLOSED (item 48, `c028843`): a real dispatch now fires one trigger
+  # per matching row, exactly the shape `for_each` is meant to prove --
+  # `deliver_for_each` resolves the aggregate it queries and `deliver`
+  # itself computes `record` before branching to it.
+  it "fires the triggered command once per matching row, real dispatch end to end" do
     runtime = boot(FOR_EACH_SOURCE, "FanoutGrowth") do
       ::FanoutGrowth::GrowthBoard.persisted_by("Memory")
       ::FanoutGrowth::GrowthTicket.persisted_by("Memory")
     end
     runtime.dispatch("FanoutGrowth::GrowthTicket.Create", id: { value: "t1" }, board_id: "b1")
+    runtime.dispatch("FanoutGrowth::GrowthTicket.Create", id: { value: "t2" }, board_id: "b1")
+    # a different board's own ticket must NOT be pinged
+    runtime.dispatch("FanoutGrowth::GrowthTicket.Create", id: { value: "t3" }, board_id: "b2")
 
-    expect { runtime.dispatch("FanoutGrowth::GrowthBoard.Open", id: { value: "b1" }) }
-      .to raise_error(NoMethodError, /undefined method [`']merge['`]? for nil/)
+    runtime.dispatch("FanoutGrowth::GrowthBoard.Open", id: { value: "b1" })
+
+    statuses = %w[t1 t2 t3].to_h do |id|
+      status = runtime.registry.repository("FanoutGrowth", runtime.registry.bluebook("FanoutGrowth").aggregate("GrowthTicket")).find(id).state[:status]
+      [id, status.respond_to?(:to_h) ? status.to_h[:value] : status]
+    end
+    expect(statuses).to eq("t1" => "pinged", "t2" => "pinged", "t3" => "open")
+  end
+
+  it "an unloaded for_each aggregate is recorded as an undelivered reaction, not a crash" do
+    source = FOR_EACH_SOURCE.sub('for_each from: "GrowthTicket.ForBoard"', 'for_each from: "GhostAggregate.ForBoard"')
+    runtime = boot(source, "FanoutGrowth") do
+      ::FanoutGrowth::GrowthBoard.persisted_by("Memory")
+      ::FanoutGrowth::GrowthTicket.persisted_by("Memory")
+    end
+
+    expect { runtime.dispatch("FanoutGrowth::GrowthBoard.Open", id: { value: "b1" }) }.not_to raise_error
+
+    entry = runtime.registry.reaction_log.find { |row| row[:policy] == "PingGrowthTicketsOnOpen" }
+    expect(entry[:delivered]).to be(false)
   end
 end


### PR DESCRIPTION
Splits `c028843` (PolicyInterpreter#deliver_for_each: resolve the aggregate it queries, fix record scoping) — item 48 of the [PR-split plan](.pr-split-plan.md).

**Two real bugs**, confirmed by a real dispatch before this fix (`spec/policy_for_each_growth_spec.rb`'s own for_each example pinned both as current, honest, documented behavior since item 09):

**(a)** `deliver_for_each` split `for_each from:` into an aggregate NAME and handed that bare String straight to `QueryInterpreter#call`, which requires a resolved aggregate OBJECT — `declared_query` calls `.query` on whatever it is given, and a String has no such method. The resolution step `Dispatcher#query` always performs first was simply missing here. Mirrored as `resolve_for_each_aggregate`, raising the same `UnknownVerb` refusal on a missing domain or aggregate that `resolve_aggregate` does, so a `for_each` naming something not loaded is recorded as an undelivered reaction rather than crashing. Also resolves the query against `policy.target_domain || domain`, not unconditionally the triggering event's own domain — the same convention `trigger` already uses.

**(b)** That alone raised a plain `NoMethodError` ("undefined method 'query' for an instance of String") — but `deliver`'s own `return deliver_for_each(...) if policy.for_each` ran BEFORE `record` (the reaction-log entry both of `deliver`'s rescue clauses call `.merge` on) was assigned, so the SAME method's own defect-recording rescue then raised a SECOND, different `NoMethodError` ("undefined method 'merge' for nil"). Fixed by computing `target`/`record` unconditionally, before the `for_each` branch.

**GENUINELY CLOSES** the exact crash `spec/policy_for_each_growth_spec.rb` (item 09) pinned as a known, honest gap — rewritten here to prove the real, positive fan-out (one dispatch per matching row) plus the honest undelivered-reaction case for an unloaded target, replacing the crash-pinning example the gap's own comment predicted would need replacing once this fix landed.

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1465 examples, 1 failure (stable) — no regressions; only the already-documented, out-of-scope `parser_parity_spec` remains. Verified genuinely failing without the fix via `git stash` (2/3 examples, the exact two original crashes).
