### PR TITLE
rust/project: two codegen bugs that stopped the crate compiling (#107)

### DIFF
--- a/rust/project/commands.rb
+++ b/rust/project/commands.rb
@@ -91,6 +91,26 @@ module RustProjection
     # "leave the target non-optional and lose the omission" and "generate
     # something this domain's OWN declarations never asked for" — skipped,
     # loudly, the same as every other ungenerable shape above.
+    # The `transition:` argument `dispatch`/`dispatch_entity` take —
+    # `Some(TransitionCheck)` for a constrained transition, `None` when
+    # there is nothing to check. Shared by the aggregate and entity emit
+    # paths, which build the identical argument from the identical hash.
+    #
+    # `None` covers two different "no check" cases on purpose: no
+    # transition row at all (the command never touches the lifecycle),
+    # and an UNCONSTRAINED row (`from: nil` — admits from any state, so a
+    # check that refuses anything would be wrong). The kernel refuses
+    # whatever `from_states` does not contain, so an unconstrained
+    # transition emitted as an EMPTY slice would refuse every state
+    # instead of admitting every state — the exact inversion of what the
+    # declaration says. See lifecycle_transition_for's own comment.
+    def transition_check_arg(transition)
+      return "None" if transition.nil? || transition[:unconstrained]
+
+      "Some(crate::kernel::TransitionCheck { field: #{transition[:field].inspect}, " \
+        "from_states: &[#{transition[:from_states].map(&:inspect).join(', ')}] })"
+    end
+
     def optional_source_mismatches(command, aggregate, value_objects_by_name)
       lifecycle_field = aggregate[:lifecycle] && aggregate[:lifecycle][:field].to_sym
       problems = []
@@ -253,12 +273,7 @@ module RustProjection
       end
 
       transition = lifecycle_transition_for(command, aggregate)
-      transition_arg =
-        if transition
-          "Some(crate::kernel::TransitionCheck { field: #{transition[:field].inspect}, from_states: &[#{transition[:from_states].map(&:inspect).join(', ')}] })"
-        else
-          "None"
-        end
+      transition_arg = transition_check_arg(transition)
 
       mutation_lines = command[:mutations].map { |m| emit_mutation_line(m, aggregate, command, value_objects_by_name) }
       # advance_lifecycle: unconditional once a transition applies at all —
@@ -405,12 +420,7 @@ module RustProjection
       # `entity` here is exactly that, not a special case either helper
       # needs to know about.
       transition = lifecycle_transition_for(command, entity)
-      transition_arg =
-        if transition
-          "Some(crate::kernel::TransitionCheck { field: #{transition[:field].inspect}, from_states: &[#{transition[:from_states].map(&:inspect).join(', ')}] })"
-        else
-          "None"
-        end
+      transition_arg = transition_check_arg(transition)
 
       mutation_lines = command[:mutations].map { |m| emit_mutation_line(m, entity, command, value_objects_by_name, optional: false) }
       mutation_lines << "        record.#{rust_ident_field(transition[:field])} = #{transition[:to_state].inspect}.to_string();" if transition

--- a/rust/project/mutations.rb
+++ b/rust/project/mutations.rb
@@ -116,13 +116,36 @@ module RustProjection
     # more than one `from:` (CloseAccount: from "open" OR "frozen") shares
     # one `to_state` across every matching row, per the "Lifecycles"
     # section above, so only `from_states` needs to be a list.
+    #
+    # `from: nil` — an UNCONSTRAINED transition, admitting from any state
+    # (`SafeDepositBox`'s own `transition "Create" => "vacant", from: nil`,
+    # a creating command, which by definition has no prior state to come
+    # from). Ruby reads it as `candidates.find { |t| !t.constrained? ||
+    # Array(t.from).include?(current) }` (IR::Lifecycle#constrained? is
+    # `!@from.nil?`) — one unconstrained row admits everything, so the
+    # whole check is skipped. `nil` used to survive into `from_states` and
+    # `.inspect` rendered it as the literal Rust token `nil`, which is not
+    # a Rust value at all: the generated crate did not compile.
+    #
+    # `unconstrained` is carried BESIDE the (compacted) list rather than
+    # returning nil for the whole row, because the caller reads this hash
+    # for TWO independent things — the `TransitionCheck` guard AND the
+    # `advance_lifecycle` assignment of `to_state`. Dropping the row
+    # entirely would silently stop advancing the lifecycle, trading a
+    # compile error for a wrong answer.
     def lifecycle_transition_for(command, aggregate)
       return nil unless aggregate[:lifecycle]
 
       rows = aggregate[:lifecycle][:transitions].select { |t| t[:command] == command[:name] }
       return nil if rows.empty?
 
-      { field: aggregate[:lifecycle][:field], to_state: rows.first[:to_state], from_states: rows.map { |r| r[:from_state] }.uniq }
+      froms = rows.map { |r| r[:from_state] }
+      {
+        field: aggregate[:lifecycle][:field],
+        to_state: rows.first[:to_state],
+        from_states: froms.compact.uniq,
+        unconstrained: froms.any?(&:nil?)
+      }
     end
 
     # Ruby's real `apply`, for `:set`, does `Value.for(aggregate,
@@ -193,13 +216,38 @@ module RustProjection
     # an argument-sourced field runs through the same `value_rhs` bridge
     # `:set` does. `append_field_problems` already confirmed either
     # direction bridges before this could be reached.
+    # `optional:` on either side is NOT a mismatch to skip over here —
+    # `optional_source_mismatches` (commands.rb) has already refused the
+    # one combination that cannot be represented (an optional ARGUMENT
+    # feeding a target field this generator has no reason to
+    # `Option`-wrap). What reaches this method is the supported case, and
+    # it has to bridge the wrapper as well as the type: `args.<name>` is
+    # `Option<T>` for an optional argument (types.rb's own rule), and the
+    # element field is `Option<U>` for an optional field.
+    #
+    # The inner conversion is `value_rhs`'s existing job either way — the
+    # same one-field rewrap it already performs — just applied to the
+    # Option's CONTENTS (`|v| v.value.clone()`) instead of to the whole
+    # expression. Reading `.value` straight off an `Option<T>` is what the
+    # generated crate used to do, and Rust has no such field: E0609, on
+    # the self-hosted grammar's own `Transition.from_state` and
+    # `NormalisationRule.position`.
     def append_field_rhs(source, field_attr, command, value_objects_by_name)
       if source.start_with?("{")
-        literal_hash_rhs(Hecksagain::Bluebook::Assembly::Marks.unmark(source), field_attr[:type], value_objects_by_name)
-      else
-        arg_attr = command[:attributes].find { |a| a[:name].to_s == source }
-        value_rhs("args.#{rust_ident_field(arg_attr[:name])}", arg_attr[:type], field_attr[:type], value_objects_by_name)
+        return literal_hash_rhs(Hecksagain::Bluebook::Assembly::Marks.unmark(source), field_attr[:type], value_objects_by_name)
       end
+
+      arg_attr = command[:attributes].find { |a| a[:name].to_s == source }
+      arg_expr = "args.#{rust_ident_field(arg_attr[:name])}"
+
+      # `as_ref()` so the Option is borrowed, never moved out of `args` —
+      # `args` is borrowed elsewhere in the same generated call (as `&dyn
+      # Fielded`, for given evaluation), the same constraint that makes
+      # every other rhs here `.clone()` rather than take ownership.
+      return "#{arg_expr}.as_ref().map(|v| #{value_rhs('v', arg_attr[:type], field_attr[:type], value_objects_by_name)})" if arg_attr[:optional]
+
+      inner = value_rhs(arg_expr, arg_attr[:type], field_attr[:type], value_objects_by_name)
+      field_attr[:optional] ? "Some(#{inner})" : inner
     end
 
     # `optional:` — true for an aggregate RECORD (every non-list field is


### PR DESCRIPTION
Fixes #107 — the hard block that has made CI red on every PR on this branch, failing at "Build the Rust conformance binary" before rspec or the model check ever ran.

CI regenerates from the current bluebooks rather than trusting the checked-in snapshot (deliberately, so it can't drift). Recent bluebook changes moved past what the generator could emit.

## Two generator bugs

**1. `nil` leaked into Rust source (E0425).** `SafeDepositBox` declares `transition "Create" => "vacant", from: nil` — unconstrained, which Ruby reads as "admits from any state". The `nil` survived into `from_states` and `.inspect` rendered it as the literal token `nil`.

Emitted as `None` now, **not** an empty slice — the kernel refuses whatever `from_states` doesn't contain, so `&[]` would refuse *every* state instead of admitting every state, exactly inverting the declaration. The `unconstrained` flag is carried beside the compacted list rather than dropping the row, because the caller uses that hash for two things: the guard **and** the `advance_lifecycle` assignment. Dropping it would have compiled fine and silently stopped advancing the lifecycle. Verified in the output that `Create` still emits `record.status = "vacant".to_string();` beside its `None`.

**2. `.value` read off an `Option<T>` (E0609).** An `append` sourcing an optional command argument. The self-hosted grammar's `Transition.from_state` and `NormalisationRule.position` are the real cases — legitimately optional on both sides, so the existing `optional_source_mismatches` guard correctly didn't skip them; the emit path just couldn't express them. Now bridges the wrapper as well as the type, reusing `value_rhs` for the inner conversion.

## Verification

Diffed generated output with and without this commit: **exactly 4 lines change across 4 files**, all of them the broken ones — nothing else in the generated tree moves.

- `bin/project_rust examples/banking && cd rust && cargo build --release` — was 4 errors, now `Finished`
- `cargo test --lib` (CI's exemplar step) — ok
- `bin/model_check` — clean

Only `rust/project/*.rb` changes. `rust/Cargo.toml` and `rust/src/generated/` are deliberately untouched: regenerating for banking flips the default feature (`pizzas` → `banking`) and rewrites a snapshot predating these bluebook changes, and CI regenerates both itself.

## CI is not green after this

This clears the *hard block* — the build steps now pass and rspec is reachable. `bundle exec rspec` still fails, on failures predating this commit plus **two `rust_conformance` fixtures this fix makes reachable for the first time**: the Rust runtime can't resolve `customer.status`, so the recent guard commits are currently a Ruby-only feature. Filed as #167, with the design question (port it to Rust, or reconsider reading across an aggregate boundary in a `given`) called out rather than answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)