### PR TITLE
bin/project_rust: name the gap that's actually still open

### DIFF
--- a/bin/project_rust
+++ b/bin/project_rust
@@ -32,7 +32,12 @@ domain = ARGV.shift or abort "usage: bin/project_rust <domain>"
 # `rust/parser`'s `hecks-parse`/`rust/codegen`'s `hecks-codegen`
 # instead, with ZERO `Kernel.load` of any domain bluebook — see
 # `rust/project_rust_pipeline.rb`'s own header for the full contract
-# and its one deliberately-named gap (the `lineage` sidecar key).
+# and its one deliberately-named gap (`manifest.json`, coverage
+# bookkeeping only). The `lineage` sidecar key this comment used to name
+# as that gap is CLOSED — `derive_lineage` computes it there for real,
+# proven byte-exact against this default path's own `Exporter.lineage`
+# by `spec/project_rust_pipeline_spec.rb` for both pizzas (a real
+# capable aggregate) and banking (real binds, zero capable).
 #
 # PAIRED, not independently toggleable: `HECKS_PARSER=rust` alone would
 # mean "parse in Rust, then hand a Rust-shaped ir.json to the STILL-Ruby


### PR DESCRIPTION
The stage-8 header still advertised the `lineage` sidecar key as the opt-in Rust path's one deliberate gap. It hasn't been for a while:

- `rust/project_rust_pipeline.rb::derive_lineage` computes it from a narrow `.hecksagon` `persisted_by` text scan
- `spec/project_rust_pipeline_spec.rb` proves it byte-exact against the default path's own `Exporter.lineage` for pizzas (a real capable aggregate) and banking (real binds, zero capable)
- `hecks-build` ports the same pass into Rust (`rust/build/src/lineage_pass.rs`)

`manifest.json` is the gap that survives. Points there instead, and records that lineage is closed so the next reader doesn't re-derive it.

Comment only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtSHx39Uxdr5bzMAkLmm31