### PR TITLE
Fix stored XSS via record id in rust/host's web layer (H10)

### DIFF
--- a/docs/audits/2026-08-10-main-bug-audit.md
+++ b/docs/audits/2026-08-10-main-bug-audit.md
@@ -232,7 +232,7 @@ chapter's assembled read model (filter still 100). Any same-process reload
 after editing only a read-model filter (test suites, consoles, hecks_studio)
 runs the stale filter. Policy→head attribution shares the same key hole.
 
-### H10 — Stored XSS via record id (Rust web layer)
+### H10 — Stored XSS via record id (Rust web layer) — FIXED 2026-08-22
 
 `rust/host/src/web.rs:639, 706` (also `:635, :696` lack URL-encoding) ·
 likely
@@ -248,6 +248,22 @@ XSS on a public Lambda URL. The not-found branch (`:672`) and the field rows
 presentation layer is not affected — it routes all dynamic content through
 `Escape.html`; this is the parallel Rust reimplementation missing the same
 guard.
+
+**Fixed**: the two call sites this described (now `web.rs`'s `aggregate_index`
+row-action-link builder and `record_show`'s action-link/heading, current line
+numbers have shifted since this was written) were extracted into two small,
+unit-tested functions — `action_link` (HTML-escapes the link text, percent-
+encodes `id` via the existing `auth::urlencode` for the query-string
+position — `esc()` alone isn't enough there, a raw `&` would smuggle a
+second bogus query parameter) and `index_row_html` (HTML-escapes `id` for
+both the path segment and the link text). The `<title>`/`<h1>` mentions
+above don't independently apply to the current code: `page()`'s own title
+parameter was already routed through `esc()`, confirmed by direct reading
+before this fix — only the two call sites named here were ever actually
+raw. The bundled URL-encoding gap noted in the parenthetical is fixed for
+these same two lines as part of this change; the broader L12 finding
+(URL-encoding generally, other call sites, both runtimes) is unchanged and
+still open.
 
 ### H11 — Session HMAC fails open when `SESSION_SECRET` is empty
 

--- a/docs/audits/2026-08-11-bug-triage.md
+++ b/docs/audits/2026-08-11-bug-triage.md
@@ -69,7 +69,7 @@ exposure.
 
 | ID | One-line | File | Confidence |
 | --- | --- | --- | --- |
-| H10 | Stored XSS via record id — the Rust web layer interpolates the aggregate id raw into link text/`href`/`<title>`/`<h1>`; every other value routes through `esc()`. Ruby presentation layer is unaffected. | `rust/host/src/web.rs:639,706` | likely |
+| H10 | ~~Stored XSS via record id~~ — **fixed 2026-08-22**: the two call sites now route through `action_link`/`index_row_html` (`rust/host/src/web.rs`), which HTML-escape the id everywhere it's rendered and percent-encode it in the query-string position. | `rust/host/src/web.rs` (`action_link`, `index_row_html`) | fixed |
 | H11 | Session HMAC fails open on an empty `SESSION_SECRET` — unset, cookie/OAuth-state HMAC keys on a known empty string. Not currently exploitable (prod sets it from Secrets Manager) but fails open instead of refusing to boot, unlike every other required var. | `rust/host/src/web.rs:90` | likely (latent) |
 | L12 | Record ids are HTML-escaped but never URL-encoded in `href`/`Location` — `&`, `+`, `?`, `#` in an id corrupt the link | `presentation/record_renderer.rb:75` | — |
 | L20 | `rename-schema` interpolates `$(OLD)`/`$(NEW)` unsanitized into SQL — operator-only, but against prod RDS | `bin/project_deploy:1517` | — |

--- a/lib/hecksagain/bluebook/assembly/marks.rb
+++ b/lib/hecksagain/bluebook/assembly/marks.rb
@@ -127,7 +127,7 @@ module Hecksagain
 
           # `:delegate` (CommandBuilder#delegates_to's own comment) rides
           # the SAME multi-binding shape `:append` does.
-          return Mutation.new(target: target, op: op, source: appended(change[:fields])) if op == :append || op == :delegate
+          return Mutation.new(target: target, op: op, source: appended(change[:fields])) if [:append, :delegate].include?(op)
 
           Mutation.new(target: target, op: op, source: classified(change[:source]))
         end

--- a/lib/hecksagain/bluebook/command.rb
+++ b/lib/hecksagain/bluebook/command.rb
@@ -39,7 +39,7 @@ module Hecksagain
       # the tail, which is why a construct with a variable shape needs no
       # new mixin API.
       def to_h
-        return super.merge(fields: appended_fields) if op == :append || op == :delegate
+        return super.merge(fields: appended_fields) if [:append, :delegate].include?(op)
 
         super.merge(source: classified_source)
       end

--- a/lib/hecksagain/bluebook/meta_validator/readings.rb
+++ b/lib/hecksagain/bluebook/meta_validator/readings.rb
@@ -158,7 +158,7 @@ module Hecksagain
             # `:delegate` (CommandBuilder#delegates_to's own comment) rides
             # the SAME multi-binding shape `:append` does — `with: {...}`
             # is a field map, same as append's own `fields:`.
-            next set_row(mutation) unless mutation.op == :append || mutation.op == :delegate
+            next set_row(mutation) unless [:append, :delegate].include?(mutation.op)
 
             mutation.source.map do |field, argument|
               # Spelled the way Mutation#appended_fields spells it, because

--- a/lib/hecksagain/bluebook/meta_validator/shapes.rb
+++ b/lib/hecksagain/bluebook/meta_validator/shapes.rb
@@ -221,7 +221,7 @@ module Hecksagain
           base = { target: target.to_sym, op: op.to_sym, sign: Hecksagain::Bluebook::Mutation.sign_for(op) }
           # `:delegate` (CommandBuilder#delegates_to's own comment) rides
           # the SAME multi-binding shape `:append` does.
-          return base.merge(fields: appended(bindings)) if op == "append" || op == "delegate"
+          return base.merge(fields: appended(bindings)) if ["append", "delegate"].include?(op)
 
           base.merge(source: classified(bindings.first))
         end

--- a/lib/hecksagain/runtime/command_interpreter.rb
+++ b/lib/hecksagain/runtime/command_interpreter.rb
@@ -41,7 +41,7 @@ module Hecksagain
         @rules    = rules
       end
 
-      # `dry_run:` — Dispatcher#dry_run's own entry point. Every step up
+      # `dry_run:` — Dispatcher#dry_run?'s own entry point. Every step up
       # through enforce_ensures/enforce_invariants runs exactly as a real
       # dispatch would (givens checked, mutations applied to `ctx.instance`
       # in memory); `step_save`/`step_emit` are the only two that read this
@@ -138,12 +138,12 @@ module Hecksagain
           entity_name, _dot, command_name = delegation.target.to_s.rpartition(".")
           entity = ctx.aggregate.entities.find { |e| e.hecks_name == entity_name } ||
                    raise(WiringError, "#{ctx.command.hecks_name} delegates_to #{entity_name}." \
-                                       "#{command_name}, but #{ctx.aggregate.hecks_name} has no " \
-                                       "entity named #{entity_name.inspect}")
+                                      "#{command_name}, but #{ctx.aggregate.hecks_name} has no " \
+                                      "entity named #{entity_name.inspect}")
           target_command = entity.command(command_name) ||
                            raise(WiringError, "#{ctx.command.hecks_name} delegates_to " \
-                                               "#{entity_name}.#{command_name}, which " \
-                                               "#{entity_name} declares no such command")
+                                              "#{entity_name}.#{command_name}, which " \
+                                              "#{entity_name} declares no such command")
 
           # `with:` REMAPS, it does not ENUMERATE — starting from a copy
           # of THIS command's own already-resolved args (`ctx.args`) and
@@ -191,7 +191,7 @@ module Hecksagain
         step(:enforce_invariants) { @rules.enforce_invariants(ctx.instance, ctx.aggregate, domain: ctx.domain) }
       end
 
-      # `dry_run:` skips this — see Dispatcher#dry_run's own comment. The
+      # `dry_run:` skips this — see Dispatcher#dry_run?'s own comment. The
       # same conditional-skip shape `step_assign_creation_attributes`
       # already has (`return unless ctx.command.creates?`), not a new
       # pattern: a step that does not apply this time traces nothing,
@@ -209,7 +209,7 @@ module Hecksagain
       # into `@rules.emit` for a command with no announced events at all.
       #
       # `dry_run:` skips this too, same reasoning as `step_save` — nothing
-      # was committed, so `ctx.result` stays nil and `Dispatcher#dry_run`
+      # was committed, so `ctx.result` stays nil and `Dispatcher#dry_run?`
       # never reads it (its own return value is just whether this raised).
       def step_emit(ctx)
         return if ctx.dry_run

--- a/lib/hecksagain/runtime/dispatcher.rb
+++ b/lib/hecksagain/runtime/dispatcher.rb
@@ -131,7 +131,7 @@ module Hecksagain
       # (an external gateway call, say) have no meaningful in-memory-only
       # form, so this refuses one outright rather than silently running
       # it for real, which "dry" would otherwise quietly lie about.
-      def dry_run(verb, **args)
+      def dry_run?(verb, **args)
         domain, aggregate_name, command_name = parse(verb)
         aggregate = resolve_aggregate(domain, aggregate_name, verb)
 

--- a/lib/hecksagain/runtime/entity_element.rb
+++ b/lib/hecksagain/runtime/entity_element.rb
@@ -135,10 +135,8 @@ module Hecksagain
         fields       = mutation.source.transform_values { |source| resolve_element_append_source(source, element, args) }
         element_type = entity.attribute(mutation.target)&.type
         value_object = aggregate.value_object(element_type)
-        if value_object
-          value_object.attributes.each do |attribute|
-            fields[attribute.name] = Value.scalar(fields[attribute.name]) if fields[attribute.name].is_a?(Value)
-          end
+        value_object&.attributes&.each do |attribute|
+          fields[attribute.name] = Value.scalar(fields[attribute.name]) if fields[attribute.name].is_a?(Value)
         end
         appended = value_object ? Value.build(value_object, fields, aggregate) : fields
         Freezer.deep(Array(element[mutation.target]) + [appended])

--- a/lib/hecksagain/runtime/entity_interpreter.rb
+++ b/lib/hecksagain/runtime/entity_interpreter.rb
@@ -50,7 +50,7 @@ module Hecksagain
       end
 
       # `dry_run:` — CommandInterpreter#call's own twin, see that method's
-      # comment for the shared reasoning (Dispatcher#dry_run's own entry
+      # comment for the shared reasoning (Dispatcher#dry_run?'s own entry
       # point). `step_save`/`step_emit` are the only two steps here that
       # read it either.
       def call(domain, aggregate, dotted, args, dry_run: false)
@@ -180,7 +180,7 @@ module Hecksagain
       end
 
       # `dry_run:` skips this too — nothing was committed, so `ctx.result`
-      # stays nil and `Dispatcher#dry_run` never reads it.
+      # stays nil and `Dispatcher#dry_run?` never reads it.
       def step_emit(ctx)
         return if ctx.dry_run
 

--- a/rust/host/src/auth.rs
+++ b/rust/host/src/auth.rs
@@ -536,7 +536,7 @@ fn base64_decode(input: &str) -> Vec<u8> {
     out
 }
 
-fn urlencode(s: &str) -> String {
+pub(crate) fn urlencode(s: &str) -> String {
     let mut out = String::new();
     for b in s.bytes() {
         match b {

--- a/rust/host/src/web.rs
+++ b/rust/host/src/web.rs
@@ -829,12 +829,10 @@ async fn aggregate_index(domain_name: &str, aggregate: &Value, format: &str, cli
                 .iter()
                 .map(|c| {
                     let cn = c.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                    format!(r#"<a href="/{domain_name}/{agg}/{cn}.html?id={id}" class="text-indigo-600 hover:underline mr-3">{cn}</a>"#)
+                    action_link(domain_name, agg, cn, id, "text-indigo-600 hover:underline mr-3")
                 })
                 .collect();
-            format!(
-                r#"<tr><td class="px-3 py-2 font-mono text-xs"><a href="/{domain_name}/{agg}/{id}.html" class="text-indigo-600 hover:underline">{id}</a></td><td class="px-3 py-2">{actions}</td></tr>"#
-            )
+            index_row_html(domain_name, agg, id, &actions)
         })
         .collect();
 
@@ -889,15 +887,16 @@ async fn record_show(domain_name: &str, aggregate: &Value, id: &str, format: &st
                 .filter(|c| !c.get("references").map(|r| r.is_null()).unwrap_or(true))
                 .map(|c| {
                     let cn = c.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                    format!(r#"<a href="/{domain_name}/{agg}/{cn}.html?id={id}" class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-500 mr-3">{cn}</a>"#)
+                    action_link(domain_name, agg, cn, id, "rounded-md bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-500 mr-3")
                 })
                 .collect::<String>()
         })
         .unwrap_or_default();
     let body = format!(
-        r#"<h1 class="text-2xl font-bold">{agg} <span class="font-mono text-lg text-slate-500">{id}</span></h1>
+        r#"<h1 class="text-2xl font-bold">{} <span class="font-mono text-lg text-slate-500">{}</span></h1>
         <dl class="mt-4 divide-y divide-slate-200 border border-slate-200 rounded-md bg-white">{rows}</dl>
-        <div class="mt-6">{actions}<a href="/{domain_name}/{agg}.html" class="text-indigo-600 hover:underline">← {agg} list</a></div>"#
+        <div class="mt-6">{actions}<a href="/{domain_name}/{agg}.html" class="text-indigo-600 hover:underline">← {agg} list</a></div>"#,
+        esc(agg), esc(id)
     );
     html(200, &page(&format!("{agg} {id}"), &body))
 }
@@ -1166,6 +1165,40 @@ fn esc(value: &str) -> String {
     value.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&quot;").replace('\'', "&#39;")
 }
 
+// H10 (docs/audits/2026-08-10-main-bug-audit.md) — `id` is a record's own
+// identity, free-form and user-supplied unless `pattern:`-constrained, NOT
+// a bluebook-declared name the way `agg`/`domain_name`/`cn` are. Every
+// call site that places `id` into rendered HTML routes through one of
+// these two functions so escaping (and, for the query-string position,
+// percent-encoding) can't be forgotten at a THIRD call site the way it
+// was at these two before this fix — Ruby's own `Escape.html`/`.attr`
+// already covers `id` everywhere (`record_table.rb:45`, `record_
+// renderer.rb:43,79`); this closes the parallel Rust gap, not a new
+// capability Ruby lacks too.
+//
+// `id` goes into a QUERY-STRING value here (`?id=...`), not just an HTML
+// attribute — `esc()` alone is not enough (a raw `&` would end the
+// parameter early, corrupting `cn` as a second bogus param), so this
+// percent-encodes via `auth::urlencode` (already RFC3986-unreserved-safe,
+// already exercised by the OAuth redirect path) rather than HTML-escaping
+// the query value. `cn` is still `esc()`-escaped for the link text/href
+// segment, even though it's bluebook-declared rather than user input —
+// cheap, consistent, and never wrong.
+fn action_link(domain_name: &str, agg: &str, cn: &str, id: &str, class: &str) -> String {
+    format!(r#"<a href="/{domain_name}/{agg}/{}.html?id={}" class="{class}">{}</a>"#, esc(cn), auth::urlencode(id), esc(cn))
+}
+
+// The row's own link to itself — `id` sits in a PATH segment here, not a
+// query value, so `esc()` (not percent-encoding) is the right guard,
+// matching what the sibling not-found/field-row branches already do
+// correctly (`html_not_found`, the field-value `<dd>` rows).
+fn index_row_html(domain_name: &str, agg: &str, id: &str, actions: &str) -> String {
+    let id = esc(id);
+    format!(
+        r#"<tr><td class="px-3 py-2 font-mono text-xs"><a href="/{domain_name}/{agg}/{id}.html" class="text-indigo-600 hover:underline">{id}</a></td><td class="px-3 py-2">{actions}</td></tr>"#
+    )
+}
+
 fn page(title: &str, body: &str) -> String {
     format!(
         r#"<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{}</title><script src="https://cdn.tailwindcss.com"></script></head><body class="bg-slate-50 text-slate-900 min-h-screen"><header class="bg-white border-b border-slate-200"><div class="max-w-3xl mx-auto px-4 py-3"><a href="/" class="font-semibold text-slate-900">rust/host — served straight off the bluebook IR</a></div></header><main class="max-w-3xl mx-auto px-4 py-8">{}</main></body></html>"#,
@@ -1192,6 +1225,48 @@ fn respond(status: u16, content_type: &str, body: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // H10 (docs/audits/2026-08-10-main-bug-audit.md) — a record's own
+    // identity is user-supplied, free-form unless `pattern:`-constrained,
+    // and used to be interpolated raw at these two call sites. A creating
+    // command persisting this exact id used to render live, executable
+    // markup for every later viewer of the index row or record page.
+    const MALICIOUS_ID: &str = r#"x"><script>alert(1)</script>"#;
+
+    #[test]
+    fn action_link_escapes_the_link_text_and_percent_encodes_the_query_value() {
+        let link = action_link("Pizzas", "Order", "Purchase", MALICIOUS_ID, "mr-3");
+
+        assert!(!link.contains("<script"), "{link}");
+        assert!(!link.contains(MALICIOUS_ID), "the raw id must not survive into the rendered link: {link}");
+        // The query VALUE must be percent-encoded, not HTML-escaped —
+        // `esc()` alone leaves a raw `&` in a `values.each` id, say, which
+        // would terminate the `id=` param early and smuggle a second
+        // bogus query parameter in.
+        assert!(link.contains("id=x%22%3E%3Cscript%3Ealert%281%29%3C%2Fscript%3E"), "{link}");
+    }
+
+    #[test]
+    fn action_link_renders_an_ordinary_id_unchanged() {
+        let link = action_link("Pizzas", "Order", "Purchase", "p1", "mr-3");
+        assert_eq!(link, r#"<a href="/Pizzas/Order/Purchase.html?id=p1" class="mr-3">Purchase</a>"#);
+    }
+
+    #[test]
+    fn index_row_html_escapes_the_id_in_both_the_link_text_and_the_path_segment() {
+        let row = index_row_html("Pizzas", "Order", MALICIOUS_ID, "");
+        assert!(!row.contains("<script"), "{row}");
+        assert!(row.contains("&lt;script&gt;"), "{row}");
+    }
+
+    #[test]
+    fn index_row_html_renders_an_ordinary_id_unchanged() {
+        let row = index_row_html("Pizzas", "Order", "p1", "");
+        assert_eq!(
+            row,
+            r#"<tr><td class="px-3 py-2 font-mono text-xs"><a href="/Pizzas/Order/p1.html" class="text-indigo-600 hover:underline">p1</a></td><td class="px-3 py-2"></td></tr>"#
+        );
+    }
 
     // Real corpus shapes throughout (examples/banking/bluebook/
     // banking.bluebook, examples/pizzas/bluebook/pizzas.bluebook) — read

--- a/spec/runtime/dry_run_spec.rb
+++ b/spec/runtime/dry_run_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-# Dispatcher#dry_run's own comment has the full reasoning — built for a
+# Dispatcher#dry_run?'s own comment has the full reasoning — built for a
 # downstream chess domain's own whole-board postcondition tests ("does
 # this move leave my own king in check"), which previously had to
 # dispatch a real, unrelated piece's own move purely to trigger the
@@ -11,7 +11,7 @@ require "spec_helper"
 # event, which is exactly the surface dry_run needs to prove itself
 # against: does a dry run see through the delegation, and does it
 # correctly reach NEITHER persistence NOR reactions in either shape.
-RSpec.describe "Dispatcher#dry_run" do
+RSpec.describe "Dispatcher#dry_run?" do
   DRY_RUN_FIXTURE = File.join(InMemoryDomain::ROOT, "spec/fixtures/delegates_to/delegates_to.bluebook")
 
   def boot
@@ -38,7 +38,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b1" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b1", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    result = runtime.dry_run("DelegatesTo::Board.Piece.Move", name: "b1", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    result = runtime.dry_run?("DelegatesTo::Board.Piece.Move", name: "b1", id: { value: "p1" }, to: { file: 5, rank: 5 })
 
     expect(result).to be(true)
     expect(board(runtime, "b1")[:pieces].first[:square].to_h).to eq(file: 3, rank: 3)
@@ -50,7 +50,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b2", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
     expect {
-      runtime.dry_run("DelegatesTo::Board.Piece.Move", name: "b2", id: { value: "p1" }, to: { file: 3, rank: 3 })
+      runtime.dry_run?("DelegatesTo::Board.Piece.Move", name: "b2", id: { value: "p1" }, to: { file: 3, rank: 3 })
     }.to raise_error(Hecksagain::Runtime::GivenNotMet, /destination differs from current square/)
   end
 
@@ -64,7 +64,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b3" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b3", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    result = runtime.dry_run("DelegatesTo::Board.MovePiece", name: "b3", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    result = runtime.dry_run?("DelegatesTo::Board.MovePiece", name: "b3", id: { value: "p1" }, to: { file: 5, rank: 5 })
 
     expect(result).to be(true)
     expect(board(runtime, "b3")[:pieces].first[:square].to_h).to eq(file: 3, rank: 3)
@@ -73,14 +73,14 @@ RSpec.describe "Dispatcher#dry_run" do
   # POLICIES MUST NEVER FIRE — `move_count` (bumped by
   # OnPieceMovedBumpMoveCount, the same policy delegates_to_spec.rb's
   # own ambient-args test uses) staying at its default proves
-  # Dispatcher#dry_run never reaches `announced.each { @policies.react
+  # Dispatcher#dry_run? never reaches `announced.each { @policies.react
   # }` at all, not merely that it reacted and rescued something.
   it "never triggers a policy reaction — nothing was announced to react to" do
     runtime = boot
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b4" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b4", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    runtime.dry_run("DelegatesTo::Board.MovePiece", name: "b4", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    runtime.dry_run?("DelegatesTo::Board.MovePiece", name: "b4", id: { value: "p1" }, to: { file: 5, rank: 5 })
 
     expect(board(runtime, "b4")[:move_count].to_h).to eq(value: 0)
   end
@@ -90,7 +90,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b5" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b5", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    runtime.dry_run("DelegatesTo::Board.MovePiece", name: "b5", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    runtime.dry_run?("DelegatesTo::Board.MovePiece", name: "b5", id: { value: "p1" }, to: { file: 5, rank: 5 })
     runtime.dispatch("DelegatesTo::Board.MovePiece", name: "b5", id: { value: "p1" }, to: { file: 6, rank: 6 })
 
     expect(board(runtime, "b5")[:pieces].first[:square].to_h).to eq(file: 6, rank: 6)
@@ -99,7 +99,7 @@ RSpec.describe "Dispatcher#dry_run" do
 
   # No port-bearing fixture was worth building fresh for this alone —
   # the guard itself is a plain, direct `if aggregate.port(head) then
-  # raise else entity dispatch` two-liner in Dispatcher#dry_run, read
+  # raise else entity dispatch` two-liner in Dispatcher#dry_run?, read
   # and confirmed correct rather than exercised through a dedicated
   # fixture. Named here so the gap is visible, not silently assumed
   # covered.


### PR DESCRIPTION
## Summary

Fixes **H10** (`docs/audits/2026-08-10-main-bug-audit.md`, `docs/audits/2026-08-11-bug-triage.md`) — a stored XSS in `rust/host`'s web layer via the record id.

The aggregate `id` — free-form, user-supplied at creation time unless `pattern:`-constrained — was interpolated raw into rendered HTML at 4 sites (`aggregate_index`'s row/action links, `record_show`'s action links/heading), while every other value already routed through `esc()`. A creating command whose identity is `x"><script>alert(1)</script>` would persist, then execute for every later viewer of that record's index row or record-show page. Ruby's own presentation layer was never affected (`Escape.html`/`.attr` already covers `id` everywhere) — this was a Rust-only regression.

### Fix

Extracted the two duplicated inline action-link builders into one shared `action_link(domain_name, agg, cn, id, class)` function, plus a new `index_row_html` for the row's own self-link — both now the single place `id` enters rendered HTML.

`id` needed two different guards depending on context, not one:
- **Query-string value** (`?id=...`, in `action_link`) — HTML-escaping alone isn't sufficient (a raw `&` would terminate the `id` param early and smuggle a second bogus query parameter), so this percent-encodes via `auth::urlencode` (already a correct RFC3986-unreserved encoder, already exercised by the OAuth redirect path, now `pub(crate)`).
- **Path segment / plain text position** (`index_row_html`, the `record_show` heading) — `esc()`, matching what the sibling not-found/field-row branches already did correctly.

This also closes, for these two lines, the URL-encoding gap the audit bundled into H10's own citation. The broader **L12** finding (URL-encoding generally, other call sites, both runtimes) is deliberately untouched — separate, wider work.

4 new unit tests mirror the file's existing pure-function test style (no DB/wasm harness needed): each of `action_link`/`index_row_html` gets a malicious-id case and an ordinary-id regression case.

Both audit docs updated in place to record H10 as fixed, pointing at the actual functions.

## Base

Rebased onto #338 (8 pre-existing rubocop offenses on `main`, unrelated to this fix, cherry-picked from the separate lineage branch that already fixed them) — this PR's own diff is clean, no `--no-verify` needed once #338 lands first.

## Verification

- `cargo build`/`cargo test` in `rust/host` — all `web::tests` pass (13/13, including the 4 new ones).
- `bundle exec rubocop` clean; full `bundle exec rspec` suite and fuzzer green via the repo's own pre-push/post-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)