### PR TITLE
adapters/postgres: era mint atomicity (H2) + entity parent.customer.status

### DIFF
--- a/lib/hecksagain/adapters/driven/postgres/lineage/head_compiler.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage/head_compiler.rb
@@ -35,7 +35,22 @@ module Hecksagain
             # journal scan twice). Re-checked under the lock: the fast
             # path above skips locking entirely once any boot has already
             # finished this once, which is every boot after the first.
-            @db.transaction do
+            #
+            # NESTABLE — this runs both standalone (adapter boot, its own
+            # transaction) and from `compile_head!` while `mint_era!` is
+            # already mid-transaction (its manual `BEGIN`, held open for
+            # the era row, every aggregate's matview, and the advisory
+            # lock advance_era! relies on). `@db.transaction` is a bare
+            # BEGIN/COMMIT with no savepoint nesting (see H2 in
+            # docs/audits/2026-08-10-main-bug-audit.md) — called while
+            # already inside a transaction, its COMMIT would end THAT
+            # transaction early, releasing mint's advisory lock and
+            # letting a later step run uncommitted. `nested_transaction`
+            # tells the two cases apart and uses a SAVEPOINT for the
+            # second, so the surrounding mint stays one real transaction
+            # from BEGIN to its own COMMIT regardless of how deep this is
+            # called from.
+            nested_transaction("hecks_head_snapshot") do
               @db.exec_params("SELECT pg_advisory_xact_lock(hashtext('hecks_head_snapshot:' || $1))", [name])
               next if table_exists?(name)
 
@@ -67,6 +82,30 @@ module Hecksagain
 
           def table_exists?(name)
             @db.exec_params("SELECT to_regclass($1) IS NOT NULL AS present", [name]).getvalue(0, 0) == "t"
+          end
+
+          # A transaction wrapper safe to call from inside an already-open
+          # transaction, unlike `PG::Connection#transaction` (bare
+          # BEGIN/COMMIT, no savepoint nesting — see H2). Standalone
+          # (`PQTRANS_IDLE`), this is `@db.transaction` itself: a real
+          # transaction, committed or rolled back on the way out. Nested
+          # (anything else — `PQTRANS_INTRANS` from a manual `BEGIN` like
+          # mint_era!'s, or the gem's own `#transaction`), it's a SAVEPOINT
+          # instead: released on success, rolled back to (then the error
+          # re-raised) on failure, and either way the surrounding
+          # transaction is never touched — no early COMMIT, no early
+          # release of whatever advisory lock it holds.
+          def nested_transaction(name)
+            return @db.transaction { yield } if @db.transaction_status == PG::PQTRANS_IDLE
+
+            @db.exec("SAVEPOINT #{name}")
+            begin
+              yield
+              @db.exec("RELEASE SAVEPOINT #{name}")
+            rescue StandardError
+              @db.exec("ROLLBACK TO SAVEPOINT #{name}")
+              raise
+            end
           end
 
           # Era 1: the head is the snapshot table itself, verbatim — no

--- a/lib/hecksagain/runtime/command_rules/admissibility.rb
+++ b/lib/hecksagain/runtime/command_rules/admissibility.rb
@@ -53,10 +53,21 @@ module Hecksagain
         # dereferencing is the one thing that is SUPPOSED to override
         # its own source argument for exactly this reason; args still
         # wins over stored OWNER state (unchanged from before this fix).
-        def enforce_givens(subject, command, args, domain:)
+        # `parent:` is an entity command's OWN parent aggregate record
+        # (EntityInterpreter's `ctx.instance` — "the PARENT aggregate
+        # record", its own doc comment) — the entity's containment, not a
+        # declared reference attribute, so it doesn't come from
+        # `dereference`'s attribute scan the way `owner`'s do. Hydrated
+        # the same shape regardless: the parent's own state, plus ITS OWN
+        # references dereferenced one level in, so `parent.customer.status`
+        # (a parent aggregate reaching ITS OWN customer) resolves the same
+        # way `account.customer.status` does for a command-level reference.
+        # nil for an aggregate command — CommandInterpreter never passes it.
+        def enforce_givens(subject, command, args, domain:, parent: nil)
           state = GuardState.new(subject)
           owner = subject.aggregate if subject.respond_to?(:aggregate)
           attrs = dereference(domain, owner, subject).merge(args).merge(dereference(domain, command, args))
+          attrs = attrs.merge(parent: dereference(domain, parent.aggregate, parent.state).merge(parent.state)) if parent
           command.givens.each do |given|
             next if Bluebook::Expression::Evaluator.call(given.canonical, state, attrs)
 
@@ -77,14 +88,16 @@ module Hecksagain
         # Not new to ensures — `given` lives under the same rule — but an
         # ensures is more likely to collide, since it typically re-reads a
         # field the command just took in to mutate it.
-        def enforce_ensures(subject, command, args, old:, domain:)
+        def enforce_ensures(subject, command, args, old:, domain:, parent: nil)
           state = GuardState.new(subject)
           owner = subject.aggregate if subject.respond_to?(:aggregate)
           # Same merge-order reasoning as enforce_givens above: an
           # aliased command-level reference must override its own raw
           # id argument, not the other way round. `old` still wins over
           # everything, unchanged.
-          attrs = dereference(domain, owner, subject).merge(args).merge(dereference(domain, command, args)).merge(old: old)
+          attrs = dereference(domain, owner, subject).merge(args).merge(dereference(domain, command, args))
+          attrs = attrs.merge(parent: dereference(domain, parent.aggregate, parent.state).merge(parent.state)) if parent
+          attrs = attrs.merge(old: old)
           command.ensures.each do |rule|
             next if Bluebook::Expression::Evaluator.call(rule.canonical, state, attrs)
 

--- a/lib/hecksagain/runtime/entity_interpreter.rb
+++ b/lib/hecksagain/runtime/entity_interpreter.rb
@@ -97,7 +97,7 @@ module Hecksagain
       end
 
       def step_enforce_givens(ctx)
-        step(:enforce_givens) { @rules.enforce_givens(ctx.view, ctx.command, ctx.args, domain: ctx.domain) }
+        step(:enforce_givens) { @rules.enforce_givens(ctx.view, ctx.command, ctx.args, domain: ctx.domain, parent: ctx.instance) }
       end
 
       def step_admissible_transition(ctx)
@@ -121,7 +121,7 @@ module Hecksagain
       def step_enforce_ensures(ctx)
         step(:enforce_ensures) do
           settled = Instance.new(aggregate: ctx.entity, id: ctx.view.id, state: ctx.element)
-          @rules.enforce_ensures(settled, ctx.command, ctx.args, old: ctx.old_element, domain: ctx.domain)
+          @rules.enforce_ensures(settled, ctx.command, ctx.args, old: ctx.old_element, domain: ctx.domain, parent: ctx.instance)
         end
       end
 

--- a/spec/adapters/driven/postgres/lineage_spec.rb
+++ b/spec/adapters/driven/postgres/lineage_spec.rb
@@ -426,6 +426,51 @@ RSpec.describe "lineage in the Postgres adapter",
     db.close
   end
 
+  # H2, docs/audits/2026-08-10-main-bug-audit.md: every realistic mint-time
+  # refusal in this corpus turns out to be caught by the PRE-mint audit
+  # (CoverageCheck#audit! — "before anything is minted, so a refusal
+  # leaves no half-born era", per its own comment), which runs before
+  # mint_era! is even called — so a DSL-level scenario like the one above
+  # can prove the audit gate works, but can't reach the transaction bug
+  # H2 actually names. This targets the mechanism directly: does
+  # `ensure_head_snapshot!` survive being called from inside an
+  # already-open transaction the way `mint_era!` actually calls it?
+  #
+  # `PG::Connection#transaction` is a bare BEGIN/COMMIT with no savepoint
+  # nesting. Called while already mid-transaction, its COMMIT used to end
+  # THAT transaction the instant this one call returned — so a later
+  # ROLLBACK in the same logical unit of work (mint_era!'s own rescue, on
+  # whatever raises after this point) had nothing left to roll back.
+  it "ensure_head_snapshot! does not end an already-open transaction — a later rollback still undoes it" do
+    check!(V1_SOURCE)
+    registry = load_registry(V1_SOURCE)
+    acct = registry.bluebooks.values.first.aggregate("Acct")
+
+    db = PG.connect(dbname: LINEAGE_DB)
+    lineage = Hecksagain::Adapters::Postgres::Lineage.new(db, "Ledger")
+
+    db.exec("BEGIN")
+    db.exec_params(
+      "INSERT INTO hecks_eras (domain, ordinal, hash, label, held_text, watermark, held_digest, canon_form) " \
+      "VALUES ('Ledger', 99, 'placeholder-hash', 'xxxxxx', 'placeholder', 1, 'placeholder-digest', 1)"
+    )
+    # The call under test — exactly what compile_head! does for each
+    # aggregate mid-mint, on the SAME connection, INSIDE the transaction
+    # just opened above.
+    lineage.ensure_head_snapshot!(acct.storage_name, 99)
+    # Simulates mint_era!'s own rescue clause: a LATER step in the same
+    # logical mint fails, so the whole thing rolls back. If the call
+    # above already ended the transaction, this ROLLBACK has nothing to
+    # undo, and everything above survives it.
+    db.exec("ROLLBACK")
+    db.close
+
+    fresh = PG.connect(dbname: LINEAGE_DB)
+    expect(fresh.exec("SELECT count(*) FROM hecks_eras WHERE domain = 'Ledger' AND ordinal = 99")[0]["count"]).to eq("0")
+    expect(fresh.exec("SELECT to_regclass('acct_head_snapshot_99') IS NULL AS gone")[0]["gone"]).to eq("t")
+    fresh.close
+  end
+
   # ADVERSARIAL, not incidental: found by deliberately constructing a
   # move destination that collides with an existing scalar (most
   # realistically, a has_one/belongs_to reference — a bare id, never an

--- a/spec/runtime/command_rules_spec.rb
+++ b/spec/runtime/command_rules_spec.rb
@@ -312,6 +312,34 @@ RSpec.describe "the rules a command obeys" do
                          reference: { value: "case-3" }, account_number: { value: "a4" })
       end.to raise_error(Hecksagain::Runtime::NotFound)
     end
+
+    # An ENTITY command's given/ensures reaching its own PARENT aggregate
+    # (`parent.status`) and, through it, the parent's OWN reference
+    # (`parent.customer.status`) — a third shape none of the above cover:
+    # `parent` names a structural relationship (EntityInterpreter's own
+    # `ctx.instance`), not a declared reference attribute, so it needs its
+    # own hydration path rather than reusing `dereference`'s attribute
+    # scan directly.
+    it "resolves an entity command's parent.customer.status, live" do
+      runtime = funded_account(boot_banking)
+      runtime.dispatch("Banking::Account.Debit", number: { value: "a1" },
+                       amount: { cents: 100, currency: "USD" }, narrative: { text: "second" })
+      runtime.dispatch("Banking::Account.Debit", number: { value: "a1" },
+                       amount: { cents: 100, currency: "USD" }, narrative: { text: "third" })
+
+      expect do
+        runtime.dispatch("Banking::Account.LedgerEntry.Reverse",
+                         number: { value: "a1" }, sequence: { value: 2 }, narrative: { text: "before" })
+      end.not_to raise_error
+
+      runtime.dispatch("Banking::Customer.Suspend", reference: { value: "c" },
+                       standing: { value: "chargeback investigation" })
+
+      expect do
+        runtime.dispatch("Banking::Account.LedgerEntry.Reverse",
+                         number: { value: "a1" }, sequence: { value: 3 }, narrative: { text: "after" })
+      end.to raise_error(Hecksagain::Runtime::GivenNotMet, "Reverse refused — customer is active")
+    end
   end
 
   describe "the rules have one home" do


### PR DESCRIPTION
Two fixes, stacked (the second was found while re-verifying this branch after the first landed):

## 1. H2 — era mint is not atomic (fixes #163)

\`ensure_head_snapshot!\`'s inner \`@db.transaction\` (bare BEGIN/COMMIT, no savepoint nesting) committed \`mint_era!\`'s outer transaction early whenever called mid-mint — the era row and an earlier aggregate's compiled head became permanent regardless of what failed afterward in the same "atomic" mint. Fixed with a transaction-status-aware \`nested_transaction\` helper: standalone it's \`@db.transaction\` unchanged, nested it's a SAVEPOINT. Regression test confirmed failing without the fix (survives a rollback that should have undone it) and passing with it.

## 2. Entity commands can't resolve `parent.customer.status` (fixes #164)

Follow-up to #161/#162. Entity commands (\`LedgerEntry.Amend\`/\`.Reverse\`) reach their containing aggregate via \`parent.status\`/\`parent.customer.status\` — \`parent\` is a structural relationship (EntityInterpreter's own \`ctx.instance\`), not a declared reference attribute, so the previous fix's attribute scan didn't cover it. \`enforce_givens\`/\`enforce_ensures\` now take an optional \`parent:\`, hydrated the same way command-level references are.

## Verification

- New tests: 1 in \`spec/adapters/driven/postgres/lineage_spec.rb\` (real Postgres), 1 in \`spec/runtime/command_rules_spec.rb\`.
- Full suite: confirmed every failure present after these two commits was already present in a from-scratch raw-tip baseline captured earlier this session (compared by test description, not line number, since upstream churn has been shifting line numbers) — zero new failures from either fix.
- \`spec/runtime/entity_spec.rb\`'s \`"is addressed through the parent, and only that element changes"\` — failing on the raw tip with \`cannot resolve "parent"\` — now passes as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)