### PR TITLE
self-hosted grammar: Query's count/median/group_by and Policy's where/with/for_each round-trip through the Judge

### DIFF
--- a/examples/banking/bluebook/banking.bluebook
+++ b/examples/banking/bluebook/banking.bluebook
@@ -1431,6 +1431,93 @@ Hecks.bluebook "Banking", version: "v1" do
     across  "Notifications"
   end
 
+  # THE JUDGED CORPUS'S OWN EXERCISE OF A POLICY'S `where`/`with`/
+  # `for_each` (docs/hecks-migration-findings.md findings #11/#12) —
+  # same reason `Command.Freeze`'s own comment gives for
+  # `redirects_native`: Banking is the one flagship domain
+  # `spec/judge_coverage_spec.rb` reads to decide whether the judge
+  # ever OFFERS a self-hosted verb, so a construct exercised only in a
+  # fixture (reflex.bluebook) is a verb the judge never offers there.
+  # A standing note on a customer, escalated when its own severity
+  # says so (`where`, `with`) or swept zone-wide at once (`for_each`).
+  # Self-contained — nothing else in this chapter dispatches into it —
+  # so it changes nothing about how any existing aggregate behaves.
+  aggregate "WatchlistEntry" do
+    description "One name on a compliance watchlist, escalated individually or swept zone-wide at once."
+
+    identified_by { id.value }
+
+    value_object "EntryId" do
+      attribute :value, String
+    end
+
+    attribute :id,       EntryId
+    attribute :zone,     String
+    attribute :severity, String, default: "normal"
+    attribute :status,   String, default: "clear"
+
+    command "Add" do
+      attribute :id,       EntryId
+      attribute :zone,     String
+      attribute :severity, String
+
+      emits "EntryAdded"
+    end
+
+    command "Flag" do
+      role "Compliance officer"
+      goal "Mark one watchlist entry flagged"
+
+      reference_to WatchlistEntry
+      attribute :note,       String, optional: true
+      attribute :flagged_by, String, optional: true
+
+      then_set :status, to: "flagged"
+
+      emits "EntryFlagged"
+    end
+
+    query "InZone" do
+      attribute :zone, String
+      where zone: :zone
+    end
+
+    policy "EscalateOnCriticalEntry" do
+      on      "EntryAdded"
+      where   severity: "critical"
+      with    "note", "auto-flagged — critical on arrival"
+      with    "flagged_by", "policy"
+      trigger "WatchlistEntry.Flag"
+    end
+
+    policy "FlagZoneOnSweep" do
+      on       "SweepStarted"
+      for_each from: "WatchlistEntry.InZone", where: { zone: from_event(:zone) }
+      trigger  "WatchlistEntry.Flag"
+    end
+  end
+
+  # THE for_each TRIGGER FOR FlagZoneOnSweep ABOVE — its own aggregate
+  # because a sweep names a ZONE, not an entry, and has no watchlist
+  # identity of its own to reference.
+  aggregate "ComplianceSweep" do
+    description "One zone-wide compliance sweep, flagging every watchlist entry the zone currently holds."
+
+    identified_by { zone.value }
+
+    value_object "SweepZone" do
+      attribute :value, String
+    end
+
+    attribute :zone, SweepZone
+
+    command "Start" do
+      attribute :zone, SweepZone
+
+      emits "SweepStarted"
+    end
+  end
+
   process_manager "Settlement" do
     # THE FIELD, NAMED — Transfer.Request declares `attribute :reference,
     # TransferReference`, which is also what Transfer's own `identified_by

--- a/examples/banking/bluebook/banking.hecksagon
+++ b/examples/banking/bluebook/banking.hecksagon
@@ -22,6 +22,10 @@ Hecks.hecksagon "Banking" do
   Banking::OnboardingCase.projected_by("SqliteProjection")
   Banking::Statement.persisted_by("Heki")
   Banking::Statement.projected_by("SqliteProjection")
+  Banking::WatchlistEntry.persisted_by("Heki")
+  Banking::WatchlistEntry.projected_by("SqliteProjection")
+  Banking::ComplianceSweep.persisted_by("Heki")
+  Banking::ComplianceSweep.projected_by("SqliteProjection")
 end
 
 # A FRAMEWORK MEMBER BRINGS ITS OWN SHAPE, NOT ITS OWN PERSISTENCE —

--- a/lib/hecksagain/bluebook/assembly/contracts.rb
+++ b/lib/hecksagain/bluebook/assembly/contracts.rb
@@ -137,6 +137,22 @@ module Hecksagain
             wheres:          [:wheres,          [:each, :where_clause]],
             order_by:        [:order_by,        :order_by],
             limit:           [:limit,           :limit],
+            # Vendored addition, not (yet) upstream hecksagain (migration
+            # plan task 8): `count`/`median_field`/`group_by_field` never
+            # reached this table, so a query carrying any of the three
+            # survived the DSL parse and vanished the moment the same
+            # bluebook went through `MetaValidator.call` (every ordinary
+            # `Hecks.bluebook` load). Same shape as `redirects_native`'s
+            # own gap on Command — the self-hosted grammar's own "Query"
+            # aggregate needed the matching fields too (see
+            # behavior.bluebook). `count` rides as a real Ruby boolean
+            # (`:flag`, decoded from the language's stored text by
+            # `count_flag` below — see its own comment) ; `median_field`/
+            # `group_by_field` are Symbols, the same `:identity` reading
+            # `correlates_by` already uses.
+            count:           [:count,           :flag],
+            median_field:    [:median_field,    :identity],
+            group_by_field:  [:group_by_field,  :identity],
             # Held by the language as an OPEN MAP, so every one of these reads the
             # same way and a ninth option needs no new field on either side.
             offset:          [:offset,          [:option, :offset]],
@@ -150,7 +166,8 @@ module Hecksagain
           },
           rows: { wheres: :where_rows, options: :option_rows },
           reads: { attributes: [:each, :shape_field], wheres: [:each, :where_clause],
-                  order_by: [:call, :order_by], limit: [:call, :limit] },
+                  order_by: [:call, :order_by], limit: [:call, :limit],
+                  count: [:call, :count_flag] },
           derived: {
             position: :walk,
             order_field: [:folded, :order_by, :field],
@@ -193,9 +210,51 @@ module Hecksagain
             aggregate:       [:aggregate,       :plain],
             on_event:        [:on_event,        :plain],
             trigger_command: [:trigger_command, :plain],
-            target_domain:   [:target_domain,   :plain]
+            target_domain:   [:target_domain,   :plain],
+            # Vendored addition, not (yet) upstream hecksagain (migration
+            # plan task 8): `wheres`/`with_literals`/`for_each` never
+            # reached this table, so a policy carrying any of the three
+            # survived the DSL parse and vanished the moment the same
+            # bluebook went through `MetaValidator.call` (every ordinary
+            # `Hecks.bluebook` load) — see reaction.bluebook's own
+            # comment on the matching grammar addition. `wheres`/
+            # `with_literals` are open maps, the SAME `:bindings` reading
+            # `Handler#remembers` already uses (Symbol keys, matching
+            # `where`'s own `transform_keys(&:to_sym)`) — `with_literals`
+            # needs its own `:literal_map` twin only because ITS keys are
+            # Strings (`with`/`map`'s own `transform_keys(&:to_s)`).
+            # `for_each` is a compound field the language keeps as two
+            # (`for_each_from`/`for_each_where`, both `derived:` below,
+            # since assembling `for_each` as one thing is this row's job)
+            # — see IR::Policy#for_each_from/#for_each_where's own comment.
+            wheres:          [:wheres,          :bindings],
+            with_literals:   [:with_literals,   :literal_map],
+            for_each:        [:for_each,        :for_each_spec]
           },
-          derived: { position: :walk }
+          rows: {
+            wheres:         :policy_wheres_rows,
+            with_literals:  :policy_with_literals_rows,
+            for_each_where: :policy_for_each_where_rows
+          },
+          reads: {
+            wheres:        [:from, :wheres],
+            with_literals: [:from, :with_literals],
+            for_each:      [:call, :policy_for_each]
+          },
+          derived: {
+            position: :walk,
+            # `[:computed, ...]`, not `[:folded, ...]` — a folded claim
+            # needs a REAL reconstructed declaration somewhere in the
+            # assembly corpus to carry both keys together (Contract#folded's
+            # own comment), and `for_each` is new enough that nothing in
+            # that corpus exercises it yet. `computes?` asks a narrower,
+            # STATIC question instead — does `IR::Policy` answer to this
+            # name while its OWN constructor does not accept it as a
+            # keyword — which the two readers just added to `ir/policy.rb`
+            # satisfy directly, with no corpus content required.
+            for_each_from:  [:computed, :for_each_from],
+            for_each_where: [:computed, :for_each_where]
+          }
         ),
 
         "ProcessManager" => Contract.new(

--- a/lib/hecksagain/bluebook/assembly/marks.rb
+++ b/lib/hecksagain/bluebook/assembly/marks.rb
@@ -98,6 +98,27 @@ module Hecksagain
         # string of the same name.
         def bindings(with) = Array(with).to_h { |key, value| [key.to_sym, read(value)] }
 
+        # `with_literals`' own keys — a POLICY writes them as STRINGS
+        # (`with "key", "value"` / `map key: value`, both `to_s`-keyed —
+        # see PolicyBuilder#with/#map's own comments), unlike `bindings`
+        # just above, whose Symbol keys match `where`'s own
+        # `transform_keys(&:to_sym)`. Same decode (`read`) either way;
+        # only the key's own type differs.
+        def literal_map(with) = Array(with).to_h { |key, value| [key.to_s, read(value)] }
+
+        # `for_each`'s own shape — one scalar (`from`) and one open map
+        # (`where`), Reconstruction's `policy_for_each` gathers the parts,
+        # this decodes them: `where`'s values ride the exact encoding
+        # `bindings` already reads, since `for_each`'s own where-clause
+        # values are the SAME mix (a bare Symbol referencing the
+        # triggering event's payload, or a literal) `with:`/`remember`
+        # already round-trip this way.
+        def for_each_spec(value)
+          return nil unless value
+
+          { from: value[:from], where: bindings(value[:where]) }
+        end
+
         def invariant(rule)
           IR::Invariant.new(description: rule[:description], canonical: rule[:canonical])
         end

--- a/lib/hecksagain/bluebook/ir/policy.rb
+++ b/lib/hecksagain/bluebook/ir/policy.rb
@@ -41,14 +41,42 @@ module Hecksagain
 
         def event_name = Naming.unqualified(@on_event)
 
+        # COMPUTED, not stored — the self-hosted grammar's own "Policy"
+        # aggregate holds `for_each` split into two fields (`for_each_from`
+        # a scalar, `for_each_where` an open map — a value object cannot
+        # hold a Hash), where the IR keeps one Hash. These two answer the
+        # split half of that shape, the same way `ReadModel#query_name` is
+        # a real reader over a stored field rather than one of its own —
+        # see `assembly/contracts.rb`'s Policy contract, `[:computed, ...]`.
+        def for_each_from  = @for_each && @for_each[:from]
+        def for_each_where = @for_each && @for_each[:where]
+
+        # `wheres`/`with_literals`/`for_each`, vendored additions not (yet)
+        # upstream hecksagain -- unlike `aggregate` above, these ARE on
+        # the wire: `assembly/contracts.rb`'s Policy contract reads them
+        # back through the SAME spelling this writes, whether the source
+        # is this method (`spec/assembly_spec`'s own `Assembly.call(built.
+        # to_h)` check) or the self-hosted meta-domain's own
+        # reconstruction (an ordinary `Hecks.bluebook` load). Marked the
+        # same way `DispatchSpec#to_h` already marks `with_spec` --
+        # `IR.render_value` distinguishes a Symbol argument reference
+        # from a literal of the same spelling, which a bare `to_s` alone
+        # cannot.
         def to_h
           {
             name:            @name,
             on_event:        @on_event,
             trigger_command: @trigger_command,
-            target_domain:   @target_domain
+            target_domain:   @target_domain,
+            wheres:          marked_pairs(@wheres),
+            with_literals:   marked_pairs(@with_literals),
+            for_each:        @for_each && { from: @for_each[:from], where: marked_pairs(@for_each[:where]) }
           }
         end
+
+        private
+
+        def marked_pairs(map) = Hash(map).map { |key, value| [key.to_s, IR.render_value(value)] }
       end
     end
   end

--- a/lib/hecksagain/bluebook/meta_validator/readings.rb
+++ b/lib/hecksagain/bluebook/meta_validator/readings.rb
@@ -59,6 +59,28 @@ module Hecksagain
         # leading colon, which the raw `remembers` array does not).
         def remembers_rows(node) = pair_rows(node.to_h[:remembers])
 
+        # A policy's own `where field: value` conditions and `with key,
+        # value` literals — both open maps, the SAME shape Handler's
+        # `remembers`/Dispatch's `with_spec` already are, read through
+        # `to_h` for the same reason those two are: `IR::Policy#to_h`
+        # marks each value with `IR.render_value` (a leading colon for a
+        # Symbol), and reading the OBJECT instead of the wire spelling
+        # loses nothing on its own, but disagrees byte-for-byte with what
+        # `to_h` already wrote, which is exactly what `spec/round_trip_spec`
+        # compares this against.
+        def policy_wheres_rows(node) = pair_rows(node.to_h[:wheres])
+
+        def policy_with_literals_rows(node) = pair_rows(node.to_h[:with_literals])
+
+        # `for_each`'s own `where:` — the SAME open-map shape as `wheres`
+        # just above, except a value may be a bare Symbol
+        # (`from_event(:field)`, a reference into the triggering event's
+        # own payload) rather than always a literal. `IR.render_value`
+        # marks either correctly: a Symbol prints with its own leading
+        # colon, the exact spelling `Marks#bindings`' reader already
+        # expects.
+        def policy_for_each_where_rows(node) = pair_rows(node.to_h[:for_each]&.dig(:where))
+
         # A read model carries the same options an ask does, plus its filters — see
         # option_rows.
         def read_model_option_rows(node) = option_rows(node, filters: true)

--- a/lib/hecksagain/bluebook/meta_validator/reconstruction.rb
+++ b/lib/hecksagain/bluebook/meta_validator/reconstruction.rb
@@ -201,6 +201,16 @@ module Hecksagain
 
         def query(row) = declaration("Query", row).merge(options_of(row))
 
+        # `count` is stored as TEXT ("true"/"false", the same self-
+        # describing spelling every other language-held scalar uses) but
+        # `IR::Query#count` is a real Ruby boolean — so this decodes it,
+        # the same way `closed_set_of` above answers a real boolean for
+        # `ValueObject#closed_set?`. Reading `row[:count]` directly
+        # (rather than trusting `:flag`'s own `value ? true : false`) is
+        # the whole fix: ANY non-empty string, including the text
+        # "false", is truthy in Ruby.
+        def count_flag(row) = text(row[:count]).to_s == "true"
+
         def entity(row)
           {
             name:        text(row[:name]),
@@ -235,6 +245,22 @@ module Hecksagain
         end
 
         def policy(row) = declaration("Policy", row)
+
+        # `for_each` is ONE Hash in the IR (`{from:, where:}`) where the
+        # language keeps the parts — `for_each_from` a plain scalar,
+        # `for_each_where` the open map `policy_for_each_where_rows` wrote.
+        # `pairs`, not a Hash, for the same reason `remembers`/`with_spec`
+        # read back as pairs rather than decoded already — the VALUES are
+        # still marked (a colon-prefixed symbol, an inspected literal) and
+        # decoding happens once, at `Marks#for_each_spec`, the one place
+        # that builds the object every `deliver_for_each` dispatch
+        # actually reads.
+        def policy_for_each(row)
+          from = text(row[:for_each_from])
+          return nil if from.to_s.empty?
+
+          { from: from, where: pairs(row[:for_each_where]) }
+        end
 
         def process_manager(row)
           declaration("ProcessManager", row,

--- a/lib/hecksagain/language/bluebook/behavior.bluebook
+++ b/lib/hecksagain/language/bluebook/behavior.bluebook
@@ -377,6 +377,19 @@ Hecks.bluebook "Bluebook" do
     attribute :order_field, QueryText
     attribute :order_way,   QueryText
     attribute :limit,       QueryText
+    # Vendored addition, not (yet) upstream hecksagain (migration plan
+    # task 8): the self-hosted grammar's own "Query" aggregate never
+    # declared these three, so a query's `count`/`median`/`group_by`
+    # survived parsing but silently vanished the moment a bluebook was
+    # actually loaded (`Hecks.bluebook` always routes through
+    # `MetaValidator.call`, which replaces the built IR with what this
+    # domain reconstructs). Same shape as `order_field`/`order_way`/
+    # `limit` just above -- plain scalars, carried straight through
+    # `Query.Declare` rather than a sub-command, since all three are
+    # known in full by the time the DSL block finishes.
+    attribute :count,          QueryText
+    attribute :median_field,   QueryText
+    attribute :group_by_field, QueryText
     attribute :wheres,      list_of(Filter)
     attribute :attributes,  list_of(AskArgument)
     # EVERY OTHER OPTION A QUERY CAN CARRY, as an open map rather than a field
@@ -467,6 +480,9 @@ Hecks.bluebook "Bluebook" do
       attribute :order_field, QueryText, optional: true
       attribute :order_way,   QueryText, optional: true
       attribute :limit,       QueryText, optional: true
+      attribute :count,          QueryText, optional: true
+      attribute :median_field,   QueryText, optional: true
+      attribute :group_by_field, QueryText, optional: true
 
       attribute :position, Position, optional: true
       emits "AskDeclared"

--- a/lib/hecksagain/language/bluebook/reaction.bluebook
+++ b/lib/hecksagain/language/bluebook/reaction.bluebook
@@ -24,6 +24,27 @@ Hecks.bluebook "Bluebook" do
     attribute :on_event,        PolicyText
     attribute :trigger_command, PolicyText
     attribute :target_domain,   PolicyText
+    # Vendored addition, not (yet) upstream hecksagain (migration plan
+    # task 8): the self-hosted grammar's own "Policy" aggregate never
+    # declared `where`/`with`/`for_each`, so a policy carrying any of
+    # them survived the DSL parse and vanished the moment the same
+    # bluebook went through `MetaValidator.call` (every ordinary
+    # `Hecks.bluebook` load) — a `where` fired on every event
+    # regardless of payload, `with` never reached the triggered
+    # command's arguments, `for_each` fanned out to nothing. Same
+    # shape as `Handler.remembers`/`Dispatch.with_spec` one file over —
+    # an OPEN MAP has no value object that can hold it, so `wheres`/
+    # `with_literals` ride as rows, appended one pair at a time.
+    # `for_each` is a THIRD field the IR keeps as one Hash
+    # (`{from:, where:}`) where the language keeps the parts —
+    # `for_each_from` a plain scalar (known in full by the time
+    # `for_each(from:, where:)`'s call finishes, so it rides straight
+    # through `Policy.Declare` the way `order_field` does on Query),
+    # `for_each_where` the same open-map shape as `wheres` itself.
+    attribute :wheres,         list_of(Pair)
+    attribute :with_literals,  list_of(Pair)
+    attribute :for_each_from,  PolicyText
+    attribute :for_each_where, list_of(Pair)
 
     value_object "PolicyName" do
       attribute :value, String
@@ -31,6 +52,14 @@ Hecks.bluebook "Bluebook" do
     end
 
     value_object "PolicyText" do
+      attribute :value, String
+    end
+
+    # ONE OPEN-MAP ENTRY, shared by `wheres`, `with_literals` and
+    # `for_each`'s own `where` — all three are a policy's own key/value
+    # pairs, told apart only by which list they append to.
+    value_object "Pair" do
+      attribute :key,   String
       attribute :value, String
     end
 
@@ -63,9 +92,64 @@ Hecks.bluebook "Bluebook" do
       attribute :on_event,        PolicyText
       attribute :trigger_command, PolicyText
       attribute :target_domain,   PolicyText, optional: true
+      attribute :for_each_from,   PolicyText, optional: true
 
       attribute :position, Position, optional: true
       emits "ReactionDeclared"
+    end
+
+    # `where field: value` — vendored addition, not (yet) upstream
+    # hecksagain (migration plan task 8): the append counterpart to
+    # `Handler.Remember`, one aggregate over.
+    command "Where" do
+      role "Language"
+      goal "Attach one where-condition to the policy"
+
+      reference_to Policy
+      attribute :key,   PolicyText
+      attribute :value, PolicyText
+
+      then_set :wheres, append: { key: :key, value: :value }
+
+      emits "PolicyWhereAttached"
+    end
+
+    # `with key, value` / `map key: value` — vendored addition, not (yet)
+    # upstream hecksagain (migration plan task 8): same open-map shape as
+    # `Where` just above, a separate list because the two are read at
+    # different times (a where GATES the trigger, a with LITERAL rides
+    # into its arguments).
+    command "With" do
+      role "Language"
+      goal "Attach one literal argument to the policy's own trigger"
+
+      reference_to Policy
+      attribute :key,   PolicyText
+      attribute :value, PolicyText
+
+      then_set :with_literals, append: { key: :key, value: :value }
+
+      emits "PolicyWithAttached"
+    end
+
+    # `for_each from:, where: {...}` — vendored addition, not (yet)
+    # upstream hecksagain (migration plan task 8): the fan-out's OWN
+    # where-clause, resolved against the triggering event's payload
+    # rather than a stored record — see PolicyBuilder#for_each's own
+    # comment. `for_each_from` (the query's own FQN) rides on Declare
+    # itself, the same way `order_field` does on Query ; this is only
+    # the open-map half.
+    command "ForEach" do
+      role "Language"
+      goal "Attach one for_each where-condition to the policy"
+
+      reference_to Policy
+      attribute :key,   PolicyText
+      attribute :value, PolicyText
+
+      then_set :for_each_where, append: { key: :key, value: :value }
+
+      emits "PolicyForEachAttached"
     end
   end
 

--- a/spec/adapters/banking_matrix_spec.rb
+++ b/spec/adapters/banking_matrix_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe "Banking across persistence adapters" do
         Banking::OnboardingCase.projected_by("SqliteProjection") if projected
         Banking::Statement.persisted_by(adapter)
         Banking::Statement.projected_by("SqliteProjection") if projected
+        Banking::WatchlistEntry.persisted_by(adapter)
+        Banking::WatchlistEntry.projected_by("SqliteProjection") if projected
+        Banking::ComplianceSweep.persisted_by(adapter)
+        Banking::ComplianceSweep.projected_by("SqliteProjection") if projected
       end
       if adapter != "Memory"
         adapter_name = adapter

--- a/spec/corpus/banking.json
+++ b/spec/corpus/banking.json
@@ -2660,6 +2660,39 @@
         "generated_on": { "value": "2026-09-02" },
         "frequency": { "cadence": "monthly", "retention_months": 84, "paper_fee_cents": 0 }
       }
+    },
+    {
+      "verb": "Banking::WatchlistEntry.Add",
+      "args": {
+        "id": { "value": "watch-1" },
+        "zone": "downtown",
+        "severity": "critical"
+      }
+    },
+    {
+      "verb": "Banking::WatchlistEntry.Add",
+      "args": {
+        "id": { "value": "watch-2" },
+        "zone": "downtown",
+        "severity": "normal"
+      }
+    },
+    {
+      "verb": "Banking::WatchlistEntry.Flag",
+      "args": {
+        "id": "watch-2",
+        "note": "manually flagged"
+      }
+    },
+    {
+      "verb": "Banking::ComplianceSweep.Start",
+      "args": {
+        "zone": { "value": "downtown" }
+      }
+    },
+    {
+      "query": "Banking::WatchlistEntry.InZone",
+      "args": { "zone": "downtown" }
     }
   ]
 }

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -5333,6 +5333,360 @@
           "name": "StatementFrequency"
         }
       ]
+    },
+    {
+      "attributes": [
+        {
+          "admits": null,
+          "default": null,
+          "list": false,
+          "name": "id",
+          "optional": false,
+          "pattern": null,
+          "type": "EntryId"
+        },
+        {
+          "admits": null,
+          "default": null,
+          "list": false,
+          "name": "zone",
+          "optional": false,
+          "pattern": null,
+          "type": "Zone"
+        },
+        {
+          "admits": null,
+          "default": "normal",
+          "list": false,
+          "name": "severity",
+          "optional": false,
+          "pattern": null,
+          "type": "Severity"
+        },
+        {
+          "admits": null,
+          "default": "clear",
+          "list": false,
+          "name": "status",
+          "optional": false,
+          "pattern": null,
+          "type": "Status"
+        }
+      ],
+      "commands": [
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "id",
+              "optional": false,
+              "pattern": null,
+              "type": "EntryId"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "zone",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "severity",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "emits": [
+            "EntryAdded"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+
+          ],
+          "goal": null,
+          "mutations": [
+
+          ],
+          "name": "Add",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": null,
+          "role": null
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "note",
+              "optional": true,
+              "pattern": null,
+              "type": "String"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "flagged_by",
+              "optional": true,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "emits": [
+            "EntryFlagged"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+
+          ],
+          "goal": "Mark one watchlist entry flagged",
+          "mutations": [
+            {
+              "op": "set",
+              "source": {
+                "kind": "literal",
+                "value": "flagged"
+              },
+              "target": "status"
+            }
+          ],
+          "name": "Flag",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": "WatchlistEntry",
+          "role": "Compliance officer"
+        }
+      ],
+      "description": "One name on a compliance watchlist, escalated individually or swept zone-wide at once.",
+      "entities": [
+
+      ],
+      "identified_by": [
+        "id.value"
+      ],
+      "lifecycle": null,
+      "name": "WatchlistEntry",
+      "ports": [
+
+      ],
+      "provenance": null,
+      "queries": [
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "zone",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "description": null,
+          "limit": null,
+          "name": "InZone",
+          "order_by": null,
+          "wheres": [
+            {
+              "field": "zone",
+              "op": "eq",
+              "value": ":zone"
+            }
+          ]
+        }
+      ],
+      "value_objects": [
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "EntryId"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "Zone"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "Severity"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "Status"
+        }
+      ]
+    },
+    {
+      "attributes": [
+        {
+          "admits": null,
+          "default": null,
+          "list": false,
+          "name": "zone",
+          "optional": false,
+          "pattern": null,
+          "type": "SweepZone"
+        }
+      ],
+      "commands": [
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "zone",
+              "optional": false,
+              "pattern": null,
+              "type": "SweepZone"
+            }
+          ],
+          "emits": [
+            "SweepStarted"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+
+          ],
+          "goal": null,
+          "mutations": [
+
+          ],
+          "name": "Start",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": null,
+          "role": null
+        }
+      ],
+      "description": "One zone-wide compliance sweep, flagging every watchlist entry the zone currently holds.",
+      "entities": [
+
+      ],
+      "identified_by": [
+        "zone.value"
+      ],
+      "lifecycle": null,
+      "name": "ComplianceSweep",
+      "ports": [
+
+      ],
+      "provenance": null,
+      "queries": [
+
+      ],
+      "value_objects": [
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "SweepZone"
+        }
+      ]
     }
   ],
   "canonical_form": [
@@ -5357,40 +5711,126 @@
   "name": "Banking",
   "policies": [
     {
+      "for_each": null,
       "name": "ReviewOnFreeze",
       "on_event": "Account.AccountFrozen",
       "target_domain": "Compliance",
-      "trigger_command": "Compliance.OpenReview"
+      "trigger_command": "Compliance.OpenReview",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     },
     {
+      "for_each": null,
       "name": "RetryOnPaymentFailure",
       "on_event": "ScheduledPayment.ScheduledPaymentFailed",
       "target_domain": null,
-      "trigger_command": "ScheduledPayment.Retry"
+      "trigger_command": "ScheduledPayment.Retry",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     },
     {
+      "for_each": null,
+      "name": "EscalateOnCriticalEntry",
+      "on_event": "EntryAdded",
+      "target_domain": null,
+      "trigger_command": "WatchlistEntry.Flag",
+      "wheres": [
+        [
+          "severity",
+          "\"critical\""
+        ]
+      ],
+      "with_literals": [
+        [
+          "note",
+          "\"auto-flagged — critical on arrival\""
+        ],
+        [
+          "flagged_by",
+          "\"policy\""
+        ]
+      ]
+    },
+    {
+      "for_each": {
+        "from": "WatchlistEntry.InZone",
+        "where": [
+          [
+            "zone",
+            ":zone"
+          ]
+        ]
+      },
+      "name": "FlagZoneOnSweep",
+      "on_event": "SweepStarted",
+      "target_domain": null,
+      "trigger_command": "WatchlistEntry.Flag",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
+    },
+    {
+      "for_each": null,
       "name": "FreezeAccountsOnSuspension",
       "on_event": "CustomerSuspended",
       "target_domain": null,
-      "trigger_command": "Account.Freeze"
+      "trigger_command": "Account.Freeze",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     },
     {
+      "for_each": null,
       "name": "NotifyOnClosure",
       "on_event": "AccountClosed",
       "target_domain": "Notifications",
-      "trigger_command": "Notifications.Send"
+      "trigger_command": "Notifications.Send",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     },
     {
+      "for_each": null,
       "name": "ReviewOnBoxSurrender",
       "on_event": "BoxSurrendered",
       "target_domain": "Compliance",
-      "trigger_command": "Compliance.OpenReview"
+      "trigger_command": "Compliance.OpenReview",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     },
     {
+      "for_each": null,
       "name": "FlagKeyReturn",
       "on_event": "KeyReturnDue",
       "target_domain": "Notifications",
-      "trigger_command": "Notifications.Send"
+      "trigger_command": "Notifications.Send",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     }
   ],
   "process_managers": [

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -2869,6 +2869,33 @@
         {
           "admits": null,
           "default": null,
+          "list": false,
+          "name": "count",
+          "optional": false,
+          "pattern": null,
+          "type": "QueryText"
+        },
+        {
+          "admits": null,
+          "default": null,
+          "list": false,
+          "name": "median_field",
+          "optional": false,
+          "pattern": null,
+          "type": "QueryText"
+        },
+        {
+          "admits": null,
+          "default": null,
+          "list": false,
+          "name": "group_by_field",
+          "optional": false,
+          "pattern": null,
+          "type": "QueryText"
+        },
+        {
+          "admits": null,
+          "default": null,
           "list": true,
           "name": "wheres",
           "optional": false,
@@ -2965,6 +2992,33 @@
               "default": null,
               "list": false,
               "name": "limit",
+              "optional": true,
+              "pattern": null,
+              "type": "QueryText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "count",
+              "optional": true,
+              "pattern": null,
+              "type": "QueryText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "median_field",
+              "optional": true,
+              "pattern": null,
+              "type": "QueryText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "group_by_field",
               "optional": true,
               "pattern": null,
               "type": "QueryText"
@@ -5068,6 +5122,42 @@
         {
           "admits": null,
           "default": null,
+          "list": true,
+          "name": "wheres",
+          "optional": false,
+          "pattern": null,
+          "type": "Pair"
+        },
+        {
+          "admits": null,
+          "default": null,
+          "list": true,
+          "name": "with_literals",
+          "optional": false,
+          "pattern": null,
+          "type": "Pair"
+        },
+        {
+          "admits": null,
+          "default": null,
+          "list": false,
+          "name": "for_each_from",
+          "optional": false,
+          "pattern": null,
+          "type": "PolicyText"
+        },
+        {
+          "admits": null,
+          "default": null,
+          "list": true,
+          "name": "for_each_where",
+          "optional": false,
+          "pattern": null,
+          "type": "Pair"
+        },
+        {
+          "admits": null,
+          "default": null,
           "list": false,
           "name": "position",
           "optional": false,
@@ -5136,6 +5226,15 @@
               "admits": null,
               "default": null,
               "list": false,
+              "name": "for_each_from",
+              "optional": true,
+              "pattern": null,
+              "type": "PolicyText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
               "name": "position",
               "optional": true,
               "pattern": null,
@@ -5161,6 +5260,153 @@
 
           ],
           "references": null,
+          "role": "Language"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "key",
+              "optional": false,
+              "pattern": null,
+              "type": "PolicyText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "PolicyText"
+            }
+          ],
+          "emits": [
+            "PolicyWhereAttached"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+
+          ],
+          "goal": "Attach one where-condition to the policy",
+          "mutations": [
+            {
+              "fields": {
+                "key": ":key",
+                "value": ":value"
+              },
+              "op": "append",
+              "target": "wheres"
+            }
+          ],
+          "name": "Where",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": "Policy",
+          "role": "Language"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "key",
+              "optional": false,
+              "pattern": null,
+              "type": "PolicyText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "PolicyText"
+            }
+          ],
+          "emits": [
+            "PolicyWithAttached"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+
+          ],
+          "goal": "Attach one literal argument to the policy's own trigger",
+          "mutations": [
+            {
+              "fields": {
+                "key": ":key",
+                "value": ":value"
+              },
+              "op": "append",
+              "target": "with_literals"
+            }
+          ],
+          "name": "With",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": "Policy",
+          "role": "Language"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "key",
+              "optional": false,
+              "pattern": null,
+              "type": "PolicyText"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "PolicyText"
+            }
+          ],
+          "emits": [
+            "PolicyForEachAttached"
+          ],
+          "ensures": [
+
+          ],
+          "givens": [
+
+          ],
+          "goal": "Attach one for_each where-condition to the policy",
+          "mutations": [
+            {
+              "fields": {
+                "key": ":key",
+                "value": ":value"
+              },
+              "op": "append",
+              "target": "for_each_where"
+            }
+          ],
+          "name": "ForEach",
+          "provenance": null,
+          "redirects_native": [
+
+          ],
+          "references": "Policy",
           "role": "Language"
         }
       ],
@@ -5252,6 +5498,36 @@
 
           ],
           "name": "PolicyText"
+        },
+        {
+          "attributes": [
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "key",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            },
+            {
+              "admits": null,
+              "default": null,
+              "list": false,
+              "name": "value",
+              "optional": false,
+              "pattern": null,
+              "type": "String"
+            }
+          ],
+          "closed_set": false,
+          "invariants": [
+
+          ],
+          "members": [
+
+          ],
+          "name": "Pair"
         },
         {
           "attributes": [

--- a/spec/golden/ir/Pizzas.json
+++ b/spec/golden/ir/Pizzas.json
@@ -535,10 +535,17 @@
   "name": "Pizzas",
   "policies": [
     {
+      "for_each": null,
       "name": "OnPizzaPaymentReceived",
       "on_event": "PizzaPaymentReceived",
       "target_domain": null,
-      "trigger_command": "Order.Purchase"
+      "trigger_command": "Order.Purchase",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     }
   ],
   "process_managers": [

--- a/spec/golden/ir/Reflex.json
+++ b/spec/golden/ir/Reflex.json
@@ -453,22 +453,43 @@
   "name": "Reflex",
   "policies": [
     {
+      "for_each": null,
       "name": "LogOnFlip",
       "on_event": "Flipped",
       "target_domain": null,
-      "trigger_command": "Light.Log"
+      "trigger_command": "Light.Log",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     },
     {
+      "for_each": null,
       "name": "RingOnRang",
       "on_event": "Rang",
       "target_domain": null,
-      "trigger_command": "Echo.Ring"
+      "trigger_command": "Echo.Ring",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     },
     {
+      "for_each": null,
       "name": "NotifyOnRaise",
       "on_event": "Raised",
       "target_domain": "Notifications",
-      "trigger_command": "Notifications.Send"
+      "trigger_command": "Notifications.Send",
+      "wheres": [
+
+      ],
+      "with_literals": [
+
+      ]
     }
   ],
   "process_managers": [

--- a/spec/optionality_coverage_spec.rb
+++ b/spec/optionality_coverage_spec.rb
@@ -31,20 +31,19 @@ require "json"
 RSpec.describe "every nullable field the wire carries, actually filled" do
   # An entry here is a claim that some field is not worth a fixture, and
   # it must say why.
-  ALLOWED_UNSET = {
-    # `dispatch ..., for_each: { from: "Aggregate.query" }` (docs/hecks-
-    # migration-findings.md's #12) — a real, dispatch-time fan-out, but
-    # proving it needs a fixture with a genuine multi-row query wired to
-    # a saga that consumes it end to end, verified through a real
-    # dispatch, not merely a parsed declaration — exactly the discipline
-    # this migration's own findings doc names as the difference between
-    # `validate`-clean and actually working. That verification is real,
-    # separate work (Runtime::SagaInterpreter#deliver_saga_dispatch's own
-    # `@door.query` call is untested against a live for_each corpus
-    # member as of this pass), not a side effect of closing this gate.
-    "for_each" => "for_each fan-out has no corpus member exercising a real multi-row dispatch yet — " \
-                  "building and verifying one through a real dispatch is separate work"
-  }.freeze
+  #
+  # `for_each`'s own entry (removed, item 46b): Policy's own `for_each`
+  # (WatchlistEntry's FlagZoneOnSweep, banking.bluebook) now genuinely
+  # fills the field somewhere in the wire, verified through a real
+  # dispatch (item 48 closed the runtime crash that blocked it) — the
+  # claim this entry made is obsolete, not a side effect of a different
+  # gate. Note: this specifically proves POLICY's own for_each ; a saga
+  # Handler's dispatch-level for_each (item 12,
+  # SagaInterpreter#deliver_saga_dispatch) is a DIFFERENT field sharing
+  # the same wire key name and may still want its own corpus exercise —
+  # this gate cannot distinguish the two by name alone, and does not
+  # claim to have closed that one too.
+  ALLOWED_UNSET = {}.freeze
 
   # SET and NULL counts for every key in every frozen IR. An object or a list
   # counts as SET: `lifecycle` is a Hash when it is there and null when it is

--- a/spec/query_policy_self_hosted_round_trip_growth_spec.rb
+++ b/spec/query_policy_self_hosted_round_trip_growth_spec.rb
@@ -1,0 +1,162 @@
+require "spec_helper"
+require "tempfile"
+
+# Real coverage for Query's count/median/group_by and Policy's
+# where/with/for_each self-hosted grammar round-trip: every Hecks.bluebook
+# load runs MetaValidator.call, which dispatches the built IR into the
+# language's own self-hosted meta-domain and replaces it with what THAT
+# domain reconstructs. Before this fix, Query's count/median_field/
+# group_by_field and Policy's wheres/with_literals/for_each all survived
+# the DSL parse and vanished the moment a bluebook was actually loaded
+# (meta-validation ON, the ordinary path -- no ENV escape hatch needed
+# here, unlike items 06a/06b/06/08/09's own coverage).
+RSpec.describe "Query/Policy self-hosted grammar round-trip" do
+  def build(source)
+    file = Tempfile.new(["query-policy-round-trip-growth-", ".bluebook"])
+    file.write(source)
+    file.flush
+
+    registry = Hecksagain::Runtime::Registry.new
+    bluebook = nil
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      bluebook = Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+    end
+    bluebook
+  ensure
+    file&.close!
+  end
+
+  it "a query's count/median_field/group_by_field survive the Judge round-trip" do
+    source = <<~BLUEBOOK
+      Hecks.bluebook "QueryScalarsRoundTripGrowth" do
+        aggregate "Ticket" do
+          identified_by { id.value }
+          value_object "TicketId" do
+            attribute :value, String
+          end
+          attribute :id, TicketId
+          attribute :priority, Integer
+
+          command "Open" do
+            attribute :id, TicketId
+            attribute :priority, Integer
+            emits "Opened"
+          end
+
+          query "Tally" do
+            count
+          end
+
+          query "MidPriority" do
+            median :priority
+          end
+
+          query "ByPriority" do
+            group_by :priority
+          end
+        end
+      end
+    BLUEBOOK
+
+    bluebook = build(source)
+    ticket = bluebook.aggregate("Ticket")
+    expect(ticket.query("Tally").count).to be(true)
+    expect(ticket.query("MidPriority").median_field).to eq(:priority)
+    expect(ticket.query("ByPriority").group_by_field).to eq(:priority)
+  end
+
+  it "a policy's where/with survive the Judge round-trip" do
+    source = <<~BLUEBOOK
+      Hecks.bluebook "PolicyMapsRoundTripGrowth" do
+        aggregate "Ticket" do
+          identified_by { id.value }
+          value_object "TicketId" do
+            attribute :value, String
+          end
+          attribute :id,       TicketId
+          attribute :severity, String, default: "normal"
+
+          command "Open" do
+            attribute :id,       TicketId
+            attribute :severity, String
+            emits "Opened"
+          end
+
+          command "Escalate" do
+            reference_to Ticket
+            emits "Escalated"
+          end
+
+          policy "EscalateOnCritical" do
+            on      "Opened"
+            where   severity: "critical"
+            with    "note", "auto-flagged"
+            trigger "Ticket.Escalate"
+          end
+        end
+      end
+    BLUEBOOK
+
+    bluebook = build(source)
+    policy = bluebook.policies.find { |p| p.name == "EscalateOnCritical" }
+    expect(policy.wheres).to eq(severity: "critical")
+    expect(policy.with_literals).to eq("note" => "auto-flagged")
+  end
+
+  it "a policy's for_each (compound from:/where:) survives the Judge round-trip" do
+    source = <<~BLUEBOOK
+      Hecks.bluebook "PolicyForEachRoundTripGrowth" do
+        aggregate "Ticket" do
+          identified_by { id.value }
+          value_object "TicketId" do
+            attribute :value, String
+          end
+          attribute :id,    TicketId
+          attribute :board, String
+
+          command "Open" do
+            attribute :id,    TicketId
+            attribute :board, String
+            emits "Opened"
+          end
+
+          command "Ping" do
+            reference_to Ticket
+            emits "Pinged"
+          end
+
+          query "ForBoard" do
+            attribute :board, String
+            where board: :board
+          end
+        end
+
+        aggregate "Board" do
+          identified_by { id.value }
+          value_object "BoardId" do
+            attribute :value, String
+          end
+          attribute :id, BoardId
+
+          command "Sweep" do
+            attribute :id, BoardId
+            emits "Swept"
+          end
+
+          policy "PingOnSweep" do
+            on       "Swept"
+            for_each from: "Ticket.ForBoard", where: { board: from_event(:id) }
+            trigger  "Ticket.Ping"
+          end
+        end
+      end
+    BLUEBOOK
+
+    bluebook = build(source)
+    policy = bluebook.policies.find { |p| p.name == "PingOnSweep" }
+    expect(policy.for_each_from).to eq("Ticket.ForBoard")
+    expect(policy.for_each_where).to eq(board: :id)
+  end
+end

--- a/spec/specializer_spec.rb
+++ b/spec/specializer_spec.rb
@@ -1,18 +1,27 @@
 require "spec_helper"
 
 RSpec.describe "the first specializer" do
-  # Handler swapped for Bluebook (migration plan task 4): Handler grew a
-  # real `list_of` field (`remembers`, the saga-memory open map — see
+  # Handler swapped for Bluebook (item 36), Policy WITHDRAWN with no
+  # replacement (this item, 94fdc44/46b): Policy grew three real
+  # `list_of`/compound fields (`wheres`/`with_literals`/`for_each` -- see
   # reaction.bluebook's own comment), which the specializer deliberately
-  # never claims ("ONE CASE, PROVEN, NOT THE WHOLE TABLE" — Specializer#
-  # fields_for's own header). Handler's hand-written contract and the
+  # never claims ("ONE CASE, PROVEN, NOT THE WHOLE TABLE" -- Specializer#
+  # fields_for's own header). Policy's hand-written contract and the
   # specializer's derived one can no longer agree field-for-field, which
-  # is not a regression — it is exactly what "not the whole table" always
-  # meant, now actually exercised. Bluebook is the next category whose
-  # own `fields:` table is ALL plain scalars (no lists, no references,
-  # including the `category` field this migration added), so it takes
-  # Handler's place as the second independently-checked category.
-  %w[Policy Bluebook].each do |category|
+  # is not a regression -- it is exactly what "not the whole table"
+  # always meant, now actually exercised a second time.
+  #
+  # Checked every one of the twelve contract-backed categories directly
+  # (a real, one-time audit, not a guess): Bluebook is the ONLY one left
+  # with a `fields:` table this migration's own growth hasn't touched.
+  # `Member`'s own `fields: {}` looked like a second candidate but is not
+  # a genuine match -- its own `shape` attribute is real on the language
+  # side yet marked `derived: { shape: :parent }` (not a stored field) on
+  # the hand-written contract, a PRE-EXISTING mismatch unrelated to this
+  # migration, not something to paper over by picking it anyway. Rather
+  # than fake a second category, this drops to the one real, honestly
+  # checkable claim left.
+  %w[Bluebook].each do |category|
     it "derives #{category}'s fields exactly as hand-written" do
       derived = Hecksagain::Bluebook::Assembly::Specializer.fields_for(category)
       hand    = Hecksagain::Bluebook::Assembly.contract(category).fields


### PR DESCRIPTION
Splits `94fdc44` (self-hosted grammar: Query's count/median/group_by and Policy's where/with/for_each round-trip through the Judge) — item 46b of the [PR-split plan](.pr-split-plan.md). Base is item 48 (PR #98), NOT item 46 — see the real, hard dependency below.

**Finding**: same shape as `redirects_native`'s own gap — every `Hecks.bluebook` load runs `MetaValidator.call`, which dispatches the built IR into the language's own self-hosted meta-domain and replaces it with what THAT domain reconstructs. Query's `count`/`median_field`/`group_by_field` and Policy's `wheres`/`with_literals`/`for_each` all survived the DSL parse and vanished the moment a bluebook was actually loaded.

**Fix**: Query's three ride as plain scalars on `Query.Declare` (`count` needs one extra step — the language stores every scalar as text and `"false"` is a non-empty, truthy string). Policy's three are open maps or a compound field split into two (`for_each_from`/`for_each_where`), mirroring Handler's own `remembers`/Dispatch's own `with_spec`. Banking grows a small, self-contained `WatchlistEntry`/`ComplianceSweep` pair specifically to exercise `Policy.Where`/`With`/`ForEach`.

**Real, hard dependency found and resolved**: this item's own new corpus content (`WatchlistEntry`'s `for_each`-driven policy) genuinely exercises `PolicyInterpreter#deliver_for_each` for the first time via the fuzzer and round-trip specs — crashing on that method's own pre-existing bug (item 48's target). Landed item 47 (`InMemory#none_in_state`, PR #97) and item 48 (`deliver_for_each`, PR #98) FIRST, stacked below this one, so this item's own corpus content is genuinely exercised end to end.

**Corrected from the original source commit**: `Marks#literal_map` uses `read`, not `unmark` — this stack's own `Literal` module was already consolidated (the same evolution `785b90f`/item 51 documents fixing on the original author's own branch), so writing `unmark` here would introduce the exact `NoMethodError` that commit exists to fix, not reintroduce a bug only to re-fix it later.

**`spec/specializer_spec.rb`**: Policy WITHDRAWN with no replacement (not swapped, unlike Handler→Bluebook at item 36) — Policy grew three real list/compound fields, and a real, one-time audit of all twelve contract-backed categories found no genuine second all-plain category left (`Member`'s own `fields: {}` looked like a candidate but is a pre-existing, unrelated mismatch, not papered over).

**`spec/optionality_coverage_spec.rb`**: the `for_each` `ALLOWED_UNSET` entry removed — the corpus now genuinely fills the field, verified through a real dispatch now that item 48's fix is in place.

**Coverage**: `spec/query_policy_self_hosted_round_trip_growth_spec.rb`, 3 examples. Verified genuinely failing without the fix via `git stash` (3/3).

**Verification at this point in the stack**: `bundle exec rspec --no-color` → 1467 examples, 1 failure (stable across two runs) — only the already-documented, out-of-scope `parser_parity_spec` remains (its own diff now additionally shows `wheres`/`with_literals`/`for_each`, the same category of gap items 35/41 already documented).
