### PR TITLE
fix(policy_interpreter): scan every loaded bluebook for reacting policies

### DIFF
--- a/lib/hecksagain/runtime/policy_interpreter.rb
+++ b/lib/hecksagain/runtime/policy_interpreter.rb
@@ -23,8 +23,8 @@ module Hecksagain
       # is wrong here (it would explode a plain record Hash into its own
       # key/value pairs), so the two shapes are told apart explicitly.
       def react(event, domain)
-        policies_for(event, domain).each do |policy|
-          result = deliver(policy, event, domain)
+        policies_for(event).each do |policy, home_domain|
+          result = deliver(policy, event, home_domain)
           next if result.nil?
 
           (result.is_a?(Array) ? result : [result]).each { |record| @registry.reaction_log << record }
@@ -33,15 +33,33 @@ module Hecksagain
 
       private
 
-      def policies_for(event, domain)
-        bluebook = @registry.bluebook(domain)
-        return [] unless bluebook
-
+      # SCANS EVERY LOADED BLUEBOOK, not just the emitting command's own —
+      # a policy commonly lives in the CONSUMER's bluebook, reacting
+      # passively to an event a different domain's aggregate emits (the
+      # corpus-standard shape : `world/conception/bluebook/domain_cell.bluebook`'s
+      # ConceiveOnAbsorption reacts `on "DomainAbsorbed"`, an event
+      # `body/organs/bluebook/gut.bluebook`'s Gut.Absorb emits — two
+      # different bluebooks, joined only by the event's NAME). Restricting
+      # the scan to the emitting domain's own bluebook (the previous
+      # shape) silently drops every cross-domain reaction : the policy is
+      # never even a candidate, no refusal, no log entry, nothing —
+      # confirmed against the corpus's own .behaviors fixtures, several of
+      # which encode this exact cross-bluebook cascade as their contract.
+      #
+      # Returns [policy, home_domain] pairs rather than bare policies —
+      # `deliver`/`deliver_for_each` fall back to the REACTING policy's
+      # OWN domain (not the emitting one) when a trigger or for_each route
+      # is bare, and that fallback has to travel with each match now that
+      # a single event can surface policies from several different homes.
+      def policies_for(event)
         emitting = Naming.demodulise(event.aggregate)
 
-        bluebook.policies.select do |policy|
-          policy.event_name == event.name &&
-            (policy.event_qualifier.nil? || policy.event_qualifier == emitting)
+        @registry.bluebooks.each_value.flat_map do |bluebook|
+          matching = bluebook.policies.select do |policy|
+            policy.event_name == event.name &&
+              (policy.event_qualifier.nil? || policy.event_qualifier == emitting)
+          end
+          matching.map { |policy| [policy, bluebook.name] }
         end
       end
 

--- a/spec/runtime/reaction_defects_spec.rb
+++ b/spec/runtime/reaction_defects_spec.rb
@@ -41,12 +41,13 @@ RSpec.describe "a reaction that cannot be delivered" do
   end
 
   def registry_for(policy)
-    bluebook = Struct.new(:policies).new([policy])
+    bluebook = Struct.new(:name, :policies).new("Reflex", [policy])
     Class.new do
       attr_reader :reaction_log
 
       define_method(:initialize) { @reaction_log = [] }
       define_method(:bluebook) { |_domain| bluebook }
+      define_method(:bluebooks) { { "Reflex" => bluebook } }
     end.new
   end
 


### PR DESCRIPTION
## What
`policies_for(event, domain)` only looked inside the EMITTING command's own bluebook. A policy commonly lives in the CONSUMER's bluebook, reacting passively to an event a different domain's aggregate emits — two bluebooks joined only by the event's name. Restricting the scan to the emitting domain silently dropped every cross-domain reaction: the policy was never even a candidate, no refusal, no log entry, nothing.

## Context
Found investigating a miette pre-push gate failure — turned out NOT to be the actual root cause there (that runtime is the Rust `hecks-hecksagain/storehouse` crate, not this gem; see [hecks-hecksagain#3](https://github.com/chrisyoung/hecks-hecksagain/pull/3)) — but this Ruby runtime has the identical bug independently, confirmed by reproducing the same cross-domain scenario directly against `Runtime::PolicyInterpreter`. Fixing it here on its own merits, for whatever consumes this gem as the parity reference.

## Fix
Scan every bluebook the registry has loaded, not just the emitting one, carrying each match's own home domain through so `deliver`/`deliver_for_each`'s bare-trigger fallback still resolves against the REACTING policy's domain (not the emitting one). A same-domain cascade's home_domain trivially equals the emitting domain, so existing behavior is unchanged for every case that was already passing.

`registry.rb`: no new accessor needed — `bluebooks` (Hash, name → chapter) was already exposed via `attr_reader`; my first attempt added a second `def bluebooks` guessing a different (Array) shape, which silently broke `storage_shape_spec.rb` (already relying on the Hash return). Removed.

## Verification
Full `bundle exec rspec`: 1613 examples, 0 failures. Pre-push gate (suite + fuzzer + model checks + rubocop) green.