### PR TITLE
runtime: recover H1 + given/ensures reference dereferencing (customer.status)

### DIFF
--- a/docs/audits/2026-08-11-bug-triage.md
+++ b/docs/audits/2026-08-11-bug-triage.md
@@ -35,13 +35,13 @@ divergences.
 Silent, unrecoverable, or hard-to-detect data corruption. The source audit's
 own #1 priority; nothing supersedes it.
 
-| ID | One-line | File | Confidence |
-| --- | --- | --- | --- |
-| H1 | Entity commands run no argument gate — unknown args silently accepted, absent required args silently overwrite stored data with `nil` | `runtime/entity_interpreter.rb:27` | confirmed |
-| H2 | Era mint isn't atomic — inner `@db.transaction` commits the whole mint early, releasing the advisory lock mid-flight; a later raise leaves a half-born era committed | `adapters/driven/postgres/lineage/head_compiler.rb:38` | confirmed |
-| H3 | Deleting an era-migrated record resurrects it in the head view — the ancestor era's `save` row outranks the (untombstoned) delete forever | `adapters/driven/postgres.rb:192` | likely (static) |
-| H4 | Rekey SQL is invisible to the human-approval digest — two different rekey SQLs produce the identical digest; an approved rekey can be edited post-approval and still mint | `translation/audit/approval_digest.rb` | confirmed |
-| H5 | A dotted-member `compute` (e.g. `price.cents`) exempts the whole attribute from Layer-2's cross-execution equivalence gate — the gate whose entire purpose is to catch silent migration data loss produces zero violations on it | `translation/audit/layer_two.rb:56` | confirmed |
+| ID | One-line | File | Confidence | Status |
+| --- | --- | --- | --- | --- |
+| H1 | Entity commands run no argument gate — unknown args silently accepted, absent required args silently overwrite stored data with `nil` | `runtime/entity_interpreter.rb:27` | confirmed | **Fixed** — PR [#105](https://github.com/chrisyoung/hecksagain/pull/105), issue [#104](https://github.com/chrisyoung/hecksagain/issues/104) |
+| H2 | Era mint isn't atomic — inner `@db.transaction` commits the whole mint early, releasing the advisory lock mid-flight; a later raise leaves a half-born era committed | `adapters/driven/postgres/lineage/head_compiler.rb:38` | confirmed | open |
+| H3 | Deleting an era-migrated record resurrects it in the head view — the ancestor era's `save` row outranks the (untombstoned) delete forever | `adapters/driven/postgres.rb:192` | likely (static) | open |
+| H4 | Rekey SQL is invisible to the human-approval digest — two different rekey SQLs produce the identical digest; an approved rekey can be edited post-approval and still mint | `translation/audit/approval_digest.rb` | confirmed | open |
+| H5 | A dotted-member `compute` (e.g. `price.cents`) exempts the whole attribute from Layer-2's cross-execution equivalence gate — the gate whose entire purpose is to catch silent migration data loss produces zero violations on it | `translation/audit/layer_two.rb:56` | confirmed | open |
 
 H1 and H2 are flagged in the source as the cheapest fixes (two missing
 dispatch-order steps; drop or savepoint the inner transaction).

--- a/lib/hecksagain/language/bluebook/vocabulary.bluebook
+++ b/lib/hecksagain/language/bluebook/vocabulary.bluebook
@@ -207,17 +207,22 @@ Hecks.bluebook "Bluebook" do
 
     # EntityInterpreter#call — the same shape
     # one level down, on a piece an aggregate holds rather than the aggregate
-    # itself. Shorter than AggregateDispatchOrder because an entity is never
-    # CREATED through this path (no assign_creation_attributes) and inherits
-    # its aggregate's own argument gate rather than running one of its own (no
-    # refuse_unknown_arguments) — hydrating the parent and locating the
-    # element replace a single hydrate. resolve_references stayed, though —
-    # an entity command can declare a reference-typed attribute the same way
-    # an aggregate command can (CommandRules#resolve_references is shared by
+    # itself. Shorter than AggregateDispatchOrder for one remaining reason:
+    # an entity is never CREATED through this path (no
+    # assign_creation_attributes) — hydrating the parent and locating the
+    # element replace a single hydrate. It DOES run its own argument gate:
+    # an entity command is addressed through two identities at once (the
+    # parent's and the entity's own), so refuse_unknown_arguments here checks
+    # both sets of heads rather than the aggregate's alone — see
+    # EntityInterpreter::ArgumentGate. resolve_references stayed, too — an
+    # entity command can declare a reference-typed attribute the same way an
+    # aggregate command can (CommandRules#resolve_references is shared by
     # both interpreters), even though nothing in the real corpus does yet.
     value_object "EntityDispatchOrder" do
       attribute :step, String
       one_of do
+        member step: "refuse_unknown_arguments"
+        member step: "refuse_absent_arguments"
         member step: "normalize_args"
         member step: "refuse_role_mismatch"
         member step: "resolve_references"

--- a/lib/hecksagain/runtime/command_interpreter.rb
+++ b/lib/hecksagain/runtime/command_interpreter.rb
@@ -78,7 +78,7 @@ module Hecksagain
       end
 
       def step_enforce_givens(ctx)
-        step(:enforce_givens) { @rules.enforce_givens(ctx.instance, ctx.command, ctx.args) }
+        step(:enforce_givens) { @rules.enforce_givens(ctx.instance, ctx.command, ctx.args, domain: ctx.domain) }
       end
 
       def step_admissible_transition(ctx)
@@ -107,7 +107,7 @@ module Hecksagain
       end
 
       def step_enforce_ensures(ctx)
-        step(:enforce_ensures) { @rules.enforce_ensures(ctx.instance, ctx.command, ctx.args, old: ctx.old_state) }
+        step(:enforce_ensures) { @rules.enforce_ensures(ctx.instance, ctx.command, ctx.args, old: ctx.old_state, domain: ctx.domain) }
       end
 
       def step_save(ctx)

--- a/lib/hecksagain/runtime/command_rules/admissibility.rb
+++ b/lib/hecksagain/runtime/command_rules/admissibility.rb
@@ -33,10 +33,32 @@ module Hecksagain
         end
         private_constant :GuardState
 
-        def enforce_givens(subject, command, args)
+        # `domain:` is only needed to dereference a reference-typed field
+        # (`customer.status`) — see References#dereference. `owner` is the
+        # declaring aggregate/entity when `subject` carries one (an
+        # entity's pre-mutation `view` does, same as an aggregate's
+        # `Instance`); a `subject` with no `.aggregate` just hydrates
+        # nothing from state, same as GuardState degrades above.
+        #
+        # MERGE ORDER MATTERS, and it is NOT "args always win": an
+        # unaliased command-level reference dereferences under a
+        # different name than the argument holds (`account_id` the arg,
+        # `account` the hydrated key — no collision, order is moot). An
+        # ALIASED one (`reference_to Customer, as: :customer`) hydrates
+        # under the SAME name the argument itself holds — `customer` is
+        # both the raw id an arg puts there and the key `customer.status`
+        # expects to dig into. If `args` merged last, the raw id (a
+        # String) would win and `.status` on a String is where a fuzzer
+        # found this — TypeError, not a refusal. Command-level
+        # dereferencing is the one thing that is SUPPOSED to override
+        # its own source argument for exactly this reason; args still
+        # wins over stored OWNER state (unchanged from before this fix).
+        def enforce_givens(subject, command, args, domain:)
           state = GuardState.new(subject)
+          owner = subject.aggregate if subject.respond_to?(:aggregate)
+          attrs = dereference(domain, owner, subject).merge(args).merge(dereference(domain, command, args))
           command.givens.each do |given|
-            next if Bluebook::Expression::Evaluator.call(given.canonical, state, args)
+            next if Bluebook::Expression::Evaluator.call(given.canonical, state, attrs)
 
             raise GivenNotMet, "#{command.hecks_name} refused — #{given.description}"
           end
@@ -55,10 +77,16 @@ module Hecksagain
         # Not new to ensures — `given` lives under the same rule — but an
         # ensures is more likely to collide, since it typically re-reads a
         # field the command just took in to mutate it.
-        def enforce_ensures(subject, command, args, old:)
+        def enforce_ensures(subject, command, args, old:, domain:)
           state = GuardState.new(subject)
+          owner = subject.aggregate if subject.respond_to?(:aggregate)
+          # Same merge-order reasoning as enforce_givens above: an
+          # aliased command-level reference must override its own raw
+          # id argument, not the other way round. `old` still wins over
+          # everything, unchanged.
+          attrs = dereference(domain, owner, subject).merge(args).merge(dereference(domain, command, args)).merge(old: old)
           command.ensures.each do |rule|
-            next if Bluebook::Expression::Evaluator.call(rule.canonical, state, args.merge(old: old))
+            next if Bluebook::Expression::Evaluator.call(rule.canonical, state, attrs)
 
             raise EnsuresNotMet, "#{command.hecks_name} refused — #{rule.description}"
           end

--- a/lib/hecksagain/runtime/command_rules/references.rb
+++ b/lib/hecksagain/runtime/command_rules/references.rb
@@ -60,6 +60,54 @@ module Hecksagain
         def referenced_aggregate(attribute)
           attribute.type.resolve
         end
+
+        # A related record's OWN fields, reachable by name from `given`/
+        # `ensures` — `customer.status`, `account.customer.status` — without
+        # teaching the pure expression evaluator anything about
+        # repositories. The lookup happens HERE, once, before evaluation;
+        # `Resolver#lookup` just digs into a plain Hash exactly as it
+        # always has.
+        #
+        # `owner` is either the declaring aggregate/entity (its OWN
+        # `reference_to`, read off `source` — the record's stored state)
+        # or the command itself (a reference-typed ARGUMENT, read off
+        # `source` — the dispatch payload). Same shape either way: every
+        # reference-typed attribute `owner` declares becomes a key in the
+        # result, named by stripping the attribute's own `_id` suffix
+        # (`customer_id` → `customer`) — a no-op for an aliased reference
+        # that already carries no suffix (`reference_to Account, as:
+        # :source` → `source`), which is why this needs no separate case
+        # for `as:`.
+        #
+        # RECURSES into what it finds, so a chain like
+        # `account.customer.status` resolves in one pass: hydrating
+        # `account` also hydrates ITS OWN `customer_id` into a nested
+        # `customer` key. Depth-bounded rather than cycle-detected — nothing
+        # in this corpus dots more than two hops, and a bound is simpler
+        # than tracking visited (type, id) pairs for a cycle nothing here
+        # declares.
+        DEREFERENCE_DEPTH = 4
+        private_constant :DEREFERENCE_DEPTH
+
+        def dereference(domain, owner, source, depth: DEREFERENCE_DEPTH)
+          return {} if depth <= 0 || owner.nil?
+
+          owner.attributes.each_with_object({}) do |attribute, hydrated|
+            next unless attribute.reference?
+
+            id = source[attribute.name]
+            next if id.nil?
+
+            target = referenced_aggregate(attribute)
+            next unless target
+
+            record = @registry.repository(domain, target).find(id.to_s)
+            next unless record
+
+            name = attribute.name.to_s.sub(/_id\z/, "").to_sym
+            hydrated[name] = record.state.merge(dereference(domain, target, record.state, depth: depth - 1))
+          end
+        end
       end
     end
   end

--- a/lib/hecksagain/runtime/entity_interpreter.rb
+++ b/lib/hecksagain/runtime/entity_interpreter.rb
@@ -6,11 +6,13 @@ require_relative "identity"
 require_relative "instance"
 require_relative "value"
 require_relative "refusal_wording"
+require_relative "entity_interpreter/argument_gate"
 
 module Hecksagain
   module Runtime
     class EntityInterpreter
       include Interpreting
+      include ArgumentGate
 
       attr_reader :registry
 
@@ -19,13 +21,15 @@ module Hecksagain
       # spec/vocabulary_conformance_spec.rb the same way CommandInterpreter's
       # own DISPATCH_ORDER is; see that constant's doc comment for why this is
       # hand-typed rather than read live off the meta-domain at every dispatch.
-      # Shorter than the aggregate order for the same reasons the declaration
-      # itself gives : no refuse_unknown_arguments/refuse_absent_arguments (an
-      # entity inherits its aggregate's own gate) and no
-      # assign_creation_attributes (an entity is never created through this
-      # path).
+      # Shorter than the aggregate order for the one reason that still holds:
+      # no assign_creation_attributes (an entity is never created through
+      # this path). It DOES run its own refuse_unknown_arguments /
+      # refuse_absent_arguments — entity_interpreter/argument_gate.rb — the
+      # comment that used to excuse their absence here was wrong; see H1 in
+      # docs/audits/2026-08-10-main-bug-audit.md.
       DISPATCH_ORDER = %i[
-        normalize_args refuse_role_mismatch resolve_references hydrate_parent
+        refuse_unknown_arguments refuse_absent_arguments normalize_args
+        refuse_role_mismatch resolve_references hydrate_parent
         locate_element enforce_givens admissible_transition apply_mutations
         advance_lifecycle enforce_ensures save emit
       ].freeze
@@ -58,6 +62,14 @@ module Hecksagain
       end
 
       private
+
+      def step_refuse_unknown_arguments(ctx)
+        step(:refuse_unknown_arguments) { refuse_unknown_arguments(ctx.aggregate, ctx.entity, ctx.command, ctx.args) }
+      end
+
+      def step_refuse_absent_arguments(ctx)
+        step(:refuse_absent_arguments) { refuse_absent_arguments(ctx.command, ctx.args) }
+      end
 
       def step_normalize_args(ctx)
         ctx.args = step(:normalize_args) { normalize_args(ctx.aggregate, ctx.command, ctx.args) }

--- a/lib/hecksagain/runtime/entity_interpreter.rb
+++ b/lib/hecksagain/runtime/entity_interpreter.rb
@@ -97,7 +97,7 @@ module Hecksagain
       end
 
       def step_enforce_givens(ctx)
-        step(:enforce_givens) { @rules.enforce_givens(ctx.view, ctx.command, ctx.args) }
+        step(:enforce_givens) { @rules.enforce_givens(ctx.view, ctx.command, ctx.args, domain: ctx.domain) }
       end
 
       def step_admissible_transition(ctx)
@@ -121,7 +121,7 @@ module Hecksagain
       def step_enforce_ensures(ctx)
         step(:enforce_ensures) do
           settled = Instance.new(aggregate: ctx.entity, id: ctx.view.id, state: ctx.element)
-          @rules.enforce_ensures(settled, ctx.command, ctx.args, old: ctx.old_element)
+          @rules.enforce_ensures(settled, ctx.command, ctx.args, old: ctx.old_element, domain: ctx.domain)
         end
       end
 

--- a/lib/hecksagain/runtime/entity_interpreter/argument_gate.rb
+++ b/lib/hecksagain/runtime/entity_interpreter/argument_gate.rb
@@ -1,0 +1,56 @@
+require_relative "../../naming"
+require_relative "../errors"
+require_relative "../refusal_wording"
+
+module Hecksagain
+  module Runtime
+    class EntityInterpreter
+      # The payload gate — same contract as CommandInterpreter::ArgumentGate
+      # (a command takes the arguments it declares, all of them, and no
+      # others), but an entity command is addressed through TWO identities at
+      # once: the parent aggregate's (read by `parent`) and the entity's own
+      # (read by `element_of`). Both sets of heads are legitimate addressing
+      # keys, not attributes, and `:id` sugars the parent lookup the same way
+      # it does on the aggregate path.
+      #
+      # This was missing entirely — DISPATCH_ORDER's own comment claimed "an
+      # entity inherits its aggregate's own gate," but nothing on the entity
+      # dispatch path ever ran one. An unknown argument rode along untouched;
+      # a declared-but-absent one resolved to `nil` and silently overwrote
+      # whatever the stored attribute held. See docs/audits — H1.
+      module ArgumentGate
+        private
+
+        def refuse_unknown_arguments(aggregate, entity, command, args)
+          addressing = [:id, *aggregate.identity_heads, *entity.identity_heads]
+          known      = (command.attributes.map(&:name) + addressing).compact.map(&:to_sym)
+          # SORTED — refusal wording is contract, pinned byte-for-byte by the
+          # corpus, so it cannot depend on hash iteration order. Same
+          # reasoning as CommandInterpreter::ArgumentGate.
+          unknown = (args.keys.map(&:to_sym) - known).sort
+          return if unknown.empty?
+
+          raise UnknownArgument,
+                RefusalWording.render("UnknownArgument", "unknown_args",
+                                      command: command.hecks_name, unknown: unknown.join(", "),
+                                      declared: command.attributes.map(&:name).join(", "))
+        end
+
+        # Identical rule and identical wording key to the aggregate path —
+        # what counts as "required" doesn't depend on how the command is
+        # addressed, only on its own declared attributes.
+        def refuse_absent_arguments(command, args)
+          given    = args.keys.map(&:to_sym)
+          required = command.attributes.reject(&:optional?).map { |attribute| attribute.name.to_sym }
+          absent = (required - given).sort
+          return if absent.empty?
+
+          raise AbsentArgument,
+                RefusalWording.render("AbsentArgument", "absent_args",
+                                      command: command.hecks_name, absent: absent.join(", "),
+                                      declared: command.attributes.map(&:name).join(", "))
+        end
+      end
+    end
+  end
+end

--- a/spec/golden/ir/Banking.json
+++ b/spec/golden/ir/Banking.json
@@ -130,7 +130,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"active\"",
+              "description": "customer is active"
+            }
           ],
           "goal": "Stop a customer transacting while something is investigated",
           "mutations": [
@@ -159,7 +162,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"suspended\"",
+              "description": "customer is suspended"
+            }
           ],
           "goal": "Let a cleared customer transact again",
           "mutations": [
@@ -190,7 +196,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "[\"active\", \"suspended\"].include?(status)",
+              "description": "customer is active or suspended"
+            }
           ],
           "goal": "End the relationship",
           "mutations": [
@@ -537,7 +546,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            }
           ],
           "goal": "Give a customer somewhere to keep money",
           "mutations": [
@@ -599,6 +611,10 @@
 
           ],
           "givens": [
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
             {
               "canonical": "status == \"open\"",
               "description": "the account is open"
@@ -665,6 +681,10 @@
           ],
           "givens": [
             {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
               "canonical": "status == \"open\"",
               "description": "the account is open"
             },
@@ -713,7 +733,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": "Stop an account moving while something is investigated",
           "mutations": [
@@ -735,7 +762,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"frozen\"",
+              "description": "account is frozen"
+            }
           ],
           "goal": "Release a cleared account",
           "mutations": [
@@ -757,6 +791,14 @@
 
           ],
           "givens": [
+            {
+              "canonical": "customer.status != \"closed\"",
+              "description": "customer is not closed"
+            },
+            {
+              "canonical": "[\"open\", \"frozen\"].include?(status)",
+              "description": "account is open or frozen"
+            },
             {
               "canonical": "balance.cents.zero?",
               "description": "an account closes empty"
@@ -799,6 +841,14 @@
 
           ],
           "givens": [
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"open\"",
+              "description": "account is open"
+            },
             {
               "canonical": "balance.cents >= amount.cents",
               "description": "the balance covers a fee"
@@ -848,6 +898,14 @@
           ],
           "givens": [
             {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"open\"",
+              "description": "account is open"
+            },
+            {
               "canonical": "fees_cents.cents >= amount.cents",
               "description": "a correction cannot exceed collected fees"
             }
@@ -895,7 +953,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -940,6 +1005,14 @@
 
           ],
           "givens": [
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"open\"",
+              "description": "account is open"
+            },
             {
               "canonical": "interest_cents.cents >= amount.cents",
               "description": "a correction cannot exceed accrued interest"
@@ -1045,6 +1118,10 @@
               ],
               "givens": [
                 {
+                  "canonical": "state == \"posted\"",
+                  "description": "entry is posted"
+                },
+                {
                   "canonical": "amount.cents + adjustment.cents >= 0",
                   "description": "an amendment leaves a non-negative amount"
                 }
@@ -1092,7 +1169,10 @@
 
               ],
               "givens": [
-
+                {
+                  "canonical": "state == \"posted\"",
+                  "description": "entry is posted"
+                }
               ],
               "goal": "Undo a movement that should not have been posted",
               "mutations": [
@@ -1698,7 +1778,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": "Put a card in a customer's hand",
           "mutations": [
@@ -1743,7 +1826,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "[\"issued\", \"active\"].include?(status)",
+              "description": "card is issued or active"
+            }
           ],
           "goal": "Name a card so it is recognisable",
           "mutations": [
@@ -1789,7 +1875,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": "Take cash out at a machine",
           "mutations": [
@@ -1818,7 +1907,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"issued\"",
+              "description": "card is issued"
+            }
           ],
           "goal": "Start using a card",
           "mutations": [
@@ -1840,7 +1932,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "[\"issued\", \"active\"].include?(status)",
+              "description": "card is issued or active"
+            }
           ],
           "goal": "Take a card out of service",
           "mutations": [
@@ -1904,7 +1999,14 @@
 
               ],
               "givens": [
-
+                {
+                  "canonical": "status != \"retired\"",
+                  "description": "card is not retired"
+                },
+                {
+                  "canonical": "state == \"taken\"",
+                  "description": "withdrawal is taken"
+                }
               ],
               "goal": "Challenge a withdrawal that was not mine",
               "mutations": [
@@ -2284,6 +2386,10 @@
           ],
           "givens": [
             {
+              "canonical": "source.status == \"open\"",
+              "description": "source account is open"
+            },
+            {
               "canonical": "!source.to_s.empty?",
               "description": "a transfer names its source"
             },
@@ -2347,7 +2453,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "source.status == \"open\"",
+              "description": "source account is open"
+            },
+            {
+              "canonical": "status == \"requested\"",
+              "description": "transfer is requested"
+            }
           ],
           "goal": "Record that the source account has given up the money",
           "mutations": [
@@ -2369,7 +2482,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "destination.status == \"open\"",
+              "description": "destination account is open"
+            },
+            {
+              "canonical": "status == \"credited\"",
+              "description": "transfer is credited"
+            }
           ],
           "goal": "Record that the destination has received it",
           "mutations": [
@@ -2391,7 +2511,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "destination.status == \"open\"",
+              "description": "destination account is open"
+            },
+            {
+              "canonical": "status == \"debited\"",
+              "description": "transfer is debited"
+            }
           ],
           "goal": "Record that the destination credit committed",
           "mutations": [
@@ -2413,7 +2540,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "source.status == \"open\"",
+              "description": "source account is open"
+            },
+            {
+              "canonical": "status == \"debited\"",
+              "description": "transfer is debited"
+            }
           ],
           "goal": "Put the money back when the credit could not be made",
           "mutations": [
@@ -2435,7 +2569,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"requested\"",
+              "description": "transfer is requested"
+            },
+            {
+              "canonical": "source.status == \"open\"",
+              "description": "source account is open"
+            }
           ],
           "goal": "Refuse a transfer before any money moved",
           "mutations": [
@@ -2699,7 +2840,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -2744,7 +2892,18 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "status == \"authorized\"",
+              "description": "payment is authorized"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -2766,7 +2925,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "status == \"authorized\"",
+              "description": "payment is authorized"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -2788,7 +2954,18 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "status == \"captured\"",
+              "description": "payment is captured"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -2810,7 +2987,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "status == \"captured\"",
+              "description": "payment is captured"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -2840,7 +3024,18 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "disputed_by.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "[\"captured\", \"refunded\"].include?(status)",
+              "description": "payment is captured or refunded"
+            }
           ],
           "goal": "Challenge a payment that already settled",
           "mutations": [
@@ -2869,7 +3064,18 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "status == \"disputed\"",
+              "description": "payment is disputed"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -2891,7 +3097,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "status == \"disputed\"",
+              "description": "payment is disputed"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3214,7 +3427,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3259,7 +3475,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"requested\"",
+              "description": "transfer is requested"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3281,7 +3500,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"sent\"",
+              "description": "transfer is sent"
+            },
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3303,7 +3529,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"sent\"",
+              "description": "transfer is sent"
+            },
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3587,7 +3820,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3632,7 +3868,18 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            },
+            {
+              "canonical": "status == \"scheduled\"",
+              "description": "payment is scheduled"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3654,7 +3901,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"scheduled\"",
+              "description": "payment is scheduled"
+            }
           ],
           "goal": null,
           "mutations": [
@@ -3676,7 +3926,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"scheduled\"",
+              "description": "payment is scheduled"
+            }
           ],
           "goal": "Record that today's presentment could not be collected",
           "mutations": [
@@ -3701,6 +3954,10 @@
             }
           ],
           "givens": [
+            {
+              "canonical": "status == \"failed\"",
+              "description": "payment is failed"
+            },
             {
               "canonical": "attempts.value < max_attempts.value",
               "description": "a retry is still allowed"
@@ -3735,6 +3992,10 @@
 
           ],
           "givens": [
+            {
+              "canonical": "status == \"failed\"",
+              "description": "payment is failed"
+            },
             {
               "canonical": "attempts.value >= max_attempts.value",
               "description": "every retry is exhausted"
@@ -4088,7 +4349,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "status == \"vacant\"",
+              "description": "box is vacant"
+            },
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            }
           ],
           "goal": "Assign the box to a customer",
           "mutations": [
@@ -4118,6 +4386,10 @@
 
           ],
           "givens": [
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
             {
               "canonical": "status == \"rented\"",
               "description": "only a rented box is surrendered"
@@ -4170,6 +4442,10 @@
           ],
           "givens": [
             {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
               "canonical": "status == \"rented\"",
               "description": "only a rented box is opened"
             }
@@ -4210,7 +4486,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"rented\"",
+              "description": "box is rented"
+            }
           ],
           "goal": "Cut a key for the box",
           "mutations": [
@@ -4298,7 +4581,14 @@
 
               ],
               "givens": [
-
+                {
+                  "canonical": "parent.status == \"rented\"",
+                  "description": "box is rented"
+                },
+                {
+                  "canonical": "state == \"logged\"",
+                  "description": "visit is logged"
+                }
               ],
               "goal": "Note something unusual about a visit after the fact",
               "mutations": [
@@ -4387,6 +4677,10 @@
 
               ],
               "givens": [
+                {
+                  "canonical": "parent.status == \"rented\"",
+                  "description": "box is rented"
+                },
                 {
                   "canonical": "status == \"issued\"",
                   "description": "only an issued key is returned"
@@ -4735,7 +5029,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            }
           ],
           "goal": "Open a KYC case for a newly registered customer, naming the account it will become",
           "mutations": [
@@ -4772,7 +5069,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"screening\"",
+              "description": "case is screening"
+            }
           ],
           "goal": "Pass a customer's identity and screening checks",
           "mutations": [
@@ -4794,7 +5098,14 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "customer.status == \"active\"",
+              "description": "customer is active"
+            },
+            {
+              "canonical": "status == \"screening\"",
+              "description": "case is screening"
+            }
           ],
           "goal": "Refuse a customer who does not clear screening — no account was ever opened, so nothing is undone",
           "mutations": [
@@ -5028,7 +5339,10 @@
 
           ],
           "givens": [
-
+            {
+              "canonical": "account.status == \"open\"",
+              "description": "account is open"
+            }
           ],
           "goal": "Close out one period's activity into a permanent record",
           "mutations": [

--- a/spec/golden/ir/Bluebook.json
+++ b/spec/golden/ir/Bluebook.json
@@ -6738,6 +6738,18 @@
             [
               [
                 "step",
+                "refuse_unknown_arguments"
+              ]
+            ],
+            [
+              [
+                "step",
+                "refuse_absent_arguments"
+              ]
+            ],
+            [
+              [
+                "step",
                 "normalize_args"
               ]
             ],

--- a/spec/runtime/command_rules_spec.rb
+++ b/spec/runtime/command_rules_spec.rb
@@ -211,6 +211,109 @@ RSpec.describe "the rules a command obeys" do
     end
   end
 
+  # A `given`/`ensures` reading a RELATED record's own field —
+  # `customer.status`, not just the dispatching record's own attributes.
+  # The pure expression evaluator never gained repository access for
+  # this: CommandRules::References#dereference resolves it BEFORE
+  # evaluation, once, into a plain Hash `Resolver#lookup` digs into
+  # exactly as it always has. Covers both shapes that reach it —
+  # an aggregate's OWN declared reference (Account's `reference_to
+  # Customer`, read off the record's stored state) and a COMMAND's own
+  # reference-typed argument (CardPayment.Authorize's `reference_to
+  # Account`, read off the dispatch payload) — plus the two-hop chain
+  # that composes them.
+  describe "dereferencing a related record's field in given/ensures" do
+    it "reads a stored aggregate-level reference's field, live — not a snapshot taken at dispatch time" do
+      runtime = funded_account(boot_banking)
+
+      expect do
+        runtime.dispatch("Banking::Account.Credit", number: { value: "a1" },
+                         amount: { cents: 100, currency: "USD" }, narrative: { text: "before" })
+      end.not_to raise_error
+
+      runtime.dispatch("Banking::Customer.Suspend", reference: { value: "c" },
+                       standing: { value: "chargeback investigation" })
+
+      expect do
+        runtime.dispatch("Banking::Account.Credit", number: { value: "a1" },
+                         amount: { cents: 100, currency: "USD" }, narrative: { text: "after" })
+      end.to raise_error(Hecksagain::Runtime::GivenNotMet, "Credit refused — customer is active")
+    end
+
+    it "reads a command-level reference argument's field (one hop)" do
+      runtime = funded_account(boot_banking)
+
+      expect do
+        runtime.dispatch("Banking::ATMCard.Issue", account_id: "a1",
+                         serial: { value: "s1" }, daily_fee: { cents: 100 })
+      end.not_to raise_error
+    end
+
+    it "chains through a command-level reference into ITS OWN aggregate-level reference (two hops)" do
+      runtime = funded_account(boot_banking)
+
+      expect do
+        runtime.dispatch("Banking::CardPayment.Authorize", account_id: "a1",
+                         authorisation: { value: "auth1" }, amount: { cents: 500, currency: "USD" },
+                         merchant: { value: "Merchant" })
+      end.not_to raise_error
+
+      runtime.dispatch("Banking::Customer.Suspend", reference: { value: "c" },
+                       standing: { value: "chargeback investigation" })
+
+      expect do
+        runtime.dispatch("Banking::CardPayment.Authorize", account_id: "a1",
+                         authorisation: { value: "auth2" }, amount: { cents: 500, currency: "USD" },
+                         merchant: { value: "Merchant" })
+      end.to raise_error(Hecksagain::Runtime::GivenNotMet, "Authorize refused — customer is active")
+    end
+
+    it "leaves a command with no reference-typed attributes at all untouched" do
+      runtime = boot_till
+      expect { runtime.dispatch("TillRoom::Till.OpenTill", number: { value: "till-1" }) }.not_to raise_error
+    end
+
+    # Found by the fuzzer, not by hand: an ALIASED command-level reference
+    # (`reference_to Customer, as: :customer`) hydrates under the SAME name
+    # its raw id argument already holds — unlike an unaliased one
+    # (`account_id` the argument, `account` the hydrated key, no
+    # collision). The dereferenced Hash must win that collision, or
+    # `customer.status` digs into the raw id string instead — a TypeError,
+    # not a refusal, the moment the id doesn't resolve to a real record.
+    it "resolves an ALIASED command-level reference over its own raw id argument" do
+      runtime = funded_account(boot_banking)
+
+      expect do
+        runtime.dispatch("Banking::OnboardingCase.Open", customer: "c",
+                         reference: { value: "case-1" }, account_number: { value: "a2" })
+      end.not_to raise_error
+
+      runtime.dispatch("Banking::Customer.Suspend", reference: { value: "c" },
+                       standing: { value: "chargeback investigation" })
+
+      expect do
+        runtime.dispatch("Banking::OnboardingCase.Open", customer: "c",
+                         reference: { value: "case-2" }, account_number: { value: "a3" })
+      end.to raise_error(Hecksagain::Runtime::GivenNotMet, "Open refused — customer is active")
+    end
+
+    # The other half of the same bug: an id that does NOT resolve to a real
+    # record must be a clean refusal (whatever the aggregate's own gates
+    # say — here NotFound, from a plain `reference_to Customer, as:
+    # :customer` failing existence at resolve_references, BEFORE givens
+    # ever run) — never the dereferencer's problem to raise a TypeError
+    # over. This is what the fuzzer actually found: a garbage id string
+    # reaching `customer.status` and blowing up on `String#[]`.
+    it "refuses a dangling aliased reference by name, not with a TypeError from inside the guard" do
+      runtime = funded_account(boot_banking)
+
+      expect do
+        runtime.dispatch("Banking::OnboardingCase.Open", customer: "no-such-customer",
+                         reference: { value: "case-3" }, account_number: { value: "a4" })
+      end.to raise_error(Hecksagain::Runtime::NotFound)
+    end
+  end
+
   describe "the rules have one home" do
     it "leaves each interpreter with one verb" do
       surface = lambda do |klass|

--- a/spec/runtime/entity_spec.rb
+++ b/spec/runtime/entity_spec.rb
@@ -63,6 +63,37 @@ RSpec.describe "an entity" do
     expect(ledger[0][:narrative].to_h).to eq(text: "Opening")
   end
 
+  # H1, docs/audits/2026-08-10-main-bug-audit.md: an entity command ran no
+  # argument gate at all — an unknown argument rode along silently, and a
+  # declared-but-absent one resolved to nil and overwrote the stored
+  # attribute. Both halves of the gate now run on the entity path too.
+  it "refuses an argument it never declared, naming it" do
+    runtime = boot_banking
+    funded_account(runtime)
+
+    expect do
+      runtime.dispatch("Banking::Account.LedgerEntry.Reverse",
+                       number: { value: "a1" }, sequence: { value: 2 },
+                       narrative: { text: "Posted in error" }, bogus_arg: 123)
+    end.to raise_error(Hecksagain::Runtime::UnknownArgument, /bogus_arg/)
+
+    ledger = Banking::Account.find("a1").ledger
+    expect(ledger[1][:state]).to eq("posted")
+  end
+
+  it "refuses a declared argument left out, rather than silently nulling the stored value" do
+    runtime = boot_banking
+    funded_account(runtime)
+
+    expect do
+      runtime.dispatch("Banking::Account.LedgerEntry.Reverse", number: { value: "a1" }, sequence: { value: 2 })
+    end.to raise_error(Hecksagain::Runtime::AbsentArgument, /narrative/)
+
+    ledger = Banking::Account.find("a1").ledger
+    expect(ledger[1][:state]).to eq("posted")
+    expect(ledger[1][:narrative].to_h).to eq(text: "Groceries")
+  end
+
   it "has its own state machine, refusing in so many words" do
     runtime = boot_banking
     funded_account(runtime)


### PR DESCRIPTION
Two things, stacked together since the second was found while verifying the first against a fresh baseline:

## 1. Recovers H1 (previously PR #105, force-pushed away)

`fix/language-bluebook-validation` was force-pushed while #105 was merged into it, silently dropping the entity-argument-gate fix (issue #104). Confirmed via `git compare` on GitHub directly — the merge commit is no longer an ancestor of the branch tip, and `entity_interpreter/argument_gate.rb` doesn't exist on the current tip. This PR cherry-picks the original fix (`a2424b6`, `034009f`) back onto the current tip. No changes from the original.

## 2. given/ensures can now resolve a related record's field (customer.status)

Fixes #161. While re-verifying H1 against the latest tip, found that ~20 recent commits on this branch add guard clauses like `given("customer is active") { customer.status == "active" }` across many banking commands — none of which ever dispatched successfully. `customer`/`account`/`source`/`destination`/`disputed_by` were never resolvable; the pure expression evaluator has never supported dereferencing a reference into the record it points at. Confirmed on the raw branch tip with none of my changes.

Fix keeps the pure evaluator (shared by given/ensures/where/translation compute, some of which compile to SQL) untouched — `CommandRules::References#dereference` resolves references before evaluation, at the dispatch-rules layer which already has registry access. Handles aggregate-level and command-level references, recurses for chains like `account.customer.status`, depth-bounded.

A second bug turned up via the fuzzer after the first pass landed: an aliased command-level reference (`reference_to Customer, as: :customer`) hydrates under the same key its raw id argument holds, and my first merge order let the raw id win — `customer.status` on a String id raised `TypeError` instead of a clean refusal whenever the id was garbage. Fixed merge order; regression test included.

## Verification

- 6 new tests in `spec/runtime/command_rules_spec.rb` covering both bugs.
- `spec/fuzzing/properties_spec.rb`'s two previously-failing property tests (the ones that caught bug #2) now pass.
- `spec/golden/ir/{Banking,Bluebook}.json` regenerated (pre-existing staleness from the same upstream churn, caught by the same run).
- Full suite against the true current branch tip, no changes: 1212 examples, 64 failures. With both fixes here: 1220 examples, 46 failures — 18 newly passing, zero new failures (verified failure-by-failure, by description not line number, since line numbers shifted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)