### PR TITLE
feat(expression): .first, .find-then-project, nested block predicates

### DIFF
--- a/lib/hecksagain/bluebook/expression/resolver.rb
+++ b/lib/hecksagain/bluebook/expression/resolver.rb
@@ -1,6 +1,7 @@
 require "json"
 require_relative "../../rendering"
 require_relative "../../vocabulary"
+require_relative "resolver/block_predicates"
 
 module Hecksagain
   module Bluebook
@@ -122,46 +123,15 @@ module Hecksagain
         # receiver-in, scalar-out accessor, no sub-grammar of its own.
         Last           = Struct.new(:receiver, keyword_init: true)
 
-        # `receiver.all? { |x| PREDICATE }` / `.any? { ... }` / `.none? {
-        # ... }` -- vendored addition, not (yet) upstream hecksagain
-        # (migration plan task 9), completing the same `Phrase`
-        # four-segment invariant the `Split` node above was built for
-        # (`value.split("::").all? { |s| s.length > 0 }`). Structurally
-        # different from every other addition in this file: every prior
-        # suffix is a flat receiver -> scalar transform, but a block
-        # predicate needs to evaluate its own sub-expression ONCE PER
-        # ELEMENT with the block parameter bound to that element. Kept
-        # minimal per the migration plan's own instruction -- no
-        # persistent iteration-variable concept added to Resolver's
-        # state model at all ; `predicate` below is a fully-parsed
-        # EVALUATOR ast (not a Resolver ast -- the predicate is a
-        # boolean/comparison expression like `s.length > 0`, exactly the
-        # grammar `Bluebook::Expression::Evaluator` owns, not this
-        # module's own leaf grammar), parsed once at `parse`-time same as
-        # every sibling node's sub-expressions are. `mode` distinguishes
-        # all?/any?/none? without three duplicated node types, since
-        # their only difference is which Array predicate aggregates the
-        # per-element results (interpret_with_element, below, is the
-        # "smallest correct thing" the plan asked for -- it threads the
-        # element binding through a temporarily-extended `attrs` hash for
-        # that one predicate's evaluation only, never touching
-        # `interpret`'s own signature or any other node's call sites).
-        # `Resolver` already calls into `Evaluator` elsewhere in this
-        # file (`sign_test_node`/`apply_sign_test` call `Evaluator.
-        # apply`/`Evaluator::OPERATORS` directly) -- this is the same
-        # precedented cross-reference, not a new coupling.
-        BlockPredicate = Struct.new(:mode, :receiver, :param, :predicate, keyword_init: true)
-
-        # Which Array method each block-predicate suffix maps to, and
-        # which Ruby Enumerable method decides the aggregate result --
-        # declared as data, not a three-way `case`, the same shape
-        # SIGN_TEST_OPERATORS above already uses for its own suffix
-        # family.
-        BLOCK_PREDICATE_MODES = {
-          "all?"  => :all,
-          "any?"  => :any,
-          "none?" => :none
-        }.freeze
+        # `receiver.first` -- sibling addition to `Last` immediately
+        # above, same shape, same vendored-not-upstream status. Added
+        # for the shipping domain's `legs.first` (an itinerary's
+        # departure leg), the exact mirror of `legs.last` (its arrival
+        # leg) that domain already leaned on -- `Last`'s own duck-typed-
+        # on-`respond_to?` reasoning applies unchanged, so `first_of`
+        # below is `last_of` with the one method swapped, not a new
+        # design.
+        First          = Struct.new(:receiver, keyword_init: true)
 
         # `receiver.start_with?("prefix")` / `receiver.end_with?("suffix")`
         # -- vendored addition, not (yet) upstream hecksagain (migration
@@ -238,6 +208,7 @@ module Hecksagain
             return Split.new(receiver: parse(Regexp.last_match(1)), separator: Regexp.last_match(2))
           end
 
+          return First.new(receiver: parse(Regexp.last_match(1))) if expr =~ /\A(.+)\.first\z/
           return Last.new(receiver: parse(Regexp.last_match(1))) if expr =~ /\A(.+)\.last\z/
 
           if expr =~ /\A(.+)\.start_with\?\("([^"]*)"\)\z/
@@ -248,37 +219,13 @@ module Hecksagain
             return EndsWith.new(receiver: parse(Regexp.last_match(1)), substring: Regexp.last_match(2))
           end
 
+          find = parse_find(expr)
+          return find if find
+
           block_predicate = parse_block_predicate(expr)
           return block_predicate if block_predicate
 
           Lookup.new(path: expr)
-        end
-
-        # `.all?`/`.any?`/`.none?` -- vendored addition, see the
-        # `BlockPredicate` struct's own comment above. Matched last among
-        # the suffix rules (right before the `Lookup` catch-all) since
-        # its own predicate text can itself contain almost anything a
-        # leaf expression can -- letting every more specific rule above
-        # try first avoids this one accidentally swallowing a receiver
-        # another rule was meant to parse. `receiver` and the predicate
-        # body are each parsed through their OWN correct grammar --
-        # `parse` (this module's leaf grammar) for the receiver, `
-        # Evaluator.parse` (the boolean/comparison grammar) for the
-        # predicate, since a predicate like `s.length > 0` is a
-        # comparison, not a bare leaf.
-        def parse_block_predicate(expr)
-          BLOCK_PREDICATE_MODES.each do |suffix, mode|
-            match = expr.match(/\A(.+)\.#{Regexp.escape(suffix)}\s*\{\s*\|(\w+)\|\s*(.+?)\s*\}\z/m)
-            next unless match
-
-            return BlockPredicate.new(
-              mode:      mode,
-              receiver:  parse(match[1]),
-              param:     match[2],
-              predicate: Evaluator.parse(match[3])
-            )
-          end
-          nil
         end
 
         def sign_test_node(parts)
@@ -314,6 +261,10 @@ module Hecksagain
             split_value(interpret(node.receiver, state, attrs), node.separator)
           when Last
             last_of(interpret(node.receiver, state, attrs))
+          when First
+            first_of(interpret(node.receiver, state, attrs))
+          when Find
+            found_of(node, interpret(node.receiver, state, attrs), state, attrs)
           when StartsWith
             starts_with?(interpret(node.receiver, state, attrs), node.substring)
           when EndsWith
@@ -326,8 +277,8 @@ module Hecksagain
             # Every leaf node `parse` can produce has a `when` above —
             # a backstop against the day this grammar grows a new leaf
             # type (this file's own history: MatchesRegex/Presence/
-            # Split/Last/StartsWith/EndsWith/BlockPredicate were each
-            # added exactly this way, and each one — before it had an
+            # Split/Last/First/Find/StartsWith/EndsWith/BlockPredicate
+            # were each added exactly this way, and each one — before it had an
             # `interpret` arm — fell all the way through to the
             # `Lookup` catch-all in `parse` and crashed downstream with
             # an opaque type error, never here). A missing arm here
@@ -497,6 +448,15 @@ module Hecksagain
           raise EvaluationError, "last expects a list, got #{describe(value)}"
         end
 
+        # `.first` -- see the `First` struct's own comment above.
+        # `last_of` with the one method swapped, same duck-typed
+        # reasoning.
+        def first_of(value)
+          return value.first if value.respond_to?(:first)
+
+          raise EvaluationError, "first expects a list, got #{describe(value)}"
+        end
+
         # `.start_with?("prefix")` -- vendored addition, see the
         # `StartsWith` struct's own comment above. String-only, same
         # reasoning as `.split` above -- every corpus usage found this
@@ -515,38 +475,6 @@ module Hecksagain
           raise EvaluationError, "end_with? expects a string, got #{describe(value)}" unless value.is_a?(String)
 
           value.end_with?(substring)
-        end
-
-        # `.all?`/`.any?`/`.none?` -- vendored addition, see the
-        # `BlockPredicate` struct's own comment above. `collection` is
-        # already-interpreted (a real Array, produced by whatever
-        # receiver expression came before it -- typically `Split`'s
-        # output), so this only has to run the per-element predicate and
-        # aggregate. `interpret_with_element` is the "smallest correct
-        # thing" the migration plan asked for : no persistent iteration-
-        # variable concept added anywhere else in Resolver's state model,
-        # just `attrs` extended with the bound name for the span of that
-        # one predicate evaluation, discarded immediately after.
-        def evaluate_block_predicate(node, collection, state, attrs)
-          unless collection.is_a?(Array)
-            raise EvaluationError, "#{node.mode}? expects a list, got #{describe(collection)}"
-          end
-
-          outcomes = collection.map { |element| interpret_with_element(node, element, state, attrs) }
-
-          case node.mode
-          when :all  then outcomes.all?
-          when :any  then outcomes.any?
-          when :none then outcomes.none?
-          end
-        end
-
-        # Binds the block parameter for exactly one element's predicate
-        # evaluation -- `attrs` wins over `state` in `fetch` (see below),
-        # so the bound name shadows any same-named state/attrs field for
-        # the span of this one call only ; nothing persists past it.
-        def interpret_with_element(node, element, state, attrs)
-          Evaluator.interpret(node.predicate, state, attrs.merge(node.param.to_sym => element))
         end
 
         # Declared the same way in Vocabulary::ToStringType
@@ -598,11 +526,22 @@ module Hecksagain
           return unwrap_scalar(fetch(expr, state, attrs)) unless expr.include?(".")
 
           head, *rest = expr.split(".")
-          unwrap_scalar(rest.reduce(fetch(head, state, attrs)) do |value, segment|
-            break nil unless value.respond_to?(:[])
+          unwrap_scalar(walk_path(fetch(head, state, attrs), rest))
+        end
 
-            value[segment.to_sym] || value[segment]
-          end)
+        # Walks a list of dotted segments through an already-resolved
+        # Hash-like value — extracted from `lookup`'s own reduce so
+        # `found_of` (the `Find` node's own path projection) can walk a
+        # `.find { ... }`-produced element the identical way `lookup`
+        # walks a plain attribute path, rather than duplicating the
+        # `value[segment.to_sym] || value[segment]` step twice in this
+        # file.
+        def walk_path(value, segments)
+          segments.reduce(value) do |current, segment|
+            break nil unless current.respond_to?(:[])
+
+            current[segment.to_sym] || current[segment]
+          end
         end
 
         # `field == "literal"` -- vendored addition, not (yet) upstream

--- a/lib/hecksagain/bluebook/expression/resolver/block_predicates.rb
+++ b/lib/hecksagain/bluebook/expression/resolver/block_predicates.rb
@@ -1,0 +1,244 @@
+# HAND-WRITTEN — the block-predicate/find family of the leaf grammar
+# (`Bluebook::Expression::Resolver`'s own `.all?`/`.any?`/`.none?`/
+# `.find` suffixes), split into this sibling file to keep resolver.rb
+# under Metrics/ModuleLength (350) : this reopens the SAME `Resolver`
+# module resolver.rb defines, the long nested `module A; module B; ...`
+# form (not the compact `A::B` form) so bare constant/method lookups
+# here (`EvaluationError`, `Evaluator`, `describe`, `unwrap_scalar`,
+# `walk_path`) resolve exactly the way they do inside resolver.rb
+# itself — this is one module, split across two files, not two
+# modules. See resolver.rb's own header for the grammar this belongs
+# to; see each struct/method below for its own "why".
+module Hecksagain
+  module Bluebook
+    module Expression
+      module Resolver
+        # `receiver.all? { |x| PREDICATE }` / `.any? { ... }` / `.none? {
+        # ... }` -- vendored addition, not (yet) upstream hecksagain
+        # (migration plan task 9), completing the same `Phrase`
+        # four-segment invariant the `Split` node above was built for
+        # (`value.split("::").all? { |s| s.length > 0 }`). Structurally
+        # different from every other addition in this file: every prior
+        # suffix is a flat receiver -> scalar transform, but a block
+        # predicate needs to evaluate its own sub-expression ONCE PER
+        # ELEMENT with the block parameter bound to that element. Kept
+        # minimal per the migration plan's own instruction -- no
+        # persistent iteration-variable concept added to Resolver's
+        # state model at all ; `predicate` below is a fully-parsed
+        # EVALUATOR ast (not a Resolver ast -- the predicate is a
+        # boolean/comparison expression like `s.length > 0`, exactly the
+        # grammar `Bluebook::Expression::Evaluator` owns, not this
+        # module's own leaf grammar), parsed once at `parse`-time same as
+        # every sibling node's sub-expressions are. `mode` distinguishes
+        # all?/any?/none? without three duplicated node types, since
+        # their only difference is which Array predicate aggregates the
+        # per-element results (interpret_with_element, below, is the
+        # "smallest correct thing" the plan asked for -- it threads the
+        # element binding through a temporarily-extended `attrs` hash for
+        # that one predicate's evaluation only, never touching
+        # `interpret`'s own signature or any other node's call sites).
+        # `Resolver` already calls into `Evaluator` elsewhere in this
+        # file (`sign_test_node`/`apply_sign_test` call `Evaluator.
+        # apply`/`Evaluator::OPERATORS` directly) -- this is the same
+        # precedented cross-reference, not a new coupling.
+        BlockPredicate = Struct.new(:mode, :receiver, :param, :predicate, keyword_init: true)
+
+        # Which Array method each block-predicate suffix maps to, and
+        # which Ruby Enumerable method decides the aggregate result --
+        # declared as data, not a three-way `case`, the same shape
+        # SIGN_TEST_OPERATORS above already uses for its own suffix
+        # family.
+        BLOCK_PREDICATE_MODES = {
+          "all?"  => :all,
+          "any?"  => :any,
+          "none?" => :none
+        }.freeze
+
+        # `receiver.find { |x| PREDICATE }` / `.find { ... }.a.b` -- the
+        # "find-then-project" shape the shipping domain's re-routing
+        # rules kept reaching for by hand (a caller-precomputed
+        # `next_load_location` field standing in for "the leg after this
+        # one", because `BlockPredicate` above can only answer yes/no,
+        # never hand back the element it found). `path` holds the
+        # dotted segments walked past the closing `}`, e.g. the `["
+        # next_load_location"]` in `legs.find { |l| l.load_location ==
+        # x }.next_load_location` -- empty when `.find { ... }` is used
+        # bare (its own found-element-or-nil is the value, same as any
+        # other leaf, e.g. composed with `.present?` the same way every
+        # other receiver already composes with it). Reuses `param`/
+        # `predicate`'s exact field names from `BlockPredicate` on
+        # purpose: `interpret_with_element` below binds by those two
+        # names and is shared unchanged between both node types.
+        Find = Struct.new(:receiver, :param, :predicate, :path, keyword_init: true)
+
+        module_function
+
+        # `.all?`/`.any?`/`.none?` -- vendored addition, see the
+        # `BlockPredicate` struct's own comment above. Matched last among
+        # the suffix rules (right before the `Lookup` catch-all) since
+        # its own predicate text can itself contain almost anything a
+        # leaf expression can -- letting every more specific rule above
+        # try first avoids this one accidentally swallowing a receiver
+        # another rule was meant to parse. `receiver` and the predicate
+        # body are each parsed through their OWN correct grammar --
+        # `parse` (this module's leaf grammar) for the receiver, `
+        # Evaluator.parse` (the boolean/comparison grammar) for the
+        # predicate, since a predicate like `s.length > 0` is a
+        # comparison, not a bare leaf.
+        # Rewritten to a header-regex-plus-`matching_brace` scan instead
+        # of one greedy-to-`\z` regex per suffix -- the original `(.+?)
+        # \s*\}\z` shape broke the moment a predicate contained ANOTHER
+        # block predicate (`legs.any? { |l| ... legs.any? { |o| ... } }`,
+        # the exact re-routing check this grammar gap forced the
+        # shipping domain to precompute by hand instead) : looping the
+        # three suffixes with a GREEDY receiver capture matched the
+        # LAST occurrence of `.suffix? {` in the string, not the
+        # outermost one, so the "receiver" swallowed the inner call too
+        # and crashed with `TypeError: no implicit conversion of Symbol
+        # into Integer`, confirmed live, not inferred. The header regex
+        # below instead uses a NON-GREEDY receiver capture across all
+        # three suffixes at once, so it stops at the FIRST `.suffix? {`
+        # in the string (the real receiver never itself contains one) ;
+        # `matching_brace` then walks forward counting `{`/`}` depth,
+        # the same quote-aware, depth-aware discipline `split_addition`/
+        # `array_elements` already apply, so a `}` inside a nested block
+        # predicate (or a quoted `start_with?` substring) never
+        # miscounts.
+        def parse_block_predicate(expr)
+          header = expr.match(/\A(.+?)\.(#{BLOCK_PREDICATE_MODES.keys.map { |suffix| Regexp.escape(suffix) }.join('|')})\s*\{\s*\|(\w+)\|\s*/m)
+          return nil unless header
+
+          body_start = header.end(0)
+          body_end = matching_brace(expr, body_start)
+          return nil unless body_end
+          return nil unless expr[(body_end + 1)..].strip.empty?
+
+          BlockPredicate.new(
+            mode:      BLOCK_PREDICATE_MODES.fetch(header[2]),
+            receiver:  parse(header[1]),
+            param:     header[3],
+            predicate: Evaluator.parse(expr[body_start...body_end].strip)
+          )
+        end
+
+        # `receiver.find { |x| PREDICATE }` / `.find { ... }.a.b` -- see
+        # the `Find` struct's own comment above. Same header-plus-
+        # `matching_brace` shape `parse_block_predicate` uses (find is
+        # deliberately not folded into `BLOCK_PREDICATE_MODES` --
+        # `evaluate_block_predicate` aggregates a collection to a single
+        # boolean via `Enumerable#all?/any?/none?`, `Find` hands back an
+        # ELEMENT via `Enumerable#find`, a different return shape
+        # entirely, so sharing one node type would mean branching on
+        # `mode` for the return type too, exactly the "smallest correct
+        # thing, no accidental generality" the `BlockPredicate` struct's
+        # own comment already argued against). Not anchored to `\z` --
+        # unlike a block predicate, `.find { ... }` is meant to be
+        # followed by a dotted projection path, so whatever trails the
+        # closing brace is captured as `path` instead of rejecting the
+        # parse.
+        def parse_find(expr)
+          header = expr.match(/\A(.+?)\.find\s*\{\s*\|(\w+)\|\s*/m)
+          return nil unless header
+
+          body_start = header.end(0)
+          body_end = matching_brace(expr, body_start)
+          return nil unless body_end
+
+          trailing = expr[(body_end + 1)..].strip
+          return nil unless trailing.empty? || trailing.start_with?(".")
+
+          Find.new(
+            receiver:  parse(header[1]),
+            param:     header[2],
+            predicate: Evaluator.parse(expr[body_start...body_end].strip),
+            path:      trailing.empty? ? [] : trailing[1..].split(".")
+          )
+        end
+
+        # The index of the `}` that closes the `{` implicitly opened
+        # just before `start` (the caller's own header match already
+        # consumed that opening brace, so depth begins at 1) -- nil if
+        # the string runs out before depth returns to 0 (a caller-error
+        # shape, not a valid expression). Quote-aware so a `}` inside a
+        # quoted substring (`.start_with?("}")`) never miscounts, the
+        # same discipline `split_addition`/`array_elements` already
+        # apply for their own depth tracking.
+        def matching_brace(expr, start)
+          depth = 1
+          quote = nil
+          index = start
+          while index < expr.length
+            char = expr[index]
+            if quote
+              quote = nil if char == quote
+            elsif ['"', "'"].include?(char)
+              quote = char
+            elsif char == "{"
+              depth += 1
+            elsif char == "}"
+              depth -= 1
+              return index if depth.zero?
+            end
+            index += 1
+          end
+          nil
+        end
+
+        # `.all?`/`.any?`/`.none?` -- vendored addition, see the
+        # `BlockPredicate` struct's own comment above. `collection` is
+        # already-interpreted (a real Array, produced by whatever
+        # receiver expression came before it -- typically `Split`'s
+        # output), so this only has to run the per-element predicate and
+        # aggregate. `interpret_with_element` is the "smallest correct
+        # thing" the migration plan asked for : no persistent iteration-
+        # variable concept added anywhere else in Resolver's state model,
+        # just `attrs` extended with the bound name for the span of that
+        # one predicate evaluation, discarded immediately after.
+        def evaluate_block_predicate(node, collection, state, attrs)
+          unless collection.is_a?(Array)
+            raise EvaluationError, "#{node.mode}? expects a list, got #{describe(collection)}"
+          end
+
+          outcomes = collection.map { |element| interpret_with_element(node, element, state, attrs) }
+
+          case node.mode
+          when :all  then outcomes.all?
+          when :any  then outcomes.any?
+          when :none then outcomes.none?
+          end
+        end
+
+        # Binds the block parameter for exactly one element's predicate
+        # evaluation -- `attrs` wins over `state` in `fetch` (see below),
+        # so the bound name shadows any same-named state/attrs field for
+        # the span of this one call only ; nothing persists past it.
+        def interpret_with_element(node, element, state, attrs)
+          Evaluator.interpret(node.predicate, state, attrs.merge(node.param.to_sym => element))
+        end
+
+        # `.find { |x| PREDICATE }` -- see the `Find` struct's own
+        # comment above. Reuses `interpret_with_element` unchanged
+        # (below, shared with `BlockPredicate` — both bind `node.param`
+        # to one element and interpret `node.predicate` against it) to
+        # find the FIRST element the predicate accepts, then projects
+        # `node.path` through it via `walk_path`, the same dotted-
+        # segment walk `lookup` uses for a plain attribute path. `nil`
+        # (no matching element, or a `path` segment that doesn't
+        # resolve) flows through rather than raising — the same "a
+        # dispatch-time given just refuses" shape every other missing-
+        # value case in this grammar already has, and the one a re-
+        # routing check like "is there a leg after this one" needs :
+        # not finding one is a normal outcome, not an error.
+        def found_of(node, collection, state, attrs)
+          raise EvaluationError, "find expects a list, got #{describe(collection)}" unless collection.is_a?(Array)
+
+          found = collection.find { |element| interpret_with_element(node, element, state, attrs) }
+          return unwrap_scalar(found) if node.path.empty?
+          return nil if found.nil?
+
+          unwrap_scalar(walk_path(found, node.path))
+        end
+      end
+    end
+  end
+end

--- a/spec/expression_spec.rb
+++ b/spec/expression_spec.rb
@@ -209,6 +209,21 @@ RSpec.describe "the expression sublanguage" do
     end
   end
 
+  describe "first" do
+    it "reads the leading segment of a split, the mirror image of .last" do
+      matching = "dispatch::lexicon::query::command_bus"
+      not_matching = "other::lexicon::query::command_bus"
+
+      expect(evaluate('value.split("::").first == "dispatch"', value: matching)).to be(true)
+      expect(evaluate('value.split("::").first == "dispatch"', value: not_matching)).to be(false)
+    end
+
+    it "raises when the receiver has no #first" do
+      expect { evaluate("value.first", value: 12) }
+        .to raise_error(Hecksagain::Bluebook::Expression::EvaluationError, /first expects a list, got 12/)
+    end
+  end
+
   describe "block-taking all?/any?/none?" do
     it "aggregates a per-element predicate over a split array" do
       four_real_segments = "dispatch::lexicon::query::command_bus"
@@ -229,6 +244,52 @@ RSpec.describe "the expression sublanguage" do
     it "raises when the receiver is not a list" do
       expect { evaluate("value.all? { |s| s.length > 0 }", value: "oops") }
         .to raise_error(Hecksagain::Bluebook::Expression::EvaluationError, /all\? expects a list, got "oops"/)
+    end
+
+    it "handles a block predicate nested inside another block predicate's own predicate, the shipping-domain re-routing check this grammar gap forced a workaround for" do
+      # legs.any? { |l| an outer condition on l, AND some other leg satisfies an inner condition }
+      legs_with_a_later_leg = [
+        { "load" => "SESTO", "unload" => "USNYC" },
+        { "load" => "USNYC", "unload" => "AUSYD" }
+      ]
+      legs_without_a_later_leg = [
+        { "load" => "SESTO", "unload" => "USNYC" }
+      ]
+      expression = 'legs.any? { |l| l.load == "SESTO" && legs.any? { |o| o.load == "USNYC" } }'
+
+      expect(evaluate(expression, legs: legs_with_a_later_leg)).to be(true)
+      expect(evaluate(expression, legs: legs_without_a_later_leg)).to be(false)
+    end
+  end
+
+  describe "find" do
+    let(:legs) do
+      [
+        { "load" => "SESTO", "unload" => "USNYC", "voyage" => "V001" },
+        { "load" => "USNYC", "unload" => "AUSYD", "voyage" => "V002" }
+      ]
+    end
+
+    it "projects a field off the first matching element, the find-then-project shape a caller-precomputed field used to stand in for" do
+      expect(evaluate('legs.find { |l| l.load == "USNYC" }.voyage == "V002"', legs: legs)).to be(true)
+    end
+
+    it "resolves to nil, not an error, when no element matches — a normal 'no leg after this one' outcome" do
+      expect(evaluate('legs.find { |l| l.load == "ZZZZZ" }.voyage == "V002"', legs: legs)).to be(false)
+      # bare (no comparison), Evaluator truthy-casts every leaf's raw value
+      # the same way it does for `.last`/`.present?` — nil casts to false,
+      # not an error, exactly what "no leg found" should mean here.
+      expect(evaluate('legs.find { |l| l.load == "ZZZZZ" }.voyage', legs: legs)).to be(false)
+    end
+
+    it "composes bare, with no trailing path, the same way .last does" do
+      expect(evaluate('legs.find { |l| l.load == "USNYC" }.present?', legs: legs)).to be(true)
+      expect(evaluate('legs.find { |l| l.load == "ZZZZZ" }.present?', legs: legs)).to be(false)
+    end
+
+    it "raises when the receiver is not a list" do
+      expect { evaluate('value.find { |l| l.load == "USNYC" }.voyage', value: "oops") }
+        .to raise_error(Hecksagain::Bluebook::Expression::EvaluationError, /find expects a list, got "oops"/)
     end
   end
 


### PR DESCRIPTION
## What

Three additions to the expression sublanguage's vendored leaf-grammar suffix family (the same family `Split`/`Last`/`StartsWith`/`EndsWith`/`BlockPredicate` already belong to), all motivated by real gaps hit while building the `hecks_ai_training` shipping domain (a DDD Cargo Shipping model, oracle-verified against `citerus/dddsample-core`) — that domain had been working around each gap by hand.

- **`.first`** — sibling to `.last`, same duck-typed shape.
- **`.find { |x| pred }` / `.find { ... }.a.b`** — a new `Find` node that hands back the *first* matching element (or `nil`), optionally projected through a trailing dotted path. `BlockPredicate` (`.all?`/`.any?`/`.none?`) can only answer yes/no; this is the "find-then-project" shape a caller-precomputed field (e.g. a hand-derived `next_load_location`) used to stand in for.
- **Nested block predicates** (`legs.any? { |l| ... legs.any? { |o| ... } }`) — `parse_block_predicate`'s old greedy-receiver-per-suffix regex matched the *last* `.suffix? {` in the string, not the outermost one, and crashed with `TypeError: no implicit conversion of Symbol into Integer` the moment a predicate contained another block predicate. Rewritten to a non-greedy combined-suffix header regex plus a new quote-aware `matching_brace` depth scanner, shared by both `parse_block_predicate` and `parse_find`.

Ruby-only — confirmed these suffixes are vendored additions never folded into `Grammar.admitted_operators` / the generated Rust `OperatorCategory` enum, so no Rust kernel parity work is required.

Extracted the block-predicate/find cluster (structs, parsers, `matching_brace`, `evaluate_block_predicate`/`interpret_with_element`, `found_of`) into a new sibling file, `lib/hecksagain/bluebook/expression/resolver/block_predicates.rb`, reopening the same `Resolver` module — `resolver.rb` had grown past `Metrics/ModuleLength` (350) with the new code inline.

## Example usage

```ruby
given "there is a leg after this one whose load location matches" do
  legs.find { |l| l.load_location == event_location }.next_load_location.present?
end

given "the next leg after a matching one departs from the unload point" do
  legs.find { |l| l.load_location == event_location }.next_load_location == next_leg.load_location
end
```

## Testing

- 7 new specs in `spec/expression_spec.rb` (`.first` x2, `.find` x4, nested block predicate x1).
- Full suite: 1454 examples, 0 failures.
- rubocop clean (521 files).
- Pre-push gate green end to end: suite, fuzzer, engine agreement, model checks, doc-coverage, rubocop.
