### PR TITLE
Salvage from fix/language-bluebook-validation: H2 atomicity, a latent codegen trap, array literals, and the audit record

### DIFF
--- a/docs/audits/2026-08-11-bug-triage.md
+++ b/docs/audits/2026-08-11-bug-triage.md
@@ -1,0 +1,231 @@
+# Bug triage — 2026-08-10 audit, prioritized
+
+_2026-08-11._ Every finding in [`2026-08-10-main-bug-audit.md`](2026-08-10-main-bug-audit.md),
+reorganized into priority tiers. That file stays the source of truth for
+detail (reproductions, code snippets, confidence); this file is an index and
+an ordering.
+
+## Methodology note
+
+**This is a reorganization, not a re-verification.** Nothing here was
+re-checked against current code — treat every item's status as "reported
+2026-08-10, unconfirmed since." A day of dev/QA work has landed on top of
+that snapshot (multiple QA sessions, the quality-control bluebook, entity
+and query bug fixes — see `qa/reports/` and recent memory), so some of these
+may already be fixed, or partially fixed. **Re-verify a finding before
+starting work on it**, and check `qa/reports/` first in case it's already
+tracked (and possibly already resolved) there under a different name.
+
+Priority within a tier follows the source audit's own severity/confidence
+signals (blast radius, silence, confirmed vs. likely/possible) — it is not a
+new judgment call layered on top.
+
+**ID scheme:** `S1`–`S3` and `H1`–`H14` are the source audit's own labels.
+`M1`–`M29`, `L1`–`L24`, and `R1`–`R5` are assigned here (medium/low/Rust-parity
+were unlabeled bullets in the source) — use these IDs when opening a fix or
+cross-referencing `qa/reports/`.
+
+75 findings total: 3 systemic, 14 high, 29 medium, 24 low, 5 Rust parity
+divergences.
+
+---
+
+## Tier 1 — Data loss / migration integrity (fix first)
+
+Silent, unrecoverable, or hard-to-detect data corruption. The source audit's
+own #1 priority; nothing supersedes it.
+
+| ID | One-line | File | Confidence | Status |
+| --- | --- | --- | --- | --- |
+| H1 | Entity commands run no argument gate — unknown args silently accepted, absent required args silently overwrite stored data with `nil` | `runtime/entity_interpreter.rb:27` | confirmed | **Fixed** — PR [#105](https://github.com/chrisyoung/hecksagain/pull/105), issue [#104](https://github.com/chrisyoung/hecksagain/issues/104) |
+| H2 | Era mint isn't atomic — inner `@db.transaction` commits the whole mint early, releasing the advisory lock mid-flight; a later raise leaves a half-born era committed | `adapters/driven/postgres/lineage/head_compiler.rb:38` | confirmed | **Fixed** — PR [#165](https://github.com/chrisyoung/hecksagain/pull/165), issue [#163](https://github.com/chrisyoung/hecksagain/issues/163) |
+| H3 | Deleting an era-migrated record resurrects it in the head view — the ancestor era's `save` row outranks the (untombstoned) delete forever | `adapters/driven/postgres.rb:192` | likely (static) | open |
+| H4 | Rekey SQL is invisible to the human-approval digest — two different rekey SQLs produce the identical digest; an approved rekey can be edited post-approval and still mint | `translation/audit/approval_digest.rb` | confirmed | open |
+| H5 | A dotted-member `compute` (e.g. `price.cents`) exempts the whole attribute from Layer-2's cross-execution equivalence gate — the gate whose entire purpose is to catch silent migration data loss produces zero violations on it | `translation/audit/layer_two.rb:56` | confirmed | open |
+
+H1 and H2 are flagged in the source as the cheapest fixes (two missing
+dispatch-order steps; drop or savepoint the inner transaction).
+
+---
+
+## Tier 2 — Systemic root causes (fix next — each retires a cluster)
+
+Single points that fan out into multiple downstream bugs elsewhere in this
+document. Fixing the root is expected to retire (or at least shrink) the
+related medium-severity query findings noted below.
+
+| ID | One-line | File | Confidence | Likely retires |
+| --- | --- | --- | --- | --- |
+| S1 | `render_value` collapses every non-symbol to `.to_s` on the IR wire, erasing type tags — `"007"→7`, `"true"→true`, `nil→""`, `eq: nil` compiles to `= ''` instead of IS NULL | `query_specification/common/comparators.rb:6` | confirmed | M1, M2, M4 (query-engine type/nil divergences) |
+| S2 | `h[k.to_sym] \|\| h[k]` (5+ call sites) turns a stored `false` into `nil` via Ruby's `\|\|`-falls-through-on-false — `where(flags.active: false)` never matches | `field_path.rb:44` + 4 others | confirmed | any boolean-leaf query/`ne` bug not otherwise attributed |
+| S3 | An aggregate's identity, free-form unless `pattern:`-constrained, flows unescaped into URLs and HTML — root of H10 and H12 | (see H10, H12) | — | H10, H12, L12 |
+
+---
+
+## Tier 3 — Security
+
+Before the Rust web surface (or any operator tooling) takes more untrusted
+exposure.
+
+| ID | One-line | File | Confidence |
+| --- | --- | --- | --- |
+| H10 | Stored XSS via record id — the Rust web layer interpolates the aggregate id raw into link text/`href`/`<title>`/`<h1>`; every other value routes through `esc()`. Ruby presentation layer is unaffected. | `rust/host/src/web.rs:639,706` | likely |
+| H11 | Session HMAC fails open on an empty `SESSION_SECRET` — unset, cookie/OAuth-state HMAC keys on a known empty string. Not currently exploitable (prod sets it from Secrets Manager) but fails open instead of refusing to boot, unlike every other required var. | `rust/host/src/web.rs:90` | likely (latent) |
+| L12 | Record ids are HTML-escaped but never URL-encoded in `href`/`Location` — `&`, `+`, `?`, `#` in an id corrupt the link | `presentation/record_renderer.rb:75` | — |
+| L20 | `rename-schema` interpolates `$(OLD)`/`$(NEW)` unsanitized into SQL — operator-only, but against prod RDS | `bin/project_deploy:1517` | — |
+
+---
+
+## Tier 4 — Wrong-answer / broken-route bugs on live paths
+
+Confirmed or likely-live silent-wrong-answer bugs, grouped by subsystem.
+Ordered high-severity first, then the medium-severity items most likely
+related to (or exposed by) S1/S2 above.
+
+**Query/routing (high):**
+
+| ID | One-line | File |
+| --- | --- | --- |
+| H6 | `limit` applied before `offset` in the in-memory query port — `limit 10 offset 10` on 30 rows returns 0 rows instead of rows 11–20 | `ports/query/in_memory.rb:21` |
+| H7 | Reference/entity query engine ignores `offset`, and reads fields directly instead of via `FieldPath.dig` — dotted `where`/`order_by` silently wrong on the *only* engine for entity queries | `runtime/query_interpreter.rb:78,149,261` |
+| H8 | `seal_defaults` doesn't cover `one_of` closed sets — a documented-in-its-own-comment case boots clean, then refuses every create at dispatch | `bluebook/dsl/aggregate_builder.rb:228` |
+| H9 | Meta-validator cache key omits read-model filters — a same-process reload after editing only a filter serves the stale one | `bluebook/meta_validator.rb:127` |
+| H12 | Record ids containing `.` are unroutable — detail page, JSON view, and index link all 404 | `presentation/app.rb:70` |
+
+**Query engine semantics (medium — likely related to S1/S2):**
+
+| ID | One-line | File |
+| --- | --- | --- |
+| M1 | `ne` matches nil-held rows in memory; SQL `<>` excludes NULL | `ports/query/in_memory.rb:33` |
+| M2 | `in` stringifies both sides, matching across types and `nil`↔`""` | `ports/query/in_memory.rb:37` |
+| M3 | Default NULL ordering diverges between memory (SQLite convention) and Postgres | `query_specification/common/null_policy.rb:16` |
+| M4 | Multi-numeric value object unwraps to first-numeric in one engine, whole hash in the other — `gt`/`lt` silently false on one side | `ports/query/in_memory.rb:74` vs `query_interpreter.rb:250` |
+| M5 | `FieldPath#read` violates its "or nil, never raise" contract — raises `TypeError` through an Array | `query_specification/field_path.rb:45` |
+
+**Expression sublanguage (medium):**
+
+| ID | One-line | File |
+| --- | --- | --- |
+| M6 | Negated membership (`!names.include?(x)`) is inexpressible — all three spellings raise | `bluebook/expression/evaluator.rb:69` |
+| M7 | Canonical-form normalisation rewrites string-literal *contents*, quote-blind | `bluebook/expression/canonical_form.rb:39` |
+| M8 | `modulo` truncates floats and zero-checks before coercion → raw `ZeroDivisionError` | `bluebook/expression/resolver.rb:201` |
+| M9 | Raw `TypeError`s cross the `DomainRefusal` boundary | `resolver.rb:212` / `evaluator.rb:72` |
+
+**IR round-trip losses (medium):**
+
+| ID | One-line | File |
+| --- | --- | --- |
+| M10 | `formerly_known_as` and chapter-level `@ports` are ivars absent from `to_h` — lost on IR round-trip | `bluebook/ir/bluebook.rb:69` |
+| M11 | `correlates_by` maps `nil → ""` on the wire | `bluebook/ir/process_manager.rb:113` |
+
+**DSL sealing / assembly (medium):**
+
+| ID | One-line | File |
+| --- | --- | --- |
+| M12 | Duplicate attribute names both survive into IR — nothing refuses them | `bluebook/dsl/attribute_collector.rb:34` |
+| M13 | An entity's attribute types are never resolved as references — undeclared type boots clean | `meta_validator/judge.rb:260` |
+| M14 | Entity query hops are not sealed — `where` through an undeclared aggregate boots clean | `bluebook_builder.rb:195` |
+| M15 | Object-literal decoders corrupt on an embedded `"`; under Ruby ≥3.4 every object-literal default/binding decodes to `{}` | `marks.rb:171` / `meta_validator/shapes.rb:94` |
+| M16 | `plural`/`singularize` are not inverses for `-es` — `has_many Boxes` refuses a phantom `Boxe` | `naming.rb:61` + `aggregate_builder.rb:88` |
+
+**Runtime (medium):**
+
+| ID | One-line | File |
+| --- | --- | --- |
+| M17 | A composite-identity creating command that doesn't redeclare its heads as attributes persists them as `nil` | `runtime/instance.rb:95` |
+| M18 | `Identity.of` raises `NoMethodError` on a non-string identity part where a refusal belongs | `runtime/identity.rb:63` |
+| M19 | In-process vs. SQLite read-model paths diverge on missing heads/root/join scope | `read_model_interpreter.rb:78` vs `sqlite/projection.rb:39` |
+| M20 | `@reaction_depth` is a plain (non-thread-local) ivar on a thread-shared dispatcher — matches the known Puma-concurrency bug class | `dispatcher.rb:165` |
+
+---
+
+## Tier 5 — Ops & translation correctness
+
+| ID | One-line | File |
+| --- | --- | --- |
+| H13 | `make deploy` always exits non-zero for Shared-mode domains — the unautomated `mint-era` stub `exit 1`s after a successful `sam deploy`, training operators to ignore red deploys | `bin/project_deploy` |
+| H14 | Generated `scaffold-translation`/`translation-audit` targets open a real prod SSM tunnel, then silently scaffold/audit the developer's *local* DB instead | `bin/project_deploy:1389` |
+| M26 | Layer 1 checks lifecycle values against targets only, not `ModelCheck.full_states` — a valid `from:`-only state blocks the mint | `translation/audit/layer_one.rb:24` |
+| M27 | Sequential in-place rename loses data on swap/chain renames (`{a:b,b:a}` on `{a:1,b:2}` → `{a:1}`) — Layer 2's reference, so the compiled SQL agrees and it mints silently | `ports/persistence/lineage.rb:92` |
+| M28 | Adding Google OAuth to a live stack deadlocks `make deploy` — pre-deploy `mint-era` queries outputs the deploy hasn't created yet | `bin/project_deploy:1818` |
+| M29 | RDS master passwords may contain `%`, invalid in libpq's URI parser — ~29% of 32-char passwords | `bin/project_deploy:816` |
+| L15 | `bin/project` missing the executable bit | — |
+| L16 | `bin/present --port=8080` (equals form) silently ignored; `-p abc` binds an ephemeral port | `bin/present:64` |
+| L17 | `bin/evolve`'s `option` swallows a following flag as its value | `bin/evolve:48` |
+| L18 | `bin/evolve rename` has no rescue/ensure — a mid-cascade raise leaves `syntax.bluebook` half-renamed | `bin/evolve:63` |
+| L19 | `bin/stores` on a nonexistent domain path exits 0 with no output | `bin/stores:14` |
+| L13 | `reset!` on a lineage-provisioned journal (FORCE RLS, no DELETE policy) silently deletes zero rows | `adapters/driven/postgres.rb:225` |
+
+---
+
+## Tier 6 — Harness / test-quality blind spots
+
+Fixing these doesn't fix a product bug directly, but it's why several of the
+above stayed hidden behind a green suite — and why fixes to them need new
+coverage, not just a patch.
+
+| ID | One-line | File |
+| --- | --- | --- |
+| M21 | Three shipped framework aggregates (RoleAssignment, RoleTransition via composite id; ConsoleSettings `Replace*` via `list_of`) are half-unfuzzable — every acting step refused, zero events | `fuzzing/sequence_generator/outcome_tracker.rb:14` + `step_builder.rb:36` |
+| M22 | `saga_advances_follow_declared_handlers` passes vacuously — the log copies `from:`/`to:` from the handler it's then checked against | `fuzzing/properties.rb:61` |
+| M23 | The query oracle masks refusal-shaped divergence — both engines share one `begin`, an entry where either raised is skipped | `fuzzing/replay.rb:49` |
+| M24 | `shrink_arguments` never accumulates drops — each accepted drop reverts the previous ones | `bin/fuzz:139` |
+| M25 | `RoleTransition` has an absorbing `revoked` state — a revoked pair can never be re-granted, contradicting its own header comment | `framework/bluebook/governance.bluebook:84` |
+| R1 | 6 events differ on the full corpus (not the 3 pinned fixtures) — Rust emits `nil` for an omitted optional arg where Ruby omits the key | `rust/src/kernel/json.rs:178` |
+| R2 | Refusal counts diverge, Ruby 94 vs Rust 131 — 37 "query steps not generated yet" placeholders shift every later index | `rust/src/kernel/cli.rs:76` |
+| R3 | Dispatch-order inversion — Rust checks role/references before VO invariant/admits/pattern; Ruby is the reverse. Same bad input → different refusal per runtime. | `rust/project/registry.rb:116` |
+| R4 | Empty-string identity component accepted by Rust, rejected by Ruby — real persisted-state divergence | `rust/src/kernel/*` (`to_id_component`) vs `Identity.of` |
+| R5 | `cargo build --features banking` fails to compile (mutually-exclusive domain features unmarked); plus latent codegen landmines (a domain named `version`/`edition`/`path`/`default`, or a description with `#{`/`#@`/control chars) | `Cargo.toml`, `bin/project_rust:160` |
+
+The recorded Rust-parity status ("35/35 instances") only holds for the 3
+pinned fixtures — R1–R4 surface only against the full corpus.
+
+---
+
+## Tier 7 — Low severity (cosmetic, latent, or gated behind untriggered input)
+
+Everything from the source audit's Low section not already placed above.
+
+| ID | One-line | File |
+| --- | --- | --- |
+| L1 | `catch_up!` only enforces history consistency under the exact symbol `:strict` | `ports/projection.rb:44` |
+| L2 | Chained non-root heads are still declaration-order dependent one level deeper than the root-first fix reached | `runtime/read_model_interpreter.rb:55` |
+| L3 | `Dir[…].first` reproduces the multi-file wrong-source bug `EraCheck` already fixed elsewhere; only reached from a spec today | `runtime/era_guard.rb:29` |
+| L4 | `sign_of` returns `-1` for any op without a sign; unreachable today | `runtime/command_rules/arithmetic.rb:85` |
+| L5 | `match_transition` falls back to `matches.first` when no `from:` admits the state; dead code, zero callers | `bluebook/ir/lifecycle.rb:58` |
+| L6 | A multi-column `one_of` is admitted on its first column only | `runtime/value/admission.rb:14` |
+| L7 | `one_of` member values are stringified in `to_h` (`Integer 1 → "1"`) | `bluebook/ir/value_object.rb:57` |
+| L8 | Possessive-quantifier check doesn't skip character-class interiors — `[*+]` wrongly refused, `a{2}+` wrongly admitted | `bluebook/pattern_subset.rb:88` |
+| L9 | `validate_command!` accepts creating-command names a `Handle` can't dispatch → `NoMethodError` instead of 404 | `facade/json_door.rb:85` |
+| L10 | `run_query` omits `JSON::ParserError` from its rescue list — a malformed list-of-VO query 500s instead of a 422 | `presentation/app.rb:200` |
+| L11 | A record whose id equals a command/query name shadows its own detail page | `presentation/app.rb:106` |
+| L14 | SQLite/D1 store literal `"null"` text where Postgres stores SQL NULL — decodes the same today, diverges under a future `IS NULL` check | `adapters/driven/sqlite.rb:86` / `d1.rb:136` |
+| L21 | `f64→i64` cast saturates silently where Ruby keeps a Bignum | `rust/src/kernel/json.rs:108` |
+| L22 | `Int + Int` uses plain `+` (debug panic / release wrap) where Ruby promotes to Bignum | `rust/src/kernel/expr.rs:239` |
+| L23 | `nest()`'s `.as_object_mut().unwrap()` panics (500) on a scalar/group path-prefix collision | `rust/host/src/web.rs:562` |
+| L24 | Post-accept redirect id is `mutations.last().last()`, which can belong to a cascaded reaction's aggregate, not the form's target | `rust/host/src/web.rs:748` |
+
+---
+
+## Cleared (no action — carried forward from source audit)
+
+SQL identifier quoting and JSONB path building in the Postgres adapter;
+`search_path` schema isolation; ORDER BY tiebreakers; the `Handle`
+composite-identity fix; `JsonDoor` wiring; the Ruby presentation layer's
+HTML escaping; comma-bearing `contains`; `AppendOnly#save`'s shallow dup;
+the `rust_conformance` comparison logic itself.
+
+---
+
+## Harness baseline (from the source audit, unchanged)
+
+| Harness | Result @ 2026-08-10 |
+| --- | --- |
+| RSpec | 1170 examples, 0 real failures |
+| Property fuzzer (`bin/fuzz --seeds 60 --steps 40`) | clean |
+| IR model checker (`bin/model_check`) | clean |
+| Rust `cargo test` | passes, zero unit tests exist |
+
+Re-run before trusting this baseline for any fix — this branch
+(`fix/language-bluebook-validation`) currently has 53 unrelated pre-existing
+`rspec` failures as of 2026-08-11 that this snapshot predates.

--- a/lib/hecksagain/adapters/driven/postgres/lineage/head_compiler.rb
+++ b/lib/hecksagain/adapters/driven/postgres/lineage/head_compiler.rb
@@ -35,7 +35,22 @@ module Hecksagain
             # journal scan twice). Re-checked under the lock: the fast
             # path above skips locking entirely once any boot has already
             # finished this once, which is every boot after the first.
-            @db.transaction do
+            #
+            # NESTABLE — this runs both standalone (adapter boot, its own
+            # transaction) and from `compile_head!` while `mint_era!` is
+            # already mid-transaction (its manual `BEGIN`, held open for
+            # the era row, every aggregate's matview, and the advisory
+            # lock advance_era! relies on). `@db.transaction` is a bare
+            # BEGIN/COMMIT with no savepoint nesting (see H2 in
+            # docs/audits/2026-08-10-main-bug-audit.md) — called while
+            # already inside a transaction, its COMMIT would end THAT
+            # transaction early, releasing mint's advisory lock and
+            # letting a later step run uncommitted. `nested_transaction`
+            # tells the two cases apart and uses a SAVEPOINT for the
+            # second, so the surrounding mint stays one real transaction
+            # from BEGIN to its own COMMIT regardless of how deep this is
+            # called from.
+            nested_transaction("hecks_head_snapshot") do
               @db.exec_params("SELECT pg_advisory_xact_lock(hashtext('hecks_head_snapshot:' || $1))", [name])
               next if table_exists?(name)
 
@@ -67,6 +82,30 @@ module Hecksagain
 
           def table_exists?(name)
             @db.exec_params("SELECT to_regclass($1) IS NOT NULL AS present", [name]).getvalue(0, 0) == "t"
+          end
+
+          # A transaction wrapper safe to call from inside an already-open
+          # transaction, unlike `PG::Connection#transaction` (bare
+          # BEGIN/COMMIT, no savepoint nesting — see H2). Standalone
+          # (`PQTRANS_IDLE`), this is `@db.transaction` itself: a real
+          # transaction, committed or rolled back on the way out. Nested
+          # (anything else — `PQTRANS_INTRANS` from a manual `BEGIN` like
+          # mint_era!'s, or the gem's own `#transaction`), it's a SAVEPOINT
+          # instead: released on success, rolled back to (then the error
+          # re-raised) on failure, and either way the surrounding
+          # transaction is never touched — no early COMMIT, no early
+          # release of whatever advisory lock it holds.
+          def nested_transaction(name)
+            return @db.transaction { yield } if @db.transaction_status == PG::PQTRANS_IDLE
+
+            @db.exec("SAVEPOINT #{name}")
+            begin
+              yield
+              @db.exec("RELEASE SAVEPOINT #{name}")
+            rescue StandardError
+              @db.exec("ROLLBACK TO SAVEPOINT #{name}")
+              raise
+            end
           end
 
           # Era 1: the head is the snapshot table itself, verbatim — no

--- a/lib/hecksagain/bluebook/expression/resolver.rb
+++ b/lib/hecksagain/bluebook/expression/resolver.rb
@@ -29,6 +29,14 @@ module Hecksagain
         FloatLiteral   = Struct.new(:value, keyword_init: true)
         StringLiteral  = Struct.new(:value, keyword_init: true)
         BoolLiteral    = Struct.new(:value, keyword_init: true)
+        # `["active", "suspended"]` — a literal set, the haystack half of
+        # an `.include?`. Vocabulary::IncludeHaystack has always ADMITTED
+        # Array (and Evaluator#includes? has always had a `when Array`
+        # arm), but nothing could produce one: there was no array-literal
+        # node, so `["a", "b"].include?(x)` fell through to Lookup and
+        # refused with `cannot resolve "[\"a\", \"b\"]"`. A declared
+        # capability with no way to spell it.
+        ArrayLiteral   = Struct.new(:elements, keyword_init: true)
         # A plain class, not `Struct.new(keyword_init: true)` — every
         # sibling leaf node here carries at least one field, but this
         # one carries none by nature (a nil literal has no data to
@@ -198,6 +206,8 @@ module Hecksagain
           return BoolLiteral.new(value: true)                 if expr == "true"
           return BoolLiteral.new(value: false)                if expr == "false"
           return NilLiteral.new                                if expr == "nil"
+          elements = array_elements(expr)
+          return ArrayLiteral.new(elements: elements.map { |element| parse(element) }) if elements
 
           arithmetic = split_addition(expr)
           return Addition.new(left: parse(arithmetic[0]), right: parse(arithmetic[1])) if arithmetic
@@ -279,6 +289,7 @@ module Hecksagain
         def interpret(node, state, attrs)
           case node
           when IntegerLiteral, FloatLiteral, StringLiteral, BoolLiteral then node.value
+          when ArrayLiteral then node.elements.map { |element| interpret(element, state, attrs) }
           when NilLiteral then nil
           when Addition
             add(interpret(node.left, state, attrs), interpret(node.right, state, attrs))
@@ -358,6 +369,42 @@ module Hecksagain
           options |= Regexp::EXTENDED   if flags.include?("x")
 
           Regexp.new(pattern, options).match?(text)
+        end
+
+        # The elements of a bracketed literal, or nil if this isn't one.
+        # Splits on TOP-LEVEL commas only — quote-aware and depth-aware,
+        # the same discipline `split_addition` already applies, so a
+        # nested array or a comma inside a string element stays whole.
+        def array_elements(expr)
+          return nil unless expr.start_with?("[") && expr.end_with?("]")
+
+          inner = expr[1..-2].strip
+          return [] if inner.empty?
+
+          elements = []
+          depth = 0
+          quote = nil
+          current = +""
+          inner.each_char do |char|
+            if quote
+              quote = nil if char == quote
+              current << char
+              next
+            end
+            case char
+            when '"', "'" then quote = char
+            when "[", "(" then depth += 1
+            when "]", ")" then depth -= 1
+            end
+            if char == "," && depth.zero?
+              elements << current.strip
+              current = +""
+            else
+              current << char
+            end
+          end
+          elements << current.strip
+          elements.reject(&:empty?)
         end
 
         def split_addition(expr)

--- a/qa/reports/2026-08-12.md
+++ b/qa/reports/2026-08-12.md
@@ -1,0 +1,92 @@
+# QA Session Report — 2026-08-12
+
+**Session status:** COMPLETE
+**Focus:** Triaging the 2026-08-10 bug audit, fixing Tier 1 findings, unblocking CI, and reconciling `fix/language-bluebook-validation` against `main`
+**Method:** every claim below was **run**, not read. Where something is unverified, it says so.
+
+---
+
+## Headline
+
+`main` is **fully green — 1482 examples, 0 failures**.
+`fix/language-bluebook-validation` is **not — 1319 examples, 45 failures**, and 19 spec files behind.
+
+This is not inherited breakage. `safe_deposit_box_spec`, `query_comparators_spec` and `entity_spec` **pass 23/23 on `main`** and fail on the branch. The branch regressed them.
+
+---
+
+## Shipped (merged)
+
+| Issue | What | PR |
+| --- | --- | --- |
+| #104 | **H1** — entity commands ran no argument gate; an omitted declared argument resolved to `nil` and silently overwrote stored data | #105, recovered in #162 |
+| #161 | `given`/`ensures` could not resolve a related record's field (`customer.status`) | #162 |
+| #164 | …nor an entity command's `parent.customer.status` | #165 |
+| #163 | **H2** — era mint was not atomic; a nested `@db.transaction` committed the whole mint early and released the advisory lock mid-flight | #165 |
+| #107 | **CI hard block** — two codegen bugs stopped the Rust crate compiling at all | #168 |
+
+## Open
+
+| Issue | What |
+| --- | --- |
+| #167 | Rust runtime cannot resolve `customer.status` — the new guards are Ruby-only, so 2 conformance fixtures diverge. Mechanism built and compiling; **cannot land** because the generated tree holds domains (`embryonaut`) whose bluebooks are not in this repo and so cannot be regenerated to match. |
+| #169 | Array literals now spellable (`["open","frozen"].include?(status)`) — **49 → 45 failures**. PR open. |
+| #170 | Reconciliation plan for this branch. |
+
+---
+
+## Root cause of the branch's failures
+
+The guard commits added, in `banking.bluebook`:
+
+- `customer.status` / `account.status` — **branch 77, main 1**
+- array-literal guards — **branch 5, main 0**
+
+Both used expression forms the language did not support. **None were dispatched before being committed.** Two of the three classes are now fixed (#161/#164, #169).
+
+What remains is mostly **not runtime bugs**. The representative failure:
+
+```
+Authorize refused — customer is active
+```
+
+The guard is working correctly; the spec's fixture suspends a customer and then expects a later dispatch to succeed, which the new rule rightly forbids. The guards changed what is legal; the fixtures were never updated.
+
+Still outstanding and probably a **real second defect**: the `safe_deposit_box_spec` cluster (9 failures), `no SafeDepositBox with branch_code.value, box_number.value "DOWNTOWN:12"` — composite-identity lookup.
+
+---
+
+## Correcting the record: `2026-08-12-SESSION.md`
+
+That report predates this session and its conclusions are contradicted by measurement. Recording this because it was **relied on**, not to relitigate it.
+
+| It claimed | Measured |
+| --- | --- |
+| "**Bugs Found This Session:** 0 (verification only)" | 3 distinct runtime/language defects found and fixed (#161, #164, #169), plus 2 codegen defects (#107) |
+| "✅ **Composite Identity Handling** — SafeDepositBox tested: works correctly" | `safe_deposit_box_spec` fails **9/9** on that exact path |
+| "✅ **Reference Integrity** — cross-aggregate references verified" | `customer.status` was **completely unresolvable** — 77 call sites, none able to dispatch |
+| "✅ **Banking Domain Commands** — 57 commands checked… All correct" | Covers the guard commits that could never run |
+| "**41 test failures** … **Assessment: NOT BUGS** … tests need updates" | Partly true, partly not. Some were real language defects, now fixed. And the cause is not "pattern validation" — it is this branch's own guards; `main` runs the same specs green. |
+
+**The pattern worth naming:** that report verified by *reading* and reported it as ✅. The earlier handover note in this repo flagged the sibling failure mode — `FIXED` meaning *committed* rather than *verified*, twice. A report asserting "0 bugs, all verified" is more harmful than no report, because it suppresses exactly the re-checking that surfaced 45 real failures.
+
+**Suggested gate:** a ✅ in these reports should require a command and its output. If it was not run, mark it *unverified* rather than passed.
+
+---
+
+## Recommended order of work
+
+1. ~~cross-aggregate dereferencing~~ (done)
+2. ~~array literals~~ (#169)
+3. `safe_deposit_box_spec` composite identity — investigate; likely a real bug
+4. update spec fixtures that violate the new guards
+5. **then** merge `main`'s 158 commits — deliberately last, so conflicts in `banking.bluebook` (both sides rewrote it heavily) are resolved against a branch that is already green
+
+---
+
+## Verification notes
+
+- Suite numbers taken with **all other agents stopped**, so they are stable and reproducible.
+- `main` baseline measured in a clean worktree off `origin/main`, full `CI=1` run.
+- CI results confirmed on **real CI**, not just locally: after #168, `Build the Rust conformance binary` and `Build the exemplar module` both pass for the first time on this branch; the local and CI rspec counts matched exactly (1319 / 49).
+- Every fix landed with regression tests; the #169 fix was checked to add no new failures.

--- a/rust/project/commands.rb
+++ b/rust/project/commands.rb
@@ -2,6 +2,20 @@ module RustProjection
   module Projector
     module_function
 
+    # The `transition:` argument `dispatch`/`dispatch_entity` take.
+    # `None` covers two different "no check" cases on purpose: no
+    # transition row at all, and an UNCONSTRAINED row (`from: nil` —
+    # admits from any state). The kernel refuses whatever `from_states`
+    # does not contain, so an unconstrained transition emitted as an
+    # EMPTY slice would refuse every state instead of admitting every
+    # state — the exact inversion of what the declaration says.
+    def transition_check_arg(transition)
+      return "None" if transition.nil? || transition[:unconstrained]
+
+      "Some(crate::kernel::TransitionCheck { field: #{transition[:field].inspect}, " \
+        "from_states: &[#{transition[:from_states].map(&:inspect).join(', ')}] })"
+    end
+
     def command_skip_reason(command, aggregate, value_objects_by_name)
       unsupported_ops = command[:mutations].reject { |m| %w[append set increment decrement].include?(m[:op].to_s) }.map { |m| m[:op] }.uniq
       return "then_set op(s) #{unsupported_ops.join(', ')} not generated yet (only append/set/increment/decrement are)" if unsupported_ops.any?
@@ -268,11 +282,7 @@ module RustProjection
 
       transition = lifecycle_transition_for(command, aggregate)
       transition_arg =
-        if transition
-          "Some(crate::kernel::TransitionCheck { field: #{transition[:field].inspect}, from_states: &[#{transition[:from_states].map(&:inspect).join(', ')}] })"
-        else
-          "None"
-        end
+        transition_check_arg(transition)
 
       mutation_lines = command[:mutations].map { |m| emit_mutation_line(m, aggregate, command, value_objects_by_name) }
       # advance_lifecycle: unconditional once a transition applies at all —
@@ -432,11 +442,7 @@ module RustProjection
       # needs to know about.
       transition = lifecycle_transition_for(command, entity)
       transition_arg =
-        if transition
-          "Some(crate::kernel::TransitionCheck { field: #{transition[:field].inspect}, from_states: &[#{transition[:from_states].map(&:inspect).join(', ')}] })"
-        else
-          "None"
-        end
+        transition_check_arg(transition)
 
       mutation_lines = command[:mutations].map { |m| emit_mutation_line(m, entity, command, value_objects_by_name, optional: false) }
       mutation_lines << "        record.#{rust_ident_field(transition[:field])} = #{transition[:to_state].inspect}.to_string();" if transition

--- a/rust/project/mutations.rb
+++ b/rust/project/mutations.rb
@@ -136,7 +136,26 @@ module RustProjection
       rows = aggregate[:lifecycle][:transitions].select { |t| t[:command] == command[:name] }
       return nil if rows.empty?
 
-      { field: aggregate[:lifecycle][:field], to_state: rows.first[:to_state], from_states: rows.map { |r| r[:from_state] }.uniq }
+      # `from: nil` — an UNCONSTRAINED transition, admitting from any
+      # state (a creating command has no prior state to come from).
+      # Ruby reads it as `!t.constrained? || Array(t.from).include?(...)`
+      # (IR::Lifecycle#constrained? is `!@from.nil?`), so one such row
+      # admits everything and the whole check is skipped. Left in,
+      # `nil.inspect` renders as the literal Rust token `nil`, which is
+      # not a Rust value: the generated crate does not compile.
+      #
+      # Carried BESIDE the compacted list rather than returning nil for
+      # the row, because the caller reads this hash for TWO things — the
+      # TransitionCheck guard AND the advance_lifecycle assignment of
+      # to_state. Dropping the row would compile and silently stop
+      # advancing the lifecycle: a wrong answer traded for a build error.
+      froms = rows.map { |r| r[:from_state] }
+      {
+        field: aggregate[:lifecycle][:field],
+        to_state: rows.first[:to_state],
+        from_states: froms.compact.uniq,
+        unconstrained: froms.any?(&:nil?)
+      }
     end
 
     # Ruby's real `apply`, for `:set`, does `Value.for(aggregate,

--- a/spec/adapters/driven/postgres/lineage_spec.rb
+++ b/spec/adapters/driven/postgres/lineage_spec.rb
@@ -426,6 +426,51 @@ RSpec.describe "lineage in the Postgres adapter",
     db.close
   end
 
+  # H2, docs/audits/2026-08-10-main-bug-audit.md: every realistic mint-time
+  # refusal in this corpus turns out to be caught by the PRE-mint audit
+  # (CoverageCheck#audit! — "before anything is minted, so a refusal
+  # leaves no half-born era", per its own comment), which runs before
+  # mint_era! is even called — so a DSL-level scenario like the one above
+  # can prove the audit gate works, but can't reach the transaction bug
+  # H2 actually names. This targets the mechanism directly: does
+  # `ensure_head_snapshot!` survive being called from inside an
+  # already-open transaction the way `mint_era!` actually calls it?
+  #
+  # `PG::Connection#transaction` is a bare BEGIN/COMMIT with no savepoint
+  # nesting. Called while already mid-transaction, its COMMIT used to end
+  # THAT transaction the instant this one call returned — so a later
+  # ROLLBACK in the same logical unit of work (mint_era!'s own rescue, on
+  # whatever raises after this point) had nothing left to roll back.
+  it "ensure_head_snapshot! does not end an already-open transaction — a later rollback still undoes it" do
+    check!(V1_SOURCE)
+    registry = load_registry(V1_SOURCE)
+    acct = registry.bluebooks.values.first.aggregate("Acct")
+
+    db = PG.connect(dbname: LINEAGE_DB)
+    lineage = Hecksagain::Adapters::Postgres::Lineage.new(db, "Ledger")
+
+    db.exec("BEGIN")
+    db.exec_params(
+      "INSERT INTO hecks_eras (domain, ordinal, hash, label, held_text, watermark, held_digest, canon_form) " \
+      "VALUES ('Ledger', 99, 'placeholder-hash', 'xxxxxx', 'placeholder', 1, 'placeholder-digest', 1)"
+    )
+    # The call under test — exactly what compile_head! does for each
+    # aggregate mid-mint, on the SAME connection, INSIDE the transaction
+    # just opened above.
+    lineage.ensure_head_snapshot!(acct.storage_name, 99)
+    # Simulates mint_era!'s own rescue clause: a LATER step in the same
+    # logical mint fails, so the whole thing rolls back. If the call
+    # above already ended the transaction, this ROLLBACK has nothing to
+    # undo, and everything above survives it.
+    db.exec("ROLLBACK")
+    db.close
+
+    fresh = PG.connect(dbname: LINEAGE_DB)
+    expect(fresh.exec("SELECT count(*) FROM hecks_eras WHERE domain = 'Ledger' AND ordinal = 99")[0]["count"]).to eq("0")
+    expect(fresh.exec("SELECT to_regclass('acct_head_snapshot_99') IS NULL AS gone")[0]["gone"]).to eq("t")
+    fresh.close
+  end
+
   # ADVERSARIAL, not incidental: found by deliberately constructing a
   # move destination that collides with an existing scalar (most
   # realistically, a has_one/belongs_to reference — a bare id, never an


### PR DESCRIPTION
`fix/language-bluebook-validation` is being abandoned — 259 ahead / 180 behind, with 45 failures of its own making against a green main. These are the pieces worth keeping, each **re-verified against main** rather than trusted from the branch.

**H2 — era mint is not atomic (#163).** Confirmed still live on main before porting: `BEGIN` at `mint_transaction.rb:19` → `compile_head!` at `:45` → `ensure_head_snapshot!` at `head_compiler.rb:274` → `@db.transaction` at `:38`. pg's `#transaction` is a bare BEGIN/COMMIT with no savepoint nesting, so it ended the outer transaction early and released the advisory lock mid-mint. Regression test proved to fail without the fix.

**The `nil` half of #107.** `from: nil` rendered as the literal Rust token `nil`. Latent on main (nothing writes `from: nil` here) but it converts "someone writes one" into "the crate won't compile." Emitted as `None`, **not** an empty slice — the kernel refuses whatever isn't in `from_states`, so `&[]` would invert the meaning.

**Not ported:** that issue's `Option<T>` half — main already fixes it more thoroughly via `optional_value_rhs`.

**Array literals.** `IncludeHaystack` admits Array and the evaluator has a `when Array` arm, but no array-literal node existed — a declared capability with no way to spell it.

**Docs:** the audit, its triage, and the 2026-08-12 report.

## Verification
`1577 examples, 3 failures` — the **same 3 on pristine `origin/main`** with none of this applied (a schema-evolution doctest racing on a fixed global Postgres DB name, plus two `load_hygiene` examples). **Zero regressions.** `cargo build --release` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)