### PR TITLE
style: fix 8 pre-existing rubocop offenses on main

### DIFF
--- a/lib/hecksagain/bluebook/assembly/marks.rb
+++ b/lib/hecksagain/bluebook/assembly/marks.rb
@@ -127,7 +127,7 @@ module Hecksagain
 
           # `:delegate` (CommandBuilder#delegates_to's own comment) rides
           # the SAME multi-binding shape `:append` does.
-          return Mutation.new(target: target, op: op, source: appended(change[:fields])) if op == :append || op == :delegate
+          return Mutation.new(target: target, op: op, source: appended(change[:fields])) if [:append, :delegate].include?(op)
 
           Mutation.new(target: target, op: op, source: classified(change[:source]))
         end

--- a/lib/hecksagain/bluebook/command.rb
+++ b/lib/hecksagain/bluebook/command.rb
@@ -39,7 +39,7 @@ module Hecksagain
       # the tail, which is why a construct with a variable shape needs no
       # new mixin API.
       def to_h
-        return super.merge(fields: appended_fields) if op == :append || op == :delegate
+        return super.merge(fields: appended_fields) if [:append, :delegate].include?(op)
 
         super.merge(source: classified_source)
       end

--- a/lib/hecksagain/bluebook/meta_validator/readings.rb
+++ b/lib/hecksagain/bluebook/meta_validator/readings.rb
@@ -158,7 +158,7 @@ module Hecksagain
             # `:delegate` (CommandBuilder#delegates_to's own comment) rides
             # the SAME multi-binding shape `:append` does — `with: {...}`
             # is a field map, same as append's own `fields:`.
-            next set_row(mutation) unless mutation.op == :append || mutation.op == :delegate
+            next set_row(mutation) unless [:append, :delegate].include?(mutation.op)
 
             mutation.source.map do |field, argument|
               # Spelled the way Mutation#appended_fields spells it, because

--- a/lib/hecksagain/bluebook/meta_validator/shapes.rb
+++ b/lib/hecksagain/bluebook/meta_validator/shapes.rb
@@ -221,7 +221,7 @@ module Hecksagain
           base = { target: target.to_sym, op: op.to_sym, sign: Hecksagain::Bluebook::Mutation.sign_for(op) }
           # `:delegate` (CommandBuilder#delegates_to's own comment) rides
           # the SAME multi-binding shape `:append` does.
-          return base.merge(fields: appended(bindings)) if op == "append" || op == "delegate"
+          return base.merge(fields: appended(bindings)) if ["append", "delegate"].include?(op)
 
           base.merge(source: classified(bindings.first))
         end

--- a/lib/hecksagain/runtime/command_interpreter.rb
+++ b/lib/hecksagain/runtime/command_interpreter.rb
@@ -41,7 +41,7 @@ module Hecksagain
         @rules    = rules
       end
 
-      # `dry_run:` — Dispatcher#dry_run's own entry point. Every step up
+      # `dry_run:` — Dispatcher#dry_run?'s own entry point. Every step up
       # through enforce_ensures/enforce_invariants runs exactly as a real
       # dispatch would (givens checked, mutations applied to `ctx.instance`
       # in memory); `step_save`/`step_emit` are the only two that read this
@@ -138,12 +138,12 @@ module Hecksagain
           entity_name, _dot, command_name = delegation.target.to_s.rpartition(".")
           entity = ctx.aggregate.entities.find { |e| e.hecks_name == entity_name } ||
                    raise(WiringError, "#{ctx.command.hecks_name} delegates_to #{entity_name}." \
-                                       "#{command_name}, but #{ctx.aggregate.hecks_name} has no " \
-                                       "entity named #{entity_name.inspect}")
+                                      "#{command_name}, but #{ctx.aggregate.hecks_name} has no " \
+                                      "entity named #{entity_name.inspect}")
           target_command = entity.command(command_name) ||
                            raise(WiringError, "#{ctx.command.hecks_name} delegates_to " \
-                                               "#{entity_name}.#{command_name}, which " \
-                                               "#{entity_name} declares no such command")
+                                              "#{entity_name}.#{command_name}, which " \
+                                              "#{entity_name} declares no such command")
 
           # `with:` REMAPS, it does not ENUMERATE — starting from a copy
           # of THIS command's own already-resolved args (`ctx.args`) and
@@ -191,7 +191,7 @@ module Hecksagain
         step(:enforce_invariants) { @rules.enforce_invariants(ctx.instance, ctx.aggregate, domain: ctx.domain) }
       end
 
-      # `dry_run:` skips this — see Dispatcher#dry_run's own comment. The
+      # `dry_run:` skips this — see Dispatcher#dry_run?'s own comment. The
       # same conditional-skip shape `step_assign_creation_attributes`
       # already has (`return unless ctx.command.creates?`), not a new
       # pattern: a step that does not apply this time traces nothing,
@@ -209,7 +209,7 @@ module Hecksagain
       # into `@rules.emit` for a command with no announced events at all.
       #
       # `dry_run:` skips this too, same reasoning as `step_save` — nothing
-      # was committed, so `ctx.result` stays nil and `Dispatcher#dry_run`
+      # was committed, so `ctx.result` stays nil and `Dispatcher#dry_run?`
       # never reads it (its own return value is just whether this raised).
       def step_emit(ctx)
         return if ctx.dry_run

--- a/lib/hecksagain/runtime/dispatcher.rb
+++ b/lib/hecksagain/runtime/dispatcher.rb
@@ -131,7 +131,7 @@ module Hecksagain
       # (an external gateway call, say) have no meaningful in-memory-only
       # form, so this refuses one outright rather than silently running
       # it for real, which "dry" would otherwise quietly lie about.
-      def dry_run(verb, **args)
+      def dry_run?(verb, **args)
         domain, aggregate_name, command_name = parse(verb)
         aggregate = resolve_aggregate(domain, aggregate_name, verb)
 

--- a/lib/hecksagain/runtime/entity_element.rb
+++ b/lib/hecksagain/runtime/entity_element.rb
@@ -135,10 +135,8 @@ module Hecksagain
         fields       = mutation.source.transform_values { |source| resolve_element_append_source(source, element, args) }
         element_type = entity.attribute(mutation.target)&.type
         value_object = aggregate.value_object(element_type)
-        if value_object
-          value_object.attributes.each do |attribute|
-            fields[attribute.name] = Value.scalar(fields[attribute.name]) if fields[attribute.name].is_a?(Value)
-          end
+        value_object&.attributes&.each do |attribute|
+          fields[attribute.name] = Value.scalar(fields[attribute.name]) if fields[attribute.name].is_a?(Value)
         end
         appended = value_object ? Value.build(value_object, fields, aggregate) : fields
         Freezer.deep(Array(element[mutation.target]) + [appended])

--- a/lib/hecksagain/runtime/entity_interpreter.rb
+++ b/lib/hecksagain/runtime/entity_interpreter.rb
@@ -50,7 +50,7 @@ module Hecksagain
       end
 
       # `dry_run:` — CommandInterpreter#call's own twin, see that method's
-      # comment for the shared reasoning (Dispatcher#dry_run's own entry
+      # comment for the shared reasoning (Dispatcher#dry_run?'s own entry
       # point). `step_save`/`step_emit` are the only two steps here that
       # read it either.
       def call(domain, aggregate, dotted, args, dry_run: false)
@@ -180,7 +180,7 @@ module Hecksagain
       end
 
       # `dry_run:` skips this too — nothing was committed, so `ctx.result`
-      # stays nil and `Dispatcher#dry_run` never reads it.
+      # stays nil and `Dispatcher#dry_run?` never reads it.
       def step_emit(ctx)
         return if ctx.dry_run
 

--- a/spec/runtime/dry_run_spec.rb
+++ b/spec/runtime/dry_run_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-# Dispatcher#dry_run's own comment has the full reasoning — built for a
+# Dispatcher#dry_run?'s own comment has the full reasoning — built for a
 # downstream chess domain's own whole-board postcondition tests ("does
 # this move leave my own king in check"), which previously had to
 # dispatch a real, unrelated piece's own move purely to trigger the
@@ -11,7 +11,7 @@ require "spec_helper"
 # event, which is exactly the surface dry_run needs to prove itself
 # against: does a dry run see through the delegation, and does it
 # correctly reach NEITHER persistence NOR reactions in either shape.
-RSpec.describe "Dispatcher#dry_run" do
+RSpec.describe "Dispatcher#dry_run?" do
   DRY_RUN_FIXTURE = File.join(InMemoryDomain::ROOT, "spec/fixtures/delegates_to/delegates_to.bluebook")
 
   def boot
@@ -38,7 +38,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b1" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b1", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    result = runtime.dry_run("DelegatesTo::Board.Piece.Move", name: "b1", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    result = runtime.dry_run?("DelegatesTo::Board.Piece.Move", name: "b1", id: { value: "p1" }, to: { file: 5, rank: 5 })
 
     expect(result).to be(true)
     expect(board(runtime, "b1")[:pieces].first[:square].to_h).to eq(file: 3, rank: 3)
@@ -50,7 +50,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b2", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
     expect {
-      runtime.dry_run("DelegatesTo::Board.Piece.Move", name: "b2", id: { value: "p1" }, to: { file: 3, rank: 3 })
+      runtime.dry_run?("DelegatesTo::Board.Piece.Move", name: "b2", id: { value: "p1" }, to: { file: 3, rank: 3 })
     }.to raise_error(Hecksagain::Runtime::GivenNotMet, /destination differs from current square/)
   end
 
@@ -64,7 +64,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b3" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b3", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    result = runtime.dry_run("DelegatesTo::Board.MovePiece", name: "b3", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    result = runtime.dry_run?("DelegatesTo::Board.MovePiece", name: "b3", id: { value: "p1" }, to: { file: 5, rank: 5 })
 
     expect(result).to be(true)
     expect(board(runtime, "b3")[:pieces].first[:square].to_h).to eq(file: 3, rank: 3)
@@ -73,14 +73,14 @@ RSpec.describe "Dispatcher#dry_run" do
   # POLICIES MUST NEVER FIRE — `move_count` (bumped by
   # OnPieceMovedBumpMoveCount, the same policy delegates_to_spec.rb's
   # own ambient-args test uses) staying at its default proves
-  # Dispatcher#dry_run never reaches `announced.each { @policies.react
+  # Dispatcher#dry_run? never reaches `announced.each { @policies.react
   # }` at all, not merely that it reacted and rescued something.
   it "never triggers a policy reaction — nothing was announced to react to" do
     runtime = boot
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b4" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b4", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    runtime.dry_run("DelegatesTo::Board.MovePiece", name: "b4", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    runtime.dry_run?("DelegatesTo::Board.MovePiece", name: "b4", id: { value: "p1" }, to: { file: 5, rank: 5 })
 
     expect(board(runtime, "b4")[:move_count].to_h).to eq(value: 0)
   end
@@ -90,7 +90,7 @@ RSpec.describe "Dispatcher#dry_run" do
     runtime.dispatch("DelegatesTo::Board.OpenBoard", name: { value: "b5" })
     runtime.dispatch("DelegatesTo::Board.PlacePiece", name: "b5", id: { value: "p1" }, square: { file: 3, rank: 3 })
 
-    runtime.dry_run("DelegatesTo::Board.MovePiece", name: "b5", id: { value: "p1" }, to: { file: 5, rank: 5 })
+    runtime.dry_run?("DelegatesTo::Board.MovePiece", name: "b5", id: { value: "p1" }, to: { file: 5, rank: 5 })
     runtime.dispatch("DelegatesTo::Board.MovePiece", name: "b5", id: { value: "p1" }, to: { file: 6, rank: 6 })
 
     expect(board(runtime, "b5")[:pieces].first[:square].to_h).to eq(file: 6, rank: 6)
@@ -99,7 +99,7 @@ RSpec.describe "Dispatcher#dry_run" do
 
   # No port-bearing fixture was worth building fresh for this alone —
   # the guard itself is a plain, direct `if aggregate.port(head) then
-  # raise else entity dispatch` two-liner in Dispatcher#dry_run, read
+  # raise else entity dispatch` two-liner in Dispatcher#dry_run?, read
   # and confirmed correct rather than exercised through a dedicated
   # fixture. Named here so the gap is visible, not silently assumed
   # covered.


### PR DESCRIPTION
Cherry-picks the exact, already-verified fix from the ADR 0029/0030 lineage branch (commit 559638f8) onto main directly — these 8 offenses predate that branch and are unrelated to it, but were blocking clean pushes on every other branch cut from main (including the new XSS fix, #337).

- Style/MultipleComparison (marks.rb, command.rb, meta_validator/readings.rb, meta_validator/shapes.rb), Layout/LineEndStringConcatenationIndentation (command_interpreter.rb), and Style/SafeNavigation + its cascading indentation fixes (entity_element.rb) — all mechanical, rubocop -A.
- Naming/PredicateMethod on Dispatcher#dry_run: renamed to Dispatcher#dry_run? rather than suppressed (this codebase carries no rubocop:disable comments anywhere; the method always either raises or returns true, a real predicate shape). Every call site and comment naming the method updated (command_interpreter.rb, entity_interpreter.rb, spec/runtime/dry_run_spec.rb).

Verified: `bundle exec rubocop` clean (526 files, no offenses). Full rspec suite green via the repo's own post-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)