### PR TITLE
tenant_isolation_spec: stop picking an arbitrary table via unordered information_schema.tables

### DIFF
--- a/spec/tenant_isolation_spec.rb
+++ b/spec/tenant_isolation_spec.rb
@@ -208,13 +208,29 @@ RSpec.describe "multitenancy: one boot per tenant, one shared route table" do
         # entirely, confirms the table itself holds nothing. Found by
         # name via information_schema rather than hardcoded — this is
         # deliberately not asserting PostgresEra's own storage_name
-        # convention, only that whichever table it created in acme's
-        # write ended up empty in bloom's own schema.
+        # convention, only that whichever table holds the AGGREGATE'S
+        # OWN data (not any of PostgresEra's own bookkeeping tables) in
+        # acme's write ended up empty in bloom's own schema.
+        #
+        # NOT `.first` on the unfiltered list — found live, the flaky
+        # way: `information_schema.tables` makes no ordering guarantee,
+        # and this schema also holds hecks_eras/hecks_era_texts/hecks_
+        # backfill_progress, each carrying its own legitimate 1-row
+        # bookkeeping entry PostgresEra provisions for EVERY schema it
+        # touches, tenant write or not. Whichever one the catalog
+        # happened to return first was failing this exact assertion on
+        # real, correct isolation — `widget_head` itself was empty the
+        # whole time. `_head` is the one naming shape only an
+        # aggregate's own data table has (`Lineage#head_view`) — no
+        # bookkeeping table ends in it, and `_head_snapshot_<era>`
+        # doesn't either, so this still isn't the storage_name
+        # convention itself, only the shape every aggregate's head
+        # shares regardless of what it's actually called.
         direct = PG.connect(dbname: db)
         direct.exec("SET search_path TO tenant_bloom")
         table = direct.exec("SELECT table_name FROM information_schema.tables WHERE table_schema = 'tenant_bloom'")
-                      .map { |row| row["table_name"] }.first
-        expect(table).not_to be_nil, "PostgresEra never created a table in tenant_bloom's own schema at all"
+                      .map { |row| row["table_name"] }.find { |name| name.end_with?("_head") }
+        expect(table).not_to be_nil, "PostgresEra never created an aggregate head table in tenant_bloom's own schema at all"
         rows = direct.exec("SELECT count(*) FROM #{table}")
         expect(rows.first["count"]).to eq("0")
         direct.close


### PR DESCRIPTION
## Why CI has been red on `main`

`tenant_isolation_spec.rb`'s real-Postgres isolation assertion took `.first` off an **unordered** `information_schema.tables` result to find "whichever table PostgresEra created in tenant_bloom's schema," then asserted it held 0 rows.

That schema also holds `hecks_eras`/`hecks_era_texts`/`hecks_backfill_progress` — each carrying its own legitimate 1-row bookkeeping entry PostgresEra provisions for **every** schema it touches, tenant write or not, entirely unrelated to the `Widget` aggregate under test. Whichever one Postgres's catalog happened to return first was failing this assertion on real, correct isolation.

## Confirmed live, not guessed

Reproduced the exact boot/dispatch sequence by hand against a local Postgres 14 and inspected the database directly: `widget_head` held 0 rows in `tenant_bloom` the entire time (real isolation is fine); `hecks_eras`, `hecks_era_texts`, and `hecks_backfill_progress` each held 1 row of their own bookkeeping. Catalog ordering is stable *within* one Postgres instance but not guaranteed *across* instances — which is exactly why CI has been consistently red (same instance, same ordering) while local runs here passed (a different one).

## Fix

Filters to the `_head` naming shape instead (`Lineage#head_view`) — no bookkeeping table ends in it, and `head_snapshot`'s own `_head_snapshot_<era>` doesn't either. Preserves the original comment's intent (not hardcoding the `storage_name` convention) while actually being correct regardless of catalog ordering.

## Verification

- Passes against real local Postgres, run twice.
- The Memory-backed sibling example in the same file is untouched.
- Full local pre-push gate green: parallel suite, fuzzer, model checker, doc coverage, rubocop (522 files, no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)