### PR TITLE
A value object's from_json silently swallows a mistyped nested key

### DIFF
--- a/rust/codegen/src/domain_generator.rs
+++ b/rust/codegen/src/domain_generator.rs
@@ -147,7 +147,18 @@ pub fn generate(exemplar: &Exemplar, ir: &Json, source_label: &str, mod_name: &s
                 let name = crate::naming::rust_ident(vo.get("name").and_then(Json::as_str).unwrap_or(""));
                 puts_str(&mut out, &json_codec::emit_to_json_flat(exemplar, &name, attrs, false, &[], None));
                 puts_blank(&mut out);
-                puts_str(&mut out, &json_codec::emit_from_json_flat(exemplar, &name, attrs, None, None));
+                // `Some(&[])` — mirrors the Ruby generator's own fix
+                // (rust/project/domain_generator.rb): a value object gets
+                // the same unknown-key refusal an aggregate command's own
+                // args struct already gets below, just with no extra
+                // allowed keys beyond its own declared attributes. Without
+                // this, a mistyped nested VO field (e.g. `{"value": N}`
+                // for a VO that declares `count`) silently fell through to
+                // any `default:` the real field carries, with zero
+                // refusal — found live dispatching a real command through
+                // the compiled binary.
+                let empty_allowlist: [String; 0] = [];
+                puts_str(&mut out, &json_codec::emit_from_json_flat(exemplar, &name, attrs, Some(&empty_allowlist), None));
             }
             puts_blank(&mut out);
         }

--- a/rust/project/domain_generator.rb
+++ b/rust/project/domain_generator.rb
@@ -211,10 +211,26 @@ module RustProjection
               # fresh one (emit_closed_set_table_codec's own header).
               f.puts Projector.emit_closed_set_table_codec(vo)
             else
+              # `unknown_argument_allowlist: []` — a value object gets the
+              # SAME unknown-key refusal an aggregate command's own args
+              # struct already gets (`emit_from_json_flat`'s own header),
+              # just with no extra allowed keys beyond its own declared
+              # attributes (a VO never has an `id`/reference/correlation
+              # key the way a command does). Without this, a caller who
+              # mistypes a nested VO field name (e.g. `{"value": 100000}`
+              # for `Units`, which declares `count`) gets no refusal at
+              # all whenever the REAL field carries a `default:` — the
+              # generated `from_json` just falls through to that default,
+              # silently discarding the caller's actual input. Found live
+              # dispatching `EmbryonautFoundersApp::Member.Admit` through
+              # this exact generated code: `units: {"value": 100000}`
+              # saved as `{"count": 0}`, with `refusals` empty — a real,
+              # silent-wrong-data class of bug, not a caller mistake this
+              # generator should tolerate.
               name = Projector.rust_ident(vo[:name])
               f.puts Projector.emit_to_json_flat(name, vo[:attributes], value_objects_by_name)
               f.puts
-              f.puts Projector.emit_from_json_flat(name, vo[:attributes], value_objects_by_name)
+              f.puts Projector.emit_from_json_flat(name, vo[:attributes], value_objects_by_name, unknown_argument_allowlist: [])
             end
             f.puts
           end


### PR DESCRIPTION
Found live, while dispatching `EmbryonautFoundersApp::Member.Admit` through a freshly-compiled Rust binary generated from a real external app's bluebook: `units: {"value": 100000}` (the wrong key — `Units` declares `count`) saved as `{"count": 0}`, with an **empty** `refusals` array. No error, no warning — the caller's real input was silently discarded.

## Root cause

Both code generators — Ruby's `rust/project/domain_generator.rb` and the from-scratch Rust port `rust/codegen/src/domain_generator.rs` — call `emit_from_json_flat` for a value object's own `from_json` with the unknown-key allowlist left `nil`/`None`. An aggregate command's own top-level args struct already gets a real "unknown argument" refusal (`command_argument_allowlist` / `emit_unknown_argument_check`), but that same protection was never wired up for a **nested** value object. Any field with a declared `default:` falls straight through to it whenever the exact expected key is absent — with zero visibility into whether the caller's JSON carried some *other*, unrecognized key instead of a legitimate omission.

## Fix

Both generators, identically: `unknown_argument_allowlist: []` (Ruby) / `Some(&[])` (Rust) at the one call site each has for a VO's own `from_json` — no extra allowed keys beyond the VO's own declared attributes (a VO never has an `id`/reference/correlation key the way a command does). A mistyped nested field now refuses cleanly:

```
"Units does not declare value — it takes count"
```

instead of silently discarding real input.

## Verification

- The exact malformed payload that surfaced this now refuses through the compiled binary.
- The correctly-shaped payload still succeeds and saves the real value.
- `codegen_parity_spec.rb` confirms both generators still emit byte-identical output after the fix.
- Full suite green twice (1330 examples, 0 failures, default order + `--order random`).
