### PR TITLE
fix(rendering): Runtime::Value no longer leaks a raw object pointer into refusal messages

### DIFF
--- a/lib/hecksagain/rendering.rb
+++ b/lib/hecksagain/rendering.rb
@@ -21,7 +21,27 @@ module Hecksagain
       case value
       when nil then "nil"
       when Hash, Array then JSON.generate(value)
-      else value.inspect
+      else
+        # A Hecksagain::Runtime::Value reaching a refusal message (an
+        # arithmetic op's own `amount`/`current`, an Admissibility
+        # `current`, ...) had no case here, falling straight through to
+        # Ruby's own #inspect and leaking a raw object pointer
+        # ("#<Hecksagain::Runtime::Value:0x...>") into an otherwise
+        # correct domain refusal. Duck-typed on `respond_to?(:to_h)`
+        # rather than naming `Runtime::Value` directly — `Runtime::Value`
+        # itself requires THIS file (`runtime/value.rb`'s own
+        # `require_relative "../rendering"`), so naming it here would be
+        # circular. A single-field wrapper (the overwhelming common case
+        # — an amount, an id, a lifecycle field) unwraps to its bare
+        # scalar, described recursively; a genuinely multi-field value
+        # renders as its fields' JSON, same as a bare Hash already does
+        # two lines up.
+        if value.respond_to?(:to_h) && !value.is_a?(Hash) && !value.is_a?(Array)
+          fields = value.to_h
+          fields.size == 1 ? describe(fields.values.first) : JSON.generate(fields)
+        else
+          value.inspect
+        end
       end
     end
   end

--- a/spec/rendering_spec.rb
+++ b/spec/rendering_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+# `Rendering.describe` left a `Hecksagain::Runtime::Value` with no case,
+# falling straight through to Ruby's own `#inspect` and leaking a raw
+# object pointer ("#<Hecksagain::Runtime::Value:0x...>") into an otherwise
+# correct domain refusal message (an arithmetic op's own amount/current, an
+# Admissibility current, ...). Duck-typed on `respond_to?(:to_h)` rather
+# than naming `Runtime::Value` directly — that class itself requires this
+# file, so naming it here would be circular. These doubles stand in for it:
+# a single-field wrapper (the common VO shape — an amount, an id, a
+# lifecycle field) unwraps to its bare scalar; a genuinely multi-field
+# value renders as its fields' JSON, same as a bare Hash already does.
+RSpec.describe "Rendering.describe" do
+  SingleField = Struct.new(:cents) do
+    def to_h = { cents: cents }
+  end
+
+  MultiField = Struct.new(:given, :family) do
+    def to_h = { given: given, family: family }
+  end
+
+  it "unwraps a single-field wrapper to its bare scalar, described recursively" do
+    expect(Hecksagain::Rendering.describe(SingleField.new(500))).to eq("500")
+  end
+
+  it "renders a multi-field wrapper as its fields' JSON" do
+    expect(Hecksagain::Rendering.describe(MultiField.new("Annie", "Easley")))
+      .to eq('{"given":"Annie","family":"Easley"}')
+  end
+
+  it "still renders a bare Hash/Array via JSON, not the value-object branch" do
+    expect(Hecksagain::Rendering.describe({ cents: 100 })).to eq('{"cents":100}')
+    expect(Hecksagain::Rendering.describe([1, 2])).to eq("[1,2]")
+  end
+
+  it "renders nil and a plain scalar exactly as before" do
+    expect(Hecksagain::Rendering.describe(nil)).to eq("nil")
+    expect(Hecksagain::Rendering.describe(42)).to eq("42")
+    expect(Hecksagain::Rendering.describe("plain")).to eq('"plain"')
+  end
+end


### PR DESCRIPTION
## The bug

`Rendering.describe` had no case for a `Hecksagain::Runtime::Value` — an arithmetic op's own `amount`/`current` (`command_rules/arithmetic.rb`), an `Admissibility` `current`, a VO-typed coercion failure's `offered` — falling straight through to Ruby's own `#inspect` and leaking a raw object pointer (`"#<Hecksagain::Runtime::Value:0x...>"`) into an otherwise correct domain refusal message.

`inspect` and JSON already agree on scalars and disagree on everything composite — the file's own header notes both known cases (a Hash, an Array) were found by something deliberately passing the wrong shape rather than by review. A `Runtime::Value` reaching this method is the same class of gap: invisible until a real refusal carries one, at which point the message stops being useful (a caller — or a test asserting on refusal text — sees an object pointer instead of the value that was actually wrong).

## The fix

Duck-typed on `respond_to?(:to_h)` rather than naming `Runtime::Value` directly — that class itself requires this file (`runtime/value.rb`'s own `require_relative "../rendering"`), so naming it here would be circular, the same guard `Resolver#unwrap_scalar` already uses for the identical reason.

- A single-field wrapper (the common VO shape — an amount, an id, a lifecycle field) unwraps to its bare scalar, described recursively.
- A genuinely multi-field value renders as its fields' JSON, same as a bare Hash already does two lines up.
- `nil`, plain scalars, bare `Hash`/`Array` all render exactly as before — no other case's output changes.

No new functionality — this is a pure fallthrough fix in one method.

## Verification

New `spec/rendering_spec.rb` (`Runtime::Value` stood in for via duck-typed doubles, since naming the real class would reintroduce the circular require the fix itself exists to avoid): unwraps a single-field wrapper, renders a multi-field wrapper as JSON, still renders a bare Hash/Array unchanged, still renders `nil`/scalars unchanged.

Full suite green against current `main` (`d478f33` on top of `a0e9869`): 1532 examples, 0 failures.
