### PR TITLE
runtime: entity commands run their own argument gate (H1)

### DIFF
--- a/docs/audits/2026-08-11-bug-triage.md
+++ b/docs/audits/2026-08-11-bug-triage.md
@@ -35,13 +35,13 @@ divergences.
 Silent, unrecoverable, or hard-to-detect data corruption. The source audit's
 own #1 priority; nothing supersedes it.
 
-| ID | One-line | File | Confidence |
-| --- | --- | --- | --- |
-| H1 | Entity commands run no argument gate — unknown args silently accepted, absent required args silently overwrite stored data with `nil` | `runtime/entity_interpreter.rb:27` | confirmed |
-| H2 | Era mint isn't atomic — inner `@db.transaction` commits the whole mint early, releasing the advisory lock mid-flight; a later raise leaves a half-born era committed | `adapters/driven/postgres/lineage/head_compiler.rb:38` | confirmed |
-| H3 | Deleting an era-migrated record resurrects it in the head view — the ancestor era's `save` row outranks the (untombstoned) delete forever | `adapters/driven/postgres.rb:192` | likely (static) |
-| H4 | Rekey SQL is invisible to the human-approval digest — two different rekey SQLs produce the identical digest; an approved rekey can be edited post-approval and still mint | `translation/audit/approval_digest.rb` | confirmed |
-| H5 | A dotted-member `compute` (e.g. `price.cents`) exempts the whole attribute from Layer-2's cross-execution equivalence gate — the gate whose entire purpose is to catch silent migration data loss produces zero violations on it | `translation/audit/layer_two.rb:56` | confirmed |
+| ID | One-line | File | Confidence | Status |
+| --- | --- | --- | --- | --- |
+| H1 | Entity commands run no argument gate — unknown args silently accepted, absent required args silently overwrite stored data with `nil` | `runtime/entity_interpreter.rb:27` | confirmed | **Fixed** — PR [#105](https://github.com/chrisyoung/hecksagain/pull/105), issue [#104](https://github.com/chrisyoung/hecksagain/issues/104) |
+| H2 | Era mint isn't atomic — inner `@db.transaction` commits the whole mint early, releasing the advisory lock mid-flight; a later raise leaves a half-born era committed | `adapters/driven/postgres/lineage/head_compiler.rb:38` | confirmed | open |
+| H3 | Deleting an era-migrated record resurrects it in the head view — the ancestor era's `save` row outranks the (untombstoned) delete forever | `adapters/driven/postgres.rb:192` | likely (static) | open |
+| H4 | Rekey SQL is invisible to the human-approval digest — two different rekey SQLs produce the identical digest; an approved rekey can be edited post-approval and still mint | `translation/audit/approval_digest.rb` | confirmed | open |
+| H5 | A dotted-member `compute` (e.g. `price.cents`) exempts the whole attribute from Layer-2's cross-execution equivalence gate — the gate whose entire purpose is to catch silent migration data loss produces zero violations on it | `translation/audit/layer_two.rb:56` | confirmed | open |
 
 H1 and H2 are flagged in the source as the cheapest fixes (two missing
 dispatch-order steps; drop or savepoint the inner transaction).

--- a/lib/hecksagain/language/bluebook/vocabulary.bluebook
+++ b/lib/hecksagain/language/bluebook/vocabulary.bluebook
@@ -207,17 +207,22 @@ Hecks.bluebook "Bluebook" do
 
     # EntityInterpreter#call — the same shape
     # one level down, on a piece an aggregate holds rather than the aggregate
-    # itself. Shorter than AggregateDispatchOrder because an entity is never
-    # CREATED through this path (no assign_creation_attributes) and inherits
-    # its aggregate's own argument gate rather than running one of its own (no
-    # refuse_unknown_arguments) — hydrating the parent and locating the
-    # element replace a single hydrate. resolve_references stayed, though —
-    # an entity command can declare a reference-typed attribute the same way
-    # an aggregate command can (CommandRules#resolve_references is shared by
+    # itself. Shorter than AggregateDispatchOrder for one remaining reason:
+    # an entity is never CREATED through this path (no
+    # assign_creation_attributes) — hydrating the parent and locating the
+    # element replace a single hydrate. It DOES run its own argument gate:
+    # an entity command is addressed through two identities at once (the
+    # parent's and the entity's own), so refuse_unknown_arguments here checks
+    # both sets of heads rather than the aggregate's alone — see
+    # EntityInterpreter::ArgumentGate. resolve_references stayed, too — an
+    # entity command can declare a reference-typed attribute the same way an
+    # aggregate command can (CommandRules#resolve_references is shared by
     # both interpreters), even though nothing in the real corpus does yet.
     value_object "EntityDispatchOrder" do
       attribute :step, String
       one_of do
+        member step: "refuse_unknown_arguments"
+        member step: "refuse_absent_arguments"
         member step: "normalize_args"
         member step: "refuse_role_mismatch"
         member step: "resolve_references"

--- a/lib/hecksagain/runtime/entity_interpreter.rb
+++ b/lib/hecksagain/runtime/entity_interpreter.rb
@@ -6,11 +6,13 @@ require_relative "identity"
 require_relative "instance"
 require_relative "value"
 require_relative "refusal_wording"
+require_relative "entity_interpreter/argument_gate"
 
 module Hecksagain
   module Runtime
     class EntityInterpreter
       include Interpreting
+      include ArgumentGate
 
       attr_reader :registry
 
@@ -19,13 +21,15 @@ module Hecksagain
       # spec/vocabulary_conformance_spec.rb the same way CommandInterpreter's
       # own DISPATCH_ORDER is; see that constant's doc comment for why this is
       # hand-typed rather than read live off the meta-domain at every dispatch.
-      # Shorter than the aggregate order for the same reasons the declaration
-      # itself gives : no refuse_unknown_arguments/refuse_absent_arguments (an
-      # entity inherits its aggregate's own gate) and no
-      # assign_creation_attributes (an entity is never created through this
-      # path).
+      # Shorter than the aggregate order for the one reason that still holds:
+      # no assign_creation_attributes (an entity is never created through
+      # this path). It DOES run its own refuse_unknown_arguments /
+      # refuse_absent_arguments — entity_interpreter/argument_gate.rb — the
+      # comment that used to excuse their absence here was wrong; see H1 in
+      # docs/audits/2026-08-10-main-bug-audit.md.
       DISPATCH_ORDER = %i[
-        normalize_args refuse_role_mismatch resolve_references hydrate_parent
+        refuse_unknown_arguments refuse_absent_arguments normalize_args
+        refuse_role_mismatch resolve_references hydrate_parent
         locate_element enforce_givens admissible_transition apply_mutations
         advance_lifecycle enforce_ensures save emit
       ].freeze
@@ -58,6 +62,14 @@ module Hecksagain
       end
 
       private
+
+      def step_refuse_unknown_arguments(ctx)
+        step(:refuse_unknown_arguments) { refuse_unknown_arguments(ctx.aggregate, ctx.entity, ctx.command, ctx.args) }
+      end
+
+      def step_refuse_absent_arguments(ctx)
+        step(:refuse_absent_arguments) { refuse_absent_arguments(ctx.command, ctx.args) }
+      end
 
       def step_normalize_args(ctx)
         ctx.args = step(:normalize_args) { normalize_args(ctx.aggregate, ctx.command, ctx.args) }

--- a/lib/hecksagain/runtime/entity_interpreter/argument_gate.rb
+++ b/lib/hecksagain/runtime/entity_interpreter/argument_gate.rb
@@ -1,0 +1,56 @@
+require_relative "../../naming"
+require_relative "../errors"
+require_relative "../refusal_wording"
+
+module Hecksagain
+  module Runtime
+    class EntityInterpreter
+      # The payload gate — same contract as CommandInterpreter::ArgumentGate
+      # (a command takes the arguments it declares, all of them, and no
+      # others), but an entity command is addressed through TWO identities at
+      # once: the parent aggregate's (read by `parent`) and the entity's own
+      # (read by `element_of`). Both sets of heads are legitimate addressing
+      # keys, not attributes, and `:id` sugars the parent lookup the same way
+      # it does on the aggregate path.
+      #
+      # This was missing entirely — DISPATCH_ORDER's own comment claimed "an
+      # entity inherits its aggregate's own gate," but nothing on the entity
+      # dispatch path ever ran one. An unknown argument rode along untouched;
+      # a declared-but-absent one resolved to `nil` and silently overwrote
+      # whatever the stored attribute held. See docs/audits — H1.
+      module ArgumentGate
+        private
+
+        def refuse_unknown_arguments(aggregate, entity, command, args)
+          addressing = [:id, *aggregate.identity_heads, *entity.identity_heads]
+          known      = (command.attributes.map(&:name) + addressing).compact.map(&:to_sym)
+          # SORTED — refusal wording is contract, pinned byte-for-byte by the
+          # corpus, so it cannot depend on hash iteration order. Same
+          # reasoning as CommandInterpreter::ArgumentGate.
+          unknown = (args.keys.map(&:to_sym) - known).sort
+          return if unknown.empty?
+
+          raise UnknownArgument,
+                RefusalWording.render("UnknownArgument", "unknown_args",
+                                      command: command.hecks_name, unknown: unknown.join(", "),
+                                      declared: command.attributes.map(&:name).join(", "))
+        end
+
+        # Identical rule and identical wording key to the aggregate path —
+        # what counts as "required" doesn't depend on how the command is
+        # addressed, only on its own declared attributes.
+        def refuse_absent_arguments(command, args)
+          given    = args.keys.map(&:to_sym)
+          required = command.attributes.reject(&:optional?).map { |attribute| attribute.name.to_sym }
+          absent = (required - given).sort
+          return if absent.empty?
+
+          raise AbsentArgument,
+                RefusalWording.render("AbsentArgument", "absent_args",
+                                      command: command.hecks_name, absent: absent.join(", "),
+                                      declared: command.attributes.map(&:name).join(", "))
+        end
+      end
+    end
+  end
+end

--- a/spec/runtime/entity_spec.rb
+++ b/spec/runtime/entity_spec.rb
@@ -63,6 +63,37 @@ RSpec.describe "an entity" do
     expect(ledger[0][:narrative].to_h).to eq(text: "Opening")
   end
 
+  # H1, docs/audits/2026-08-10-main-bug-audit.md: an entity command ran no
+  # argument gate at all — an unknown argument rode along silently, and a
+  # declared-but-absent one resolved to nil and overwrote the stored
+  # attribute. Both halves of the gate now run on the entity path too.
+  it "refuses an argument it never declared, naming it" do
+    runtime = boot_banking
+    funded_account(runtime)
+
+    expect do
+      runtime.dispatch("Banking::Account.LedgerEntry.Reverse",
+                       number: { value: "a1" }, sequence: { value: 2 },
+                       narrative: { text: "Posted in error" }, bogus_arg: 123)
+    end.to raise_error(Hecksagain::Runtime::UnknownArgument, /bogus_arg/)
+
+    ledger = Banking::Account.find("a1").ledger
+    expect(ledger[1][:state]).to eq("posted")
+  end
+
+  it "refuses a declared argument left out, rather than silently nulling the stored value" do
+    runtime = boot_banking
+    funded_account(runtime)
+
+    expect do
+      runtime.dispatch("Banking::Account.LedgerEntry.Reverse", number: { value: "a1" }, sequence: { value: 2 })
+    end.to raise_error(Hecksagain::Runtime::AbsentArgument, /narrative/)
+
+    ledger = Banking::Account.find("a1").ledger
+    expect(ledger[1][:state]).to eq("posted")
+    expect(ledger[1][:narrative].to_h).to eq(text: "Groceries")
+  end
+
   it "has its own state machine, refusing in so many words" do
     runtime = boot_banking
     funded_account(runtime)


### PR DESCRIPTION
Fixes #104.

Stacked on `fix/language-bluebook-validation` (matching this repo's `split/*` PR convention) rather than targeting `main` directly, so this diff doesn't carry that branch's in-flight commits.

## What

`EntityInterpreter::DISPATCH_ORDER` never ran an argument gate — a comment claimed an entity "inherits its aggregate's own gate," but nothing on the entity dispatch path actually ran one. Verified before this fix:
- An unknown argument on an entity command (e.g. `bogus_arg: 123`) was silently accepted.
- A declared-but-omitted argument (e.g. `narrative` on `Account.LedgerEntry.Reverse`) was accepted, and `then_set` resolved it to `nil` — **silently overwriting the stored value with nil**.

## Fix

- New `EntityInterpreter::ArgumentGate` — addresses via both the parent aggregate's `identity_heads` *and* the entity's own, since an entity command is reached through two identities at once (not a straight reuse of `CommandInterpreter::ArgumentGate`, which only knows one).
- Wired into `DISPATCH_ORDER`, ahead of `normalize_args`, matching the aggregate path's ordering.
- `language/bluebook/vocabulary.bluebook`'s `EntityDispatchOrder` closed set + doc comment updated to match (held equal by `spec/vocabulary_conformance_spec.rb`).
- Two regression tests in `spec/runtime/entity_spec.rb`.

## Verification

Full suite (`bundle exec rspec`): 1214 examples, 31 failures — the exact same failure set already present on `fix/language-bluebook-validation` before this branch, verified line-by-line. Zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)