### PR TITLE
fix(runtime): increment/decrement/multiply on an absent VO-typed attribute no longer blame the amount

### DIFF
--- a/lib/hecksagain/runtime/command_rules/arithmetic.rb
+++ b/lib/hecksagain/runtime/command_rules/arithmetic.rb
@@ -70,6 +70,22 @@ module Hecksagain
             return arithmetic_value_object(current, amount, target, sign, op)
           end
 
+          # `current` genuinely absent (no declared default, never set) and
+          # `amount` arrives VO-wrapped — a real command argument typed the
+          # same as the attribute, but with nothing to combine field-by-
+          # field against yet (that is what `arithmetic_value_object`,
+          # above, is for once BOTH sides carry real fields). Before this,
+          # falling straight to `unless amount.is_a?(Numeric)` below
+          # refused with "increment needs an Integer, got 500" — true of
+          # nothing: 500 is exactly the Integer it asked for, just still
+          # wearing the Money wrapper the command's own declared attribute
+          # type put it in. Unwrapped here, the same shape #clamp already
+          # falls through to for an absent VO-typed attribute
+          # (`current ||= 0`, then a raw scalar) — the mutation applier
+          # re-wraps the raw result into the declared VO type on write,
+          # the same way it already does for clamp's own result.
+          amount = unwrap_single_numeric_field(amount) if amount.is_a?(Value)
+
           # Widened from Integer to Numeric (migration plan task 4, i106):
           # miette's organ math increments a Float (`increment: 0.02`) --
           # the raw, non-value-object path only ever mattered for Integer
@@ -124,6 +140,10 @@ module Hecksagain
             return combine_value_object(current, amount, target, "multiply") { |c, a| c * a }
           end
 
+          # Same absent-`current`, VO-wrapped-`amount` gap as `#arithmetic`
+          # — see that method's own comment.
+          amount = unwrap_single_numeric_field(amount) if amount.is_a?(Value)
+
           unless amount.is_a?(Numeric) && current.is_a?(Numeric)
             raise TypeMismatch, RefusalWording.render("TypeMismatch", "arithmetic_amount",
                                                        op: "multiply", target: target,
@@ -147,8 +167,12 @@ module Hecksagain
           # this was the one arithmetic op that didn't, so a VO-typed
           # attribute with no declared `default:` (genuinely absent,
           # `Instance.defaults`/`#default_for`) hit TypeMismatch on the
-          # FIRST clamp, where increment/decrement/multiply would have
-          # silently treated the same absent field as zero.
+          # FIRST clamp. (#arithmetic/#multiply's OWN absent-current gap
+          # was a real, separate bug this comment used to describe wrong —
+          # they did not "silently treat the same absent field as zero";
+          # they raised too, blaming a perfectly valid `amount` for not
+          # being an Integer when it was one, just still Money-wrapped.
+          # Fixed alongside this one — see #unwrap_single_numeric_field.)
           current ||= 0
           if current.is_a?(Value)
             fields = current.to_h
@@ -167,6 +191,25 @@ module Hecksagain
         end
 
         private
+
+        # `amount` arrives VO-wrapped whenever the command's own declared
+        # attribute type says so (a real `Money`, not a bare Integer) —
+        # true whether or not `current` has ever been set. Only meaningful
+        # to call once `current` is known NOT to be a Value itself (the
+        # `current.is_a?(Value) && amount.is_a?(Value)` branch, above in
+        # both callers, already owns the case where both sides carry real
+        # fields to combine). Refuses rather than guesses when more than
+        # one field is numeric — genuinely ambiguous which one an absent
+        # `current` should be treated as zero for, the same reasoning
+        # `combine_value_object`'s own `shared_numeric.size == 1` check
+        # already holds to when both sides ARE present.
+        def unwrap_single_numeric_field(value)
+          fields = value.to_h
+          numeric_fields = fields.keys.select { |field| fields[field].is_a?(Numeric) }
+          return value unless numeric_fields.size == 1
+
+          fields[numeric_fields.first]
+        end
 
         def combine_value_object(current, amount, target, op)
           current_fields = current.to_h

--- a/spec/mutation_arithmetic_absent_current_spec.rb
+++ b/spec/mutation_arithmetic_absent_current_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+
+# CommandRules::Arithmetic's `current ||= 0` (`#arithmetic`/`#multiply`)
+# only ever produced a genuine zero when `amount` was ALSO plain — a
+# VO-typed attribute with no declared `default:` (genuinely absent, never
+# set) hit a misleading refusal on its very first increment/decrement/
+# multiply: "increment needs an Integer, got 500" — true of nothing.
+# `amount` (500 cents) was exactly the Integer it named, just still
+# wearing the Money wrapper the command's own declared attribute type put
+# it in; the real gap was that `current` (a raw `0`, not a Value) could
+# never enter the value-object branch alongside it.
+#
+# `#clamp` already falls through to a raw scalar for the identical absent
+# case and lets the mutation applier re-wrap the result into the declared
+# VO type on write — this closes the same gap for increment/decrement/
+# multiply, by unwrapping `amount`'s own single numeric field rather than
+# refusing on it.
+RSpec.describe "arithmetic on a VO-typed attribute that was never set" do
+  def boot(&binds)
+    registry = Hecksagain::Runtime::Registry.new
+    Hecksagain.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+
+      Hecks.bluebook("ArithmeticAbsentCurrent") do
+        supporting
+        aggregate "Wallet" do
+          identified_by :label
+          attribute :label, Label
+          value_object "Label" do
+            attribute :value, String
+          end
+
+          # No default: — genuinely absent until a command first sets it.
+          attribute :balance, Money, optional: true
+          value_object "Money" do
+            attribute :cents, Integer
+          end
+
+          attribute :ambiguous, TwoNums, optional: true
+          value_object "TwoNums" do
+            attribute :a, Integer
+            attribute :b, Integer
+          end
+
+          command "Open" do
+            attribute :label, Label
+            emits "WalletOpened"
+          end
+
+          command "Deposit" do
+            reference_to Wallet
+            attribute :amount, Money
+            sets :balance, increment: :amount
+            emits "Deposited"
+          end
+
+          command "Withdraw" do
+            reference_to Wallet
+            attribute :amount, Money
+            sets :balance, decrement: :amount
+            emits "Withdrawn"
+          end
+
+          command "Scale" do
+            reference_to Wallet
+            attribute :factor, Money
+            sets :balance, multiply: :factor
+            emits "Scaled"
+          end
+
+          command "IncrementAmbiguous" do
+            reference_to Wallet
+            attribute :pair, TwoNums
+            sets :ambiguous, increment: :pair
+            emits "AmbiguousIncremented"
+          end
+        end
+      end
+
+      Hecks.hecksagon("ArithmeticAbsentCurrent", &binds)
+    end
+
+    Hecksagain::Runtime::Loader.bind_runtime(Hecksagain::Runtime::Dispatcher.new(registry))
+  end
+
+  let(:runtime) { boot { ArithmeticAbsentCurrent::Wallet.persisted_by("Memory") } }
+
+  it "increment wraps the raw result back into the declared VO type" do
+    runtime.dispatch("ArithmeticAbsentCurrent::Wallet.Open", label: { value: "w1" })
+    runtime.dispatch("ArithmeticAbsentCurrent::Wallet.Deposit", label: "w1", amount: { cents: 500 })
+
+    expect(ArithmeticAbsentCurrent::Wallet.find("w1")[:balance].to_h).to eq(cents: 500)
+  end
+
+  it "decrement wraps the raw result back into the declared VO type" do
+    runtime.dispatch("ArithmeticAbsentCurrent::Wallet.Open", label: { value: "w1" })
+    runtime.dispatch("ArithmeticAbsentCurrent::Wallet.Withdraw", label: "w1", amount: { cents: 500 })
+
+    expect(ArithmeticAbsentCurrent::Wallet.find("w1")[:balance].to_h).to eq(cents: -500)
+  end
+
+  it "multiply wraps the raw result back into the declared VO type" do
+    runtime.dispatch("ArithmeticAbsentCurrent::Wallet.Open", label: { value: "w1" })
+    runtime.dispatch("ArithmeticAbsentCurrent::Wallet.Scale", label: "w1", factor: { cents: 7 })
+
+    expect(ArithmeticAbsentCurrent::Wallet.find("w1")[:balance].to_h).to eq(cents: 0)
+  end
+
+  it "refuses rather than guesses when the source value has more than one numeric field" do
+    runtime.dispatch("ArithmeticAbsentCurrent::Wallet.Open", label: { value: "w1" })
+
+    expect do
+      runtime.dispatch("ArithmeticAbsentCurrent::Wallet.IncrementAmbiguous", label: "w1", pair: { a: 1, b: 2 })
+    end.to raise_error(Hecksagain::Runtime::TypeMismatch)
+  end
+end


### PR DESCRIPTION
## The bug

`CommandRules::Arithmetic#arithmetic`/`#multiply`'s `current ||= 0` only ever produces a genuine zero when `amount` is ALSO plain. A VO-typed attribute with no declared `default:` — genuinely absent, never set — hits a misleading refusal on its very first `increment`/`decrement`/`multiply`:

```
increment needs an Integer, got 500
```

That's true of nothing. `amount` (500 cents) is exactly the Integer it names — it's just still wearing the `Money` wrapper the command's own declared attribute type put it in. The real gap: `current` (a raw `0`, not a `Value`) can never enter the value-object branch alongside a VO-wrapped `amount`, so `amount` gets refused instead of unwrapped.

```ruby
attribute :balance, Money, optional: true   # no default — absent until first set
value_object "Money" do
  attribute :cents, Integer
end

command "Deposit" do
  reference_to Wallet
  attribute :amount, Money
  sets :balance, increment: :amount
end
```

`Wallet.Deposit(amount: { cents: 500 })` on a wallet whose `balance` was never set raises `TypeMismatch` today, even though the exact same shape (`clamp` on an absent VO-typed attribute) already works.

## Why `#clamp` doesn't have this

`#clamp` already falls through to a raw scalar for the identical absent case, and the mutation applier re-wraps the result into the declared VO type on write. Its own comment claimed `increment`/`decrement`/`multiply` "would have silently treated the same absent field as zero" — verified live, that's wrong: they raise the same class of misleading refusal `clamp` itself used to, just blaming a different argument. Fixed the comment alongside the actual gap.

## The fix

New `unwrap_single_numeric_field`, called from both `#arithmetic` and `#multiply` when `amount` is a `Value` and `current` isn't: unwraps `amount`'s own single numeric field and falls through to the existing raw path — the same thing `clamp` already does. Refuses rather than guesses when `amount` carries more than one numeric field, since it's genuinely ambiguous which one an absent `current` should be zero for.

No new functionality — this is a pure fallthrough fix in two methods, matching a pattern `clamp` already establishes.

## Verification

New `spec/mutation_arithmetic_absent_current_spec.rb`: `increment`, `decrement`, and `multiply` all wrap their raw result back into the declared VO type correctly on a never-set attribute; the ambiguous multi-numeric-field case still refuses rather than guessing.

Full suite green against current `main`: 1552 examples, 0 failures.
