### PR TITLE
adapters/memory: add reset!, matching Postgres/Sqlite/D1/PostgresEra

### DIFF
--- a/lib/hecksagain/adapters/driven/memory.rb
+++ b/lib/hecksagain/adapters/driven/memory.rb
@@ -64,6 +64,26 @@ module Hecksagain
       def events = @events
 
       def entries = @entries.dup
+
+      # Every other driven adapter (Postgres/PostgresEra/Sqlite/D1)
+      # already implements this — `Ports::Persistence::AppendOnly#reset!`
+      # forwards to it and only raises when the wrapped adapter doesn't
+      # respond to `reset!` at all, which was always this adapter's own
+      # gap, not a deliberate omission (nothing about "in memory" implies
+      # "cannot be cleared"). Existing callers that fully re-`Hecks.boot`
+      # a domain per test case don't need this — they get a brand new
+      # `Memory` instance, with brand new empty `@records`/`@events`/
+      # `@entries`, for free. This is for the other case: a caller that
+      # deliberately keeps ONE booted runtime across many cases (to skip
+      # `load_domain`'s own per-boot parse/verify cost) and wants each
+      # case to start from the same clean slate `Hecks.boot` would have
+      # given it, without paying for a fresh boot to get there.
+      def reset!
+        @records = {}
+        @events  = []
+        @entries = []
+        self
+      end
     end
   end
 end

--- a/lib/hecksagain/ports/persistence/append_only.rb
+++ b/lib/hecksagain/ports/persistence/append_only.rb
@@ -36,7 +36,16 @@ module Hecksagain
 
           @adapter.reset!
         end
-        def events = @adapter.events if @adapter.respond_to?(:events)
+
+        # NOT an endless `def events = ... if ...` — that modifier binds to
+        # the WHOLE `def`, not just its body, so it evaluates against
+        # `@adapter` while `@adapter` is still nil (class-body time,
+        # before `initialize` ever runs) and silently skips defining the
+        # method at all. Found live: nothing in this codebase called
+        # `AppendOnly#events` before Memory got a `reset!` test that did.
+        def events
+          @adapter.events if @adapter.respond_to?(:events)
+        end
 
         # An append is durable before a projection is attempted. Replaying the
         # log restores a snapshot/table after a crash in that small window.

--- a/spec/adapters/driven/memory_spec.rb
+++ b/spec/adapters/driven/memory_spec.rb
@@ -1,0 +1,59 @@
+require "hecksagain"
+
+# `Memory` was the one driven adapter without `reset!` — Postgres/
+# PostgresEra/Sqlite/D1 all already have it, and `Ports::Persistence::
+# AppendOnly#reset!` already forwards to whichever adapter it wraps,
+# raising only when the adapter doesn't respond to `reset!` at all. This
+# closes that one gap: a caller that keeps ONE booted runtime across many
+# cases (skipping `load_domain`'s own per-boot cost) can now reset it back
+# to the same clean slate a fresh `Hecks.boot` would have given it.
+RSpec.describe Hecksagain::Adapters::Memory do
+  let(:runtime) { boot_in_memory }
+
+  def repository
+    runtime.registry.repository("Pizzas", runtime.registry.bluebook("Pizzas").aggregate("Order"))
+  end
+
+  def create(name: "Margherita")
+    runtime.dispatch("Pizzas::Order.CreatePizza",
+                     name: { value: name }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } })
+  end
+
+  it "clears saved records, the append log, and recorded events back to empty" do
+    create(name: "Margherita")
+    create(name: "Diavola")
+
+    expect(repository.count).to eq(2)
+    expect(repository.entries).not_to be_empty
+
+    repository.reset!
+
+    expect(repository.count).to eq(0)
+    expect(repository.all).to eq([])
+    expect(repository.entries).to eq([])
+    expect(repository.events).to eq([])
+  end
+
+  it "leaves the adapter fully usable afterward — not just empty, but able to save and find again" do
+    create(name: "Margherita")
+    repository.reset!
+    pizza = create(name: "Diavola")
+
+    expect(repository.count).to eq(1)
+    expect(repository.find(pizza.id)).not_to be_nil
+  end
+
+  # `registry.repository` always hands back an `AppendOnly`-wrapped
+  # adapter (`RepositoryFactory.build`) — every assertion above already
+  # went through `AppendOnly#reset!`'s own forwarding, not `Memory#reset!`
+  # called bare. This confirms the ONE thing those don't: the raw adapter
+  # itself, unwrapped, without which `AppendOnly#reset!` would still raise
+  # "append-only adapter cannot reset" today.
+  it "responds to reset! on the raw adapter, not only through AppendOnly's wrapper" do
+    memory = described_class.new(aggregate: runtime.registry.bluebook("Pizzas").aggregate("Order"))
+    memory.save(Struct.new(:id, :state).new("1", { name: { value: "Margherita" } }))
+
+    expect(memory.reset!).to equal(memory)
+    expect(memory.count).to eq(0)
+  end
+end


### PR DESCRIPTION
## Why

`Memory` was the one driven adapter without `reset!` — Postgres/Sqlite/D1/PostgresEra all already have it, and `Ports::Persistence::AppendOnly#reset!` already forwards to whichever adapter it wraps, only raising when the adapter doesn't respond to `reset!` at all. That was always this adapter's own gap, not a deliberate omission.

This unblocks a real perf win downstream (`hecks_ai_training`'s `spec/shipping_spec.rb`, currently profiled): a caller that keeps ONE booted runtime across many fixture-driven cases — instead of a full `Hecks.boot` per case, paying `load_domain`'s own per-boot parse/verify cost ~300 times — can now reset the Memory-backed repositories back to the same clean slate a fresh boot would have given it, at a fraction of the cost.

## Also fixed

Found live while writing the `reset!` spec: `AppendOnly#events` was written as an endless method with a trailing `if`:

```ruby
def events = @adapter.events if @adapter.respond_to?(:events)
```

That `if` modifier binds to the *whole* `def`, not just its body, so it evaluates `@adapter.respond_to?(:events)` against `@adapter` while `@adapter` is still `nil` (class-body time, before `initialize` ever runs). The condition is always false there, so the `def` was silently skipped and `events` was never defined on `AppendOnly` at all. Nothing in this codebase called it before this PR's own spec did. Rewritten as a real multi-line `def`, matching `record_event`'s already-correct per-call guard.

## Verification

- New `spec/adapters/driven/memory_spec.rb`, exercised through both the raw adapter and the real `AppendOnly`/`registry.repository` path.
- Full pre-push gate green: suite (parallel), fuzzer, model checker (all clean/only pre-existing terminal-state warnings), doc coverage, rubocop (518 files, no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)