### PR TITLE
load hygiene: every file requires what it references, again — main fully green

### DIFF
--- a/docs/guides/schema-evolution.md
+++ b/docs/guides/schema-evolution.md
@@ -278,9 +278,9 @@ round-trip — `Hecksagain::Ports::Persistence::Lineage` is the exact
 code every mint runs internally, and it answers directly:
 
 ```ruby
-Move    = Hecksagain::Bluebook::IR::TranslationMove
-Convert = Hecksagain::Bluebook::IR::TranslationConvert
-Retype  = Hecksagain::Bluebook::IR::TranslationRetype
+Move    = Hecksagain::Bluebook::TranslationMove
+Convert = Hecksagain::Bluebook::TranslationConvert
+Retype  = Hecksagain::Bluebook::TranslationRetype
 Entry   = Hecksagain::Ports::Persistence::Entry
 Lineage = Hecksagain::Ports::Persistence::Lineage
 ```

--- a/lib/hecksagain/adapters/driven/folder.rb
+++ b/lib/hecksagain/adapters/driven/folder.rb
@@ -1,3 +1,5 @@
+require_relative "../../vocabulary"
+
 module Hecksagain
   module Adapters
     class Folder

--- a/lib/hecksagain/bluebook/attribute.rb
+++ b/lib/hecksagain/bluebook/attribute.rb
@@ -1,4 +1,6 @@
 require_relative "behaviour/attribute"
+require_relative "../ir"
+require_relative "../vocabulary"
 
 module Hecksagain
   module Bluebook

--- a/lib/hecksagain/bluebook/chapter.rb
+++ b/lib/hecksagain/bluebook/chapter.rb
@@ -1,4 +1,5 @@
 require_relative "behaviour/chapter"
+require_relative "../ir"
 
 module Hecksagain
   module Bluebook

--- a/lib/hecksagain/bluebook/expression/canonical_form.rb
+++ b/lib/hecksagain/bluebook/expression/canonical_form.rb
@@ -1,4 +1,5 @@
 require "json"
+require_relative "../../vocabulary"
 
 module Hecksagain
   module Bluebook

--- a/lib/hecksagain/bluebook/expression/evaluator.rb
+++ b/lib/hecksagain/bluebook/expression/evaluator.rb
@@ -1,4 +1,5 @@
 require "json"
+require_relative "../../vocabulary"
 
 module Hecksagain
   module Bluebook

--- a/lib/hecksagain/bluebook/expression/resolver.rb
+++ b/lib/hecksagain/bluebook/expression/resolver.rb
@@ -1,5 +1,6 @@
 require "json"
 require_relative "../../rendering"
+require_relative "../../vocabulary"
 
 module Hecksagain
   module Bluebook

--- a/lib/hecksagain/bluebook/hexagon.rb
+++ b/lib/hecksagain/bluebook/hexagon.rb
@@ -1,4 +1,5 @@
 require_relative "behaviour/hexagon"
+require_relative "../ir"
 
 module Hecksagain
   module Bluebook

--- a/lib/hecksagain/bluebook/process_manager.rb
+++ b/lib/hecksagain/bluebook/process_manager.rb
@@ -1,4 +1,5 @@
 require_relative "behaviour/process_manager"
+require_relative "../ir"
 
 module Hecksagain
   module Bluebook

--- a/lib/hecksagain/projections/ir.rb
+++ b/lib/hecksagain/projections/ir.rb
@@ -1,3 +1,5 @@
+require_relative "../projector"
+
 module Hecksagain
   module Projections
     # The canonical IR, as a constant. The implementation already existed

--- a/lib/hecksagain/projections/model.rb
+++ b/lib/hecksagain/projections/model.rb
@@ -1,4 +1,5 @@
 require_relative "model/deviations"
+require_relative "../projector"
 
 module Hecksagain
   module Projections

--- a/lib/hecksagain/projections/oidc.rb
+++ b/lib/hecksagain/projections/oidc.rb
@@ -1,4 +1,5 @@
 require_relative "../naming"
+require_relative "../projector"
 
 module Hecksagain
   module Projections

--- a/lib/hecksagain/projections/parser_table.rb
+++ b/lib/hecksagain/projections/parser_table.rb
@@ -1,3 +1,5 @@
+require_relative "../projector"
+
 module Hecksagain
   module Projections
     # THE RUST PARSER'S KEYWORD TABLE, projected from the chapter's own

--- a/lib/hecksagain/projections/reference.rb
+++ b/lib/hecksagain/projections/reference.rb
@@ -1,4 +1,5 @@
 require_relative "../doc/reference"
+require_relative "../projector"
 
 module Hecksagain
   module Projections

--- a/lib/hecksagain/projections/shape.rb
+++ b/lib/hecksagain/projections/shape.rb
@@ -1,4 +1,5 @@
 require_relative "../runtime/storage_shape"
+require_relative "../projector"
 
 module Hecksagain
   module Projections

--- a/lib/hecksagain/projections/vocabulary.rb
+++ b/lib/hecksagain/projections/vocabulary.rb
@@ -1,3 +1,5 @@
+require_relative "../projector"
+
 module Hecksagain
   module Projections
     # THE CLOSED SETS, PROJECTED — lib/hecksagain/vocabulary.rb rendered

--- a/lib/hecksagain/query_specification/common/comparators.rb
+++ b/lib/hecksagain/query_specification/common/comparators.rb
@@ -1,4 +1,5 @@
 require_relative "../../literal"
+require_relative "../../vocabulary"
 
 module Hecksagain
   module QuerySpecification

--- a/lib/hecksagain/runtime/errors.rb
+++ b/lib/hecksagain/runtime/errors.rb
@@ -1,4 +1,5 @@
 require_relative "value/invariant_violation"
+require_relative "../vocabulary"
 
 
 module Hecksagain


### PR DESCRIPTION
`main` was **1577 examples / 3 failures**. All three shared one root cause — constants moved, references didn't follow — not the environmental Postgres race the 2026-08-10 audit assumed for one of them.

**`load_hygiene_spec` (2).** The discipline from `1701bd9` drifted back out: 18 files referenced a constant they never required, so each loaded only in the order the app happens to use and broke for anyone requiring it directly. Swept the spec's own standalone-load check **to convergence** rather than patching the first layer — each fix surfaced the next, three rounds deep.

Seven were mechanical mis-resolutions worth flagging: `projections/*.rb` reference `Projector::IRProjector`/`Projector::Target` — that's `Hecksagain::Projector`, **not** the `claude_code` adapter a naive constant search lands on first.

**`schema-evolution.md` (1).** The guide spelled `Bluebook::IR::TranslationMove`; those structs now live at `Bluebook::TranslationMove`. The doctest was doing its job — executing the docs and refusing to let them lie.

## Verified — full CI equivalent
```
CI=1 bundle exec rspec                      1577 examples, 0 failures
bin/project_rust + cargo build --release    0 errors
cargo test --lib (exemplar)                 ok
bin/model_check                             clean
```

Closes #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)