### PR TITLE
fix(world): generic-settings fallback only applies when the adapter actually matches

### DIFF
--- a/lib/hecksagain/bluebook/behaviour/hexagon.rb
+++ b/lib/hecksagain/bluebook/behaviour/hexagon.rb
@@ -26,8 +26,23 @@ module Hecksagain
       module World
         def for_verb(verb) = @settings.fetch(verb.to_s, {})
 
+        # The generic `verb` entry (`persisted_by("Heki") do dir :default
+        # end`) only answers for the adapter it actually names — falling
+        # back to it unconditionally applies one adapter's settings to an
+        # unrelated one. Real, corpus-caught bug: a hecksagon binding two
+        # aggregates to two different adapters under the SAME verb (one to
+        # Heki, one to Memory) sent Memory's lookup down Heki's generic
+        # entry, then failed `check_settings` with "Memory does not
+        # declare :dir" — the generic entry's own `settings[:adapter]`
+        # names Heki, not Memory, so the fallback was never actually for
+        # this bind. `{}` is exactly right when nothing was configured for
+        # THIS adapter — Memory, which takes no values at all.
         def for_binding(verb, adapter)
-          @settings.fetch("#{verb}:#{adapter.to_s.downcase}", for_verb(verb))
+          qualified = @settings["#{verb}:#{adapter.to_s.downcase}"]
+          return qualified if qualified
+
+          generic = for_verb(verb)
+          generic[:adapter].to_s.downcase == adapter.to_s.downcase ? generic : {}
         end
       end
     end

--- a/spec/world_binding_settings_spec.rb
+++ b/spec/world_binding_settings_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+# `World#for_binding`'s generic-settings fallback used to answer for ANY
+# adapter bound under the same verb, not just the one the generic entry
+# actually names. A hecksagon binding two aggregates to two different
+# adapters under one verb (one to Heki, one to Memory) sent Memory's own
+# settings lookup down Heki's generic `persisted_by` entry — Memory then
+# failed `check_settings` with "Memory does not declare :dir", a setting
+# that was never its own. Fixed in `Behaviour::World#for_binding`
+# (lib/hecksagain/bluebook/behaviour/hexagon.rb) to only fall back to the
+# generic entry when its own `settings[:adapter]` matches the adapter being
+# asked about.
+RSpec.describe "World#for_binding" do
+  it "answers {} for an adapter the world configured nothing for, even when a sibling adapter under the same verb has settings" do
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+
+      Hecks.bluebook("Deciderate") do
+        supporting
+        aggregate "Game" do
+          identified_by :label
+          attribute :label, GameLabel
+          value_object "GameLabel" do
+            attribute :value, String
+          end
+          command "Start" do
+            attribute :label, GameLabel
+            emits "GameStarted"
+          end
+        end
+        aggregate "Bubble" do
+          identified_by :label
+          attribute :label, BubbleLabel
+          value_object "BubbleLabel" do
+            attribute :value, String
+          end
+          command "Pop" do
+            attribute :label, BubbleLabel
+            emits "BubblePopped"
+          end
+        end
+      end
+
+      Hecks.hecksagon("Deciderate") do
+        Deciderate::Game.persisted_by("Heki")
+        Deciderate::Bubble.persisted_by("Memory")
+      end
+
+      Hecks.world("Deciderate") do
+        persisted_by("Heki") do
+          dir :default
+        end
+      end
+    end
+
+    world = registry.world("Deciderate")
+
+    expect(world.for_binding("persisted_by", "Heki")).to include(adapter: "Heki")
+    expect(world.for_binding("persisted_by", "Memory")).to eq({})
+  end
+end


### PR DESCRIPTION
## The bug

`World#for_binding`'s fallback to the generic (verb-only, no adapter suffix) settings entry applies unconditionally. A hecksagon binding two aggregates to two different adapters under the same verb — one to `Heki`, one to `Memory` — sends `Memory`'s own settings lookup down `Heki`'s generic `persisted_by` entry, then fails `check_settings` with `"Memory does not declare :dir"` — a setting that was never `Memory`'s own to declare.

```ruby
Hecks.world("Example") do
  persisted_by("Heki") do
    dir :default
  end
end
# Example::Order.persisted_by("Heki")   # fine — matches the generic entry's own adapter
# Example::Cart.persisted_by("Memory")  # for_binding("persisted_by", "Memory") wrongly
                                         # falls back to Heki's { adapter: "Heki", dir: ... }
                                         # instead of answering {}
```

## The fix

`for_binding` now only falls back to the generic entry when its own `settings[:adapter]` actually matches the adapter being asked about; otherwise `{}` — exactly right for an adapter like `Memory` that takes no values at all. The qualified lookup (`"verb:adapter"`) is untouched and still wins when present.

No new functionality — this is a pure fallback-scoping fix in one method.

## Verification

New `spec/world_binding_settings_spec.rb`, reproducing the exact shape that caught this live: one domain, two aggregates, two different adapters bound under the same verb, one of them (`Heki`) carrying real settings and the other (`Memory`) carrying none. Asserts `for_binding("persisted_by", "Heki")` still includes the real settings and `for_binding("persisted_by", "Memory")` answers `{}` rather than leaking `Heki`'s.

Full suite green against current `main`: 1544 examples, 0 failures.
