### PR TITLE
Defer whole-chapter validation + chapter-given resolution until a split chapter's files all load

### DIFF
--- a/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/aggregate_builder.rb
@@ -10,7 +10,7 @@ module Hecksagain
         include RuleReference
         include WordGate
 
-        def initialize(name, chapter_named_givens: {})
+        def initialize(name, chapter_named_givens: {}, chapter_pending_givens: [])
           @name          = name
           @value_objects = []
           @commands      = []
@@ -31,6 +31,12 @@ module Hecksagain
           # aggregate the same chapter builds. See `#given`'s own
           # comment for what this closes.
           @chapter_named_givens = chapter_named_givens
+          # A CHAPTER MAY BE SPLIT ACROSS FILES — threaded in the SAME
+          # way as `@chapter_named_givens`, one Array shared chapter-wide.
+          # See `#pending_chapter_given`'s own comment for what queues
+          # here and `BluebookBuilder#resolve_pending_chapter_givens!`
+          # for where it drains.
+          @chapter_pending_givens = chapter_pending_givens
           # DEFERRED CONSTRUCTION — `entity`/`command`/`query` push a
           # pending descriptor here instead of building immediately; see
           # `#drain_pending!`'s own comment for why.
@@ -317,10 +323,17 @@ module Hecksagain
         private
 
         # PRIMITIVE 2 (RuleReference#resolve_owner_keyed) — see that
-        # method's own comment for the pool shape; the four branches
-        # below (exact owner / unambiguous single candidate / none /
-        # ambiguous) are this construct's OWN refusal wording, not
-        # shared, since `declared_by:` only exists here so far.
+        # method's own comment for the pool shape; the three branches
+        # below (exact owner / unambiguous single candidate / ambiguous)
+        # are this construct's OWN refusal wording, not shared, since
+        # `declared_by:` only exists here so far. UNRESOLVED (no
+        # candidate yet, or `declared_by:` naming an aggregate that
+        # hasn't declared it yet) is no longer a fourth branch that
+        # raises HERE — see `#pending_chapter_given`, below, for why:
+        # a chapter split across files can genuinely reference a
+        # precondition a LATER file declares, and "not found among
+        # what's loaded so far" cannot tell that apart from "genuinely
+        # never declared" until every file has.
         def reference_named_chapter_given(description, declared_by:)
           verify_resolves_via!("given", "Aggregate", "owner_keyed")
           candidates = resolve_owner_keyed(@chapter_named_givens, description)
@@ -328,19 +341,11 @@ module Hecksagain
           named =
             if declared_by
               owner = Naming.demodulise(declared_by)
-              candidates[owner] ||
-                raise(Malformed,
-                      "#{@name}'s given #{description.inspect} names no precondition " \
-                      "#{owner} declares in this chapter — #{owner} either hasn't declared " \
-                      "#{description.inspect}, or declared_by: named the wrong aggregate")
+              candidates[owner] || pending_chapter_given(description, declared_by: owner)
             elsif candidates.size == 1
               candidates.values.first
             elsif candidates.empty?
-              raise(Malformed,
-                    "#{@name}'s given #{description.inspect} names no precondition " \
-                    "any aggregate in this chapter has declared yet — declare it once " \
-                    "with a block (some aggregate's own given(#{description.inspect}) " \
-                    "{ ... }), before the aggregates that reference it")
+              pending_chapter_given(description, declared_by: nil)
             else
               raise(Malformed,
                     "#{@name}'s given #{description.inspect} is ambiguous in this chapter — " \
@@ -350,6 +355,41 @@ module Hecksagain
             end
 
           @named_givens[description] = named
+        end
+
+        # A CHAPTER MAY BE SPLIT ACROSS FILES — the SAME reason a query
+        # hop's own cross-file target, a correlation key's own emitting
+        # command, and an event's own declared shape are all resolved
+        # once the whole chapter is assembled rather than refused the
+        # moment one file's own bare reference outruns what's loaded so
+        # far (`BluebookBuilder.validate_assembled!`'s own comment).
+        #
+        # Unlike those, though, a chapter-given's resolved value is not
+        # a pass/fail check on an already-built IR — it IS part of the
+        # referencing aggregate's own IR (`preconditions:` below), built
+        # and handed off the moment THIS aggregate's own file finishes
+        # loading, long before a later file might declare the real
+        # thing. So this hands back a PLACEHOLDER `Given` — embedded
+        # exactly where the resolved one would be, by Ruby object
+        # reference, in this aggregate's own `preconditions` AND in any
+        # command in this SAME aggregate that separately bare-references
+        # the same description (`CommandBuilder#given`'s own hash-chain
+        # read of this aggregate's `@named_givens`, the identical key) —
+        # and queues the request in `@chapter_pending_givens`.
+        # `BluebookBuilder#resolve_pending_chapter_givens!` MUTATES this
+        # exact object in place, once every file has loaded, so every
+        # existing reference to it (there is only ever the one object,
+        # never a copy) sees the resolved fields simultaneously. Safe
+        # because every real reader of a `Given` — refusal wording at
+        # dispatch, `Aggregate`'s own lazy `-> { preconditions.map { ... } }`
+        # IR accessor, docs — runs strictly after boot completes, never
+        # mid-load; `judge_deferred!` resolves every pending chapter-given
+        # before anything else touches this chapter's assembled IR.
+        def pending_chapter_given(description, declared_by:)
+          placeholder = Given.new(description: description, canonical: nil, predicate: nil)
+          @chapter_pending_givens << { aggregate: @name, description: description,
+                                        declared_by: declared_by, placeholder: placeholder }
+          placeholder
         end
 
         public
@@ -405,8 +445,8 @@ module Hecksagain
           ir
         end
 
-        def self.build(name, chapter_named_givens: {}, &block)
-          builder = new(name, chapter_named_givens: chapter_named_givens)
+        def self.build(name, chapter_named_givens: {}, chapter_pending_givens: [], &block)
+          builder = new(name, chapter_named_givens: chapter_named_givens, chapter_pending_givens: chapter_pending_givens)
           builder.instance_eval(&block) if block
           builder.build
         end

--- a/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
+++ b/lib/hecksagain/bluebook/dsl/bluebook_builder.rb
@@ -21,6 +21,13 @@ module Hecksagain
           # extended across an aggregate's whole entity tree, earlier
           # this arc). See `#given`'s own comment for what this closes.
           @chapter_named_givens = {}
+          # EVERY BARE CHAPTER-GIVEN REFERENCE THIS CHAPTER'S OWN FILES
+          # LEFT UNRESOLVED SO FAR — threaded into every aggregate the
+          # same way `@chapter_named_givens` is. See
+          # `AggregateBuilder#pending_chapter_given`'s own comment for
+          # what queues here and `#resolve_pending_chapter_givens!`,
+          # below, for where it drains.
+          @chapter_pending_givens = []
         end
 
         # Chapter metadata belongs to the composed folder, not whichever file
@@ -78,7 +85,8 @@ module Hecksagain
         # chapter's own top-level shape is written with it), so also
         # named in GenericDispatch::BOOTSTRAP_CALLS_FALLBACK.
         def aggregate_impl(name, &block)
-          @aggregates << AggregateBuilder.build(name, chapter_named_givens: @chapter_named_givens, &block)
+          @aggregates << AggregateBuilder.build(name, chapter_named_givens:   @chapter_named_givens,
+                                                      chapter_pending_givens: @chapter_pending_givens, &block)
         end
 
         # `read_model` is the word (ADR 0025 reverts `report` — the IR
@@ -111,17 +119,6 @@ module Hecksagain
         end
 
         def build
-          # moved to the language: an attribute type is a reference to its Shape,
-          # so an undeclared value object fails reference resolution
-          validate_reference_value_objects!
-          validate_correlation_keys!
-          validate_no_bidirectional_references!
-          policies = @aggregates.flat_map(&:policies) + @policies
-          unless MetaValidator.shadow_parsing?
-            validate_event_shapes!
-            validate_with_projections!(policies)
-          end
-
           # The chapter is the top of the construct chain — `Bluebook` is a
           # ROOT, and its constructor stamps every aggregate and read model with
           # itself as owner, so every `hecks_fqn` below resolves by walking up
@@ -131,11 +128,122 @@ module Hecksagain
           bluebook = Bluebook::Chapter.new(name: @name, version: @version, vision: @vision,
                                            aggregates: @aggregates,
                                            read_models: @read_models,
-                                           policies: policies,
+                                           policies: @aggregates.flat_map(&:policies) + @policies,
                                            process_managers: @process_managers,
                                            classification: @classification,
                                            formerly_known_as: @formerly_known_as,
                                            attaches_to: @attaches_to || [])
+
+          # SAME REASON, SAME GATE — a bare chapter-given may still be
+          # pending (see `AggregateBuilder#pending_chapter_given`) if a
+          # file that would resolve it hasn't loaded yet; resolving now
+          # would see the same incomplete `@chapter_named_givens`
+          # `validate_assembled!` below would. Deferred to
+          # `MetaValidator.judge_deferred!` the same way, and BEFORE
+          # `validate_assembled!` there — nothing downstream should ever
+          # read an unresolved placeholder's fields.
+          resolve_pending_chapter_givens! unless MetaValidator.deferring?
+
+          # A CHAPTER MAY BE SPLIT ACROSS FILES (see `self.build`'s own
+          # comment). Every check below needs the WHOLE chapter present —
+          # a hop, a projection, a correlation key or an event shape can
+          # equally name a construct declared in a file that has not
+          # loaded yet, and `@aggregates`/`@process_managers` here are
+          # only ever as complete as whatever has loaded SO FAR. So,
+          # exactly like `MetaValidator.call` below, this is skipped
+          # while `MetaValidator.defer` is loading the chapter's files
+          # and run once instead — by `MetaValidator.judge_deferred!`,
+          # against the fully assembled chapter — after the last one
+          # loads. A single-file chapter (still the common case) never
+          # sees `deferring?` true here at all, so its own checks still
+          # run inline, exactly as before.
+          self.class.validate_assembled!(bluebook) unless MetaValidator.deferring?
+
+          # The language judges the bluebook, in the language. Last, so the
+          # meta-domain sees a fully built IR — the whole-document rules need
+          # every declaration present, which is why they cannot be givens fired
+          # at declaration time.
+          MetaValidator.call(bluebook)
+        end
+
+        # THE OTHER HALF OF A CHAPTER-WIDE `given` REFERENCE —
+        # `AggregateBuilder#pending_chapter_given` recognised an
+        # unresolved bare reference and deferred it here, unable to
+        # check further: a later file in this SAME chapter might still
+        # declare the real thing. Runs once every file has loaded,
+        # against the now-complete `@chapter_named_givens` pool — the
+        # IDENTICAL lookup `reference_named_chapter_given` already does,
+        # just late enough to see every aggregate's own declarations,
+        # not only the ones loaded before the referencing one.
+        #
+        # MUTATES each placeholder `Given` IN PLACE rather than
+        # replacing it — it is already embedded, by Ruby object
+        # reference, in the referencing aggregate's own `preconditions`
+        # and in any command (same aggregate) that separately
+        # bare-referenced the same description, so there is nothing
+        # downstream holding a second, now-stale copy to update.
+        # Instance-level (not `self.`, unlike `validate_assembled!`) —
+        # unlike that battery, this needs `@chapter_named_givens` itself,
+        # which only exists on the builder instance still open for this
+        # chapter (`MetaValidator.judge_deferred!` reaches it via
+        # `registry.bluebook_builder(name)`, guaranteed already present).
+        def resolve_pending_chapter_givens!
+          @chapter_pending_givens.each do |entry|
+            resolved = resolve_pending_chapter_given(entry)
+            entry[:placeholder].description = resolved.description
+            entry[:placeholder].canonical   = resolved.canonical
+            entry[:placeholder].predicate   = resolved.predicate
+          end
+          @chapter_pending_givens.clear
+        end
+
+        def resolve_pending_chapter_given(entry)
+          description = entry[:description]
+          candidates  = RuleReference.resolve_owner_keyed(@chapter_named_givens, description)
+
+          if entry[:declared_by]
+            candidates[entry[:declared_by]] ||
+              raise(Malformed,
+                    "#{entry[:aggregate]}'s given #{description.inspect} names no precondition " \
+                    "#{entry[:declared_by]} declares in this chapter — #{entry[:declared_by]} " \
+                    "either hasn't declared #{description.inspect}, or declared_by: named the " \
+                    "wrong aggregate")
+          elsif candidates.size == 1
+            candidates.values.first
+          elsif candidates.empty?
+            raise(Malformed,
+                  "#{entry[:aggregate]}'s given #{description.inspect} names no precondition " \
+                  "any aggregate in this chapter ever declares — declare it once with a block " \
+                  "(some aggregate's own given(#{description.inspect}) { ... })")
+          else
+            raise(Malformed,
+                  "#{entry[:aggregate]}'s given #{description.inspect} is ambiguous in this " \
+                  "chapter — #{candidates.keys.join(', ')} each declare a DIFFERENT predicate " \
+                  "under this same description; name which one with declared_by: (e.g. " \
+                  "given(#{description.inspect}, declared_by: #{candidates.keys.first}))")
+          end
+        end
+        private :resolve_pending_chapter_given
+
+        # EVERY WHOLE-CHAPTER CHECK, IN ONE PLACE — the battery `#build`
+        # used to run inline, now a pure function of an assembled
+        # `Bluebook::Chapter` so `MetaValidator.judge_deferred!` can run
+        # it too, once, on a chapter whose files have ALL loaded (see
+        # `#build`'s own comment for why that split exists at all).
+        # Public, not `private_class_method`'d, for exactly that second
+        # caller — `MetaValidator` needs to reach this with no builder
+        # instance in hand, only the chapter `judge_deferred!` already
+        # read back out of the registry.
+        def self.validate_assembled!(bluebook)
+          # moved to the language: an attribute type is a reference to its Shape,
+          # so an undeclared value object fails reference resolution
+          validate_reference_value_objects!(bluebook.aggregates)
+          validate_correlation_keys!(bluebook.process_managers, bluebook.aggregates)
+          validate_no_bidirectional_references!(bluebook.aggregates)
+          unless MetaValidator.shadow_parsing?
+            validate_event_shapes!(bluebook.aggregates)
+            validate_with_projections!(bluebook.policies, bluebook.process_managers, bluebook.aggregates)
+          end
 
           # Every hop AggregateBuilder#seal_query_field recognised and
           # deferred gets checked for real here — the earliest point a
@@ -153,15 +261,7 @@ module Hecksagain
           # own reference cannot resolve until every aggregate in the
           # chapter is real and owner-stamped (S12, ADR 0025).
           validate_projected_fields!(bluebook)
-
-          # The language judges the bluebook, in the language. Last, so the
-          # meta-domain sees a fully built IR — the whole-document rules need
-          # every declaration present, which is why they cannot be givens fired
-          # at declaration time.
-          MetaValidator.call(bluebook)
         end
-
-        private
 
         # AN ENTITY COMMAND MAY NOT NAME ITSELF AS ITS ROOT.
         #
@@ -184,10 +284,10 @@ module Hecksagain
         # Reference ATTRIBUTES are the language's business now — offered as the
         # head's own id and resolved as references, so `Aggregate.Reference` and
         # `Command.Reference` refuse an undeclared head with no predicate at all.
-        def validate_reference_value_objects!
-          heads = @aggregates.map(&:hecks_name)
+        def self.validate_reference_value_objects!(aggregates)
+          heads = aggregates.map(&:hecks_name)
 
-          violations = @aggregates.flat_map do |aggregate|
+          violations = aggregates.flat_map do |aggregate|
             aggregate.entities.flat_map do |entity|
               entity.commands.filter_map do |command|
                 next unless command.references
@@ -220,11 +320,11 @@ module Hecksagain
         # claim about what the payload holds, so two emitting commands
         # are free to differ there without actually disagreeing about
         # the event's own shape.
-        def validate_event_shapes!
-          event_emitters.each do |event_name, pairs|
+        def self.validate_event_shapes!(aggregates)
+          event_emitters(aggregates).each do |event_name, pairs|
             next if pairs.size == 1
 
-            shapes = pairs.map { |(_, command)| event_shape(command) }.uniq
+            shapes = pairs.map { |(owner, command)| event_shape(command, owner_aggregate(owner, aggregates)) }.uniq
             next if shapes.size == 1
 
             named = pairs.map { |(owner, command)| "#{owner}.#{command.hecks_name}" }.sort
@@ -257,24 +357,25 @@ module Hecksagain
         # (does the dispatched command actually declare the field) still
         # runs, since that half is true regardless of where the value
         # came from.
-        def validate_with_projections!(policies)
-          lookup = command_lookup
+        def self.validate_with_projections!(policies, process_managers, aggregates)
+          lookup = command_lookup(aggregates)
+          heads  = correlation_heads(process_managers)
 
           policies.each do |policy|
             next if policy.with_spec.to_a.empty?
 
             source_event = policy.for_each.to_s.empty? ? policy.on_event : nil
             check_with_spec!(policy.trigger_command, source_event, policy.with_spec, lookup,
-                             "#{policy.name}'s trigger")
+                             "#{policy.name}'s trigger", aggregates, heads)
           end
 
-          @process_managers.each do |pm|
+          process_managers.each do |pm|
             pm.handlers.each do |handler|
               handler.dispatches.each do |dispatch|
                 next if dispatch.with_spec.to_a.empty?
 
                 check_with_spec!(dispatch.command_name, handler.event_type, dispatch.with_spec, lookup,
-                                 "#{pm.name}'s dispatch #{dispatch.command_name}", pm: pm)
+                                 "#{pm.name}'s dispatch #{dispatch.command_name}", aggregates, heads, pm: pm)
               end
             end
           end
@@ -292,14 +393,14 @@ module Hecksagain
         # no event carried" — `AccountDebited` never declares `:reference`,
         # only `TransferRequested` (`pm.starts_on`) does, and that is
         # where the value is genuinely still coming from.
-        def check_with_spec!(command_ref, event_name, with_spec, lookup, label, pm: nil)
+        def self.check_with_spec!(command_ref, event_name, with_spec, lookup, label, aggregates, correlation_heads, pm: nil)
           target        = lookup[command_ref]
-          source_shape  = event_name && event_shape_for(event_name)
-          memory_shape  = pm && event_shape_for(pm.starts_on)
+          source_shape  = event_name && event_shape_for(event_name, aggregates)
+          memory_shape  = pm && event_shape_for(pm.starts_on, aggregates)
           correlation   = pm && pm.correlates_by && pm.correlation_head
 
           with_spec.each do |field, source|
-            raise Malformed, "#{label}'s with: names #{field.inspect}, which #{command_ref} does not declare" if target && !command_declares?(target, field)
+            raise Malformed, "#{label}'s with: names #{field.inspect}, which #{command_ref} does not declare" if target && !command_declares?(target, field, aggregates, correlation_heads)
 
             next unless source.is_a?(::Symbol)
             next if source == correlation
@@ -328,13 +429,13 @@ module Hecksagain
         # legal here : this mirrors that gate rather than re-deriving a
         # narrower rule that would refuse one of two real, already-shipped
         # dispatch conventions.
-        def command_declares?(command, field)
+        def self.command_declares?(command, field, aggregates, correlation_heads)
           return true if command.attributes.any? { |a| a.name == field }
           return true if field == :id
           return true if correlation_heads.include?(field)
           return false unless command.references
 
-          referenced = @aggregates.find { |a| a.hecks_name == command.references }
+          referenced = aggregates.find { |a| a.hecks_name == command.references }
           return false unless referenced
 
           referenced.identity_heads.include?(field) || Naming.reference_key(command.references) == field
@@ -348,10 +449,8 @@ module Hecksagain
         # passthrough, not an addressing key"). A command declaring none of
         # its attributes named this is not a gap; the correlation key rides
         # through commands that never read it, same as it does at runtime.
-        # Recomputed on every build because a split chapter keeps this builder
-        # open while later files add process managers.
-        def correlation_heads
-          @process_managers.filter_map { |pm| pm.correlates_by && pm.correlation_head }
+        def self.correlation_heads(process_managers)
+          process_managers.filter_map { |pm| pm.correlates_by && pm.correlation_head }
         end
 
         # Every command this chapter declares, an aggregate's own AND
@@ -359,10 +458,10 @@ module Hecksagain
         # declares it — shared by `validate_event_shapes!` and
         # `validate_with_projections!`'s own command lookup, the same
         # reach `HecksagonBuilder#commands_in` needs one level up (S8).
-        def each_command
-          return enum_for(:each_command) unless block_given?
+        def self.each_command(aggregates)
+          return enum_for(:each_command, aggregates) unless block_given?
 
-          @aggregates.each do |aggregate|
+          aggregates.each do |aggregate|
             aggregate.commands.each { |command| yield aggregate.hecks_name, command }
             aggregate.entities.each do |entity|
               entity.commands.each { |command| yield "#{aggregate.hecks_name}.#{entity.hecks_name}", command }
@@ -370,25 +469,79 @@ module Hecksagain
           end
         end
 
-        def event_emitters
-          @event_emitters ||= each_command.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(owner, command), index|
+        # NOT MEMOISED — this used to be `@event_emitters ||=` on the
+        # builder instance, which is safe for a one-file chapter but
+        # wrong for one split across several: the FIRST file's build()
+        # call would compute and cache it from whatever `@aggregates`
+        # held at that moment, and every later file's own validation
+        # would keep reading that same stale snapshot, silently missing
+        # any command a later file adds. Recomputed fresh every call
+        # instead — this walks the whole chapter once per `#build`, not
+        # a hot path worth memoising at that cost.
+        def self.event_emitters(aggregates)
+          each_command(aggregates).each_with_object(Hash.new { |h, k| h[k] = [] }) do |(owner, command), index|
             command.emits.each { |event_name| index[event_name] << [owner, command] }
           end
         end
 
-        def event_shape(command)
-          command.attributes.map { |a| [a.name, a.type, a.list?, a.optional?] }.sort
+        # STRUCTURAL, NOT NOMINAL. Two commands on two different
+        # aggregates that both `emits "SameEvent"` are free to type a
+        # field through two DIFFERENT, locally-scoped wrapper value
+        # objects (e.g. one aggregate's own `value: SomeText` vs
+        # another's `value: OtherText`, exactly the per-aggregate "own
+        # text VO" convention every aggregate in this grammar already
+        # follows for everything from `RuleText` to `FieldRef`) without
+        # actually disagreeing about the event's shape — comparing
+        # `a.type` by NAME would flag that as a violation for no real
+        # reason: an event is one fact, and two isomorphic wrapper types
+        # tell an identical one. So a value-object type is unwrapped to
+        # its OWN attribute shape (recursively — a wrapper could itself
+        # wrap another) before comparing, and only a primitive type
+        # (nothing left to unwrap) or two VOs that truly differ once
+        # unwrapped still counts as a real mismatch. `owner` carries the
+        # type's `value_object` lookup — a command's own attributes only
+        # know their type's NAME, never the aggregate that declared it,
+        # and two sibling aggregates in one chapter each keep a
+        # same-named VO private to themselves, so the unwrap has to ask
+        # the SAME aggregate the field's own command belongs to, never a
+        # neighbor's.
+        def self.event_shape(command, owner)
+          command.attributes.map { |a| [a.name, unwrap_shape(owner, a.type.to_s), a.list?, a.optional?] }.sort
         end
 
-        def event_shape_for(event_name)
-          pairs = event_emitters.fetch(event_name.to_s, [])
+        def self.unwrap_shape(owner, type_name, seen = [])
+          return type_name if owner.nil? # owner couldn't be resolved -- compare by name, same as before this unwrap existed
+          return type_name if Attribute::PRIMITIVES.include?(type_name)
+          return type_name if seen.include?(type_name) # a self-referential VO bottoms out on its own name, not an infinite unwrap
+
+          shape = owner.value_object(type_name)
+          return type_name unless shape # not this owner's own VO (a reference type, say) -- nothing further to unwrap
+
+          shape.attributes.map { |a| [a.name, unwrap_shape(owner, a.type.to_s, seen + [type_name]), a.list?, a.optional?] }.sort
+        end
+
+        # `owner` (from `each_command`) is a plain STRING — the aggregate's
+        # `hecks_name` alone, or `"Aggregate.Entity"` for an entity's own
+        # command. Either way the VALUE OBJECTS a command's fields can be
+        # typed with are the AGGREGATE's own (`Entity` carries no
+        # `value_object` lookup of its own — the whole rest of this file
+        # already resolves hop/type lookups only at the aggregate level,
+        # e.g. `validate_hop_tail!`'s `target.value_object(type)`), so only
+        # the first segment ever matters here.
+        def self.owner_aggregate(owner, aggregates)
+          aggregates.find { |a| a.hecks_name == owner.to_s.split(".").first }
+        end
+
+        def self.event_shape_for(event_name, aggregates)
+          pairs = event_emitters(aggregates).fetch(event_name.to_s, [])
           return nil if pairs.empty?
 
-          event_shape(pairs.first.last)
+          owner_name, command = pairs.first
+          event_shape(command, owner_aggregate(owner_name, aggregates))
         end
 
-        def command_lookup
-          each_command.each_with_object({}) do |(owner, command), index|
+        def self.command_lookup(aggregates)
+          each_command(aggregates).each_with_object({}) do |(owner, command), index|
             index["#{owner}.#{command.hecks_name}"] = command
           end
         end
@@ -419,8 +572,8 @@ module Hecksagain
         # Self-reference stays legal (`parent.parent.name` for a
         # hierarchy is real and safe) — excluded the same way the
         # direct-pair check already excluded it.
-        def validate_no_bidirectional_references!
-          edges = @aggregates.each_with_object({}) do |aggregate, index|
+        def self.validate_no_bidirectional_references!(aggregates)
+          edges = aggregates.each_with_object({}) do |aggregate, index|
             index[aggregate.hecks_name] = aggregate.reference_targets.uniq.reject { |target| target == aggregate.hecks_name }
           end
 
@@ -438,7 +591,7 @@ module Hecksagain
         # Plain DFS with a visiting/done coloring, over the reference
         # graph THIS chapter's own aggregates declare. Returns the ring
         # itself (in the order it closes), or nil.
-        def find_reference_cycle(edges)
+        def self.find_reference_cycle(edges)
           state = {}
 
           edges.each_key do |start|
@@ -449,7 +602,7 @@ module Hecksagain
           nil
         end
 
-        def reference_cycle_from(node, edges, state, path)
+        def self.reference_cycle_from(node, edges, state, path)
           return nil if state[node] == :done
           return path[path.index(node)..] if state[node] == :visiting
 
@@ -493,7 +646,7 @@ module Hecksagain
         # member needs an entity query to cross a reference yet, and a
         # named refusal beats a runtime that resolves nothing while
         # looking like it might.
-        def validate_query_hops!(bluebook)
+        def self.validate_query_hops!(bluebook)
           bluebook.aggregates.each do |aggregate|
             aggregate.queries.each do |query|
               query.wheres.each do |clause|
@@ -512,7 +665,7 @@ module Hecksagain
         # built; here every Reference has an owner and target, so a symbolic
         # comparison can inherit the type of the scalar it compares without a
         # duplicate query-local declaration.
-        def infer_hop_query_arguments!(bluebook)
+        def self.infer_hop_query_arguments!(bluebook)
           bluebook.aggregates.each do |aggregate|
             aggregate.queries.each do |query|
               query.wheres.each do |clause|
@@ -543,7 +696,7 @@ module Hecksagain
           end
         end
 
-        def refuse_entity_query_hops!(aggregate, entity)
+        def self.refuse_entity_query_hops!(aggregate, entity)
           entity.queries.each do |query|
             query.wheres.each do |clause|
               next unless QuerySpecification::HopPath.hop_head?(clause.field, entity.attributes)
@@ -557,7 +710,7 @@ module Hecksagain
           end
         end
 
-        def validate_hop_clause!(aggregate, query, clause)
+        def self.validate_hop_clause!(aggregate, query, clause)
           plan = QuerySpecification::HopPath.plan(clause.field, aggregate.attributes)
 
           case plan.refusal
@@ -589,7 +742,7 @@ module Hecksagain
         # on a value object (refused by name), or naming nothing at all
         # (refused by name) — asked instead of the hop's TARGET aggregate,
         # since that is whose shape the tail actually has to answer for.
-        def validate_hop_tail!(aggregate, query, clause, target, tail)
+        def self.validate_hop_tail!(aggregate, query, clause, target, tail)
           name, *nested = tail.to_s.split(".")
           attribute = target.attributes.find { |candidate| candidate.name.to_s == name }
           return validate_hop_comparator!(aggregate, query, clause, target, attribute, nested) if
@@ -619,7 +772,7 @@ module Hecksagain
         # already deferred this exact check for the same reason every
         # other hop check is deferred, and this is where it gets asked,
         # against the hop's TARGET instead of the querying aggregate.
-        def validate_hop_comparator!(aggregate, query, clause, target, attribute, nested)
+        def self.validate_hop_comparator!(aggregate, query, clause, target, attribute, nested)
           return unless AggregateBuilder::ORDERED_COMPARATORS.include?(clause.op.to_s.to_sym)
           return if attribute &&
                     QuerySpecification::FieldPath.numeric?(attribute, nested) { |type| target.value_object(type) }
@@ -647,13 +800,13 @@ module Hecksagain
         # one resolution primitive. A single hop can never reach
         # HopPath::MAX_HOPS, so :too_deep is structurally unreachable
         # here and is not special-cased.
-        def validate_projected_fields!(bluebook)
+        def self.validate_projected_fields!(bluebook)
           bluebook.aggregates.each do |aggregate|
             aggregate.projected_fields.each { |field| validate_projected_field!(aggregate, field) }
           end
         end
 
-        def validate_projected_field!(aggregate, field)
+        def self.validate_projected_field!(aggregate, field)
           plan = QuerySpecification::HopPath.plan("#{field.reference}/#{field.remote_field}", aggregate.attributes)
 
           if plan.refusal == :unresolvable
@@ -688,7 +841,7 @@ module Hecksagain
                 "value, never a reference, a value object, or a list"
         end
 
-        def projectable_scalar?(target, attribute)
+        def self.projectable_scalar?(target, attribute)
           !attribute.list? && !attribute.reference? && target.value_object(attribute.type).nil?
         end
 
@@ -712,11 +865,11 @@ module Hecksagain
         # aggregate's own reference key; saga_interpreter/correlation.rb), so
         # an absent field is not this check's business. Only a field that
         # resolves, and resolves to something other than a scalar, is.
-        def validate_correlation_keys!
-          @process_managers.each do |pm|
+        def self.validate_correlation_keys!(process_managers, aggregates)
+          process_managers.each do |pm|
             next unless pm.correlates_by
 
-            reason = correlation_key_violation(pm)
+            reason = correlation_key_violation(pm, aggregates)
             next unless reason
 
             raise ProcessManagerBuilder::InvalidProcessManager,
@@ -724,11 +877,11 @@ module Hecksagain
           end
         end
 
-        def correlation_key_violation(pm)
+        def self.correlation_key_violation(pm, aggregates)
           head, *rest = pm.correlates_by.to_s.split(".")
           events = reacted_events(pm)
 
-          emitting_commands(events).each do |owner, command|
+          emitting_commands(events, aggregates).each do |owner, command|
             attribute = command.attributes.find { |a| a.name == head.to_sym }
             next unless attribute
 
@@ -739,7 +892,7 @@ module Hecksagain
           nil
         end
 
-        def reacted_events(pm)
+        def self.reacted_events(pm)
           ([pm.starts_on, pm.ends_on] + pm.handlers.map(&:event_type))
             .compact
             .reject { |event| event == ProcessManager::REFUSED }
@@ -747,15 +900,15 @@ module Hecksagain
             .uniq
         end
 
-        def emitting_commands(events)
-          @aggregates.flat_map do |aggregate|
+        def self.emitting_commands(events, aggregates)
+          aggregates.flat_map do |aggregate|
             commands = aggregate.commands + aggregate.entities.flat_map(&:commands)
             commands.select { |command| (command.emits.map(&:to_s) & events).any? }
                     .map { |command| [aggregate, command] }
           end
         end
 
-        def list_or_scalar_violation(owner, attribute, segments)
+        def self.list_or_scalar_violation(owner, attribute, segments)
           return "#{attribute.name} is a list — a correlation key must name one instance's own field, " \
                  "not a whole collection" if attribute.list?
 
@@ -769,7 +922,7 @@ module Hecksagain
         # a value object this domain never declared, a field that value
         # object does not have, or a segment left over after already
         # reaching a scalar.
-        def walk_scalar(owner, type_name, segments)
+        def self.walk_scalar(owner, type_name, segments)
           if segments.empty?
             return nil if Attribute::PRIMITIVES.include?(type_name)
 

--- a/lib/hecksagain/bluebook/meta_validator.rb
+++ b/lib/hecksagain/bluebook/meta_validator.rb
@@ -119,7 +119,31 @@ module Hecksagain
 
         pending.each do |name|
           chapter = registry.bluebook(name)
-          registry.add_bluebook(call(chapter)) if chapter
+          next unless chapter
+
+          # A bare chapter-given left PENDING by any file of this
+          # chapter (`AggregateBuilder#pending_chapter_given`) resolves
+          # first — before anything below reads a `Given`'s fields.
+          # `registry.bluebook_builder(name)` is the SAME instance every
+          # one of this chapter's own files built onto (`#self.build`'s
+          # own comment); it is guaranteed already open here, since it
+          # is what produced `chapter` in the first place — the block is
+          # dead code, never actually invoked.
+          builder = registry.bluebook_builder(name) { raise "internal: no open builder for #{name}" }
+          builder.resolve_pending_chapter_givens!
+
+          # `BluebookBuilder#build` skipped its own whole-chapter battery
+          # (hops, projected fields, correlation keys, event shapes,
+          # `with:` projections) for every file of THIS chapter while
+          # `deferring?` was true, the same reason `call` below queued
+          # instead of judging — each of those checks needs every file
+          # loaded first (see `BluebookBuilder.validate_assembled!`'s own
+          # comment). `chapter` here is exactly that: whatever the LAST
+          # file's own `add_bluebook` left in the registry, which by now
+          # holds every aggregate/policy/process_manager the whole
+          # chapter declares. Run once, here, instead of once per file.
+          DSL::BluebookBuilder.validate_assembled!(chapter)
+          registry.add_bluebook(call(chapter))
         end
       end
 

--- a/rust/parser/src/parse/aggregate.rs
+++ b/rust/parser/src/parse/aggregate.rs
@@ -84,12 +84,36 @@ pub fn not_implemented(file: &str, line: usize, word: &str) -> Diagnostic {
 /// candidate is registered under the same description; omitted, it
 /// resolves only when EXACTLY one candidate exists — never guesses among
 /// several.
+///
+/// A CHAPTER MAY BE SPLIT ACROSS FILES — the target of a bare reference
+/// here may be declared in a file that has not been parsed YET, the
+/// mirror of Ruby's own `AggregateBuilder#pending_chapter_given`
+/// (`BluebookBuilder#resolve_pending_chapter_givens!`, run once every
+/// file in the chapter has loaded). So "not found among `chapter_named_
+/// givens` so far" is no longer immediately refused here — only genuine
+/// AMBIGUITY is (more files can only ADD candidates, never remove one,
+/// so a conflict seen now stays a conflict regardless of what loads
+/// later). `ChapterGivenLookup::Pending` carries everything the final
+/// pass (`parse::chapter::parse_chapter`'s own resolution loop, after
+/// every file has contributed to `chapter_named_givens`) needs to
+/// resolve it for real, or refuse it for real, once nothing more will
+/// ever be declared.
+pub enum ChapterGivenLookup {
+    Resolved(ir::Given),
+    Pending {
+        description: String,
+        declared_by: Option<String>,
+        file: String,
+        line: usize,
+    },
+}
+
 fn try_reference_named_chapter_given(
     file: &str,
     lines: &[SourceLine],
     pos: &mut usize,
     chapter_named_givens: &[(String, ir::Given)],
-) -> ParseResult<Option<ir::Given>> {
+) -> ParseResult<Option<ChapterGivenLookup>> {
     let Some(&line) = lines.get(*pos) else {
         return Ok(None);
     };
@@ -113,35 +137,27 @@ fn try_reference_named_chapter_given(
         .collect();
 
     let resolved = if let Some(owner) = declared_by {
-        candidates
+        match candidates
             .iter()
             .find(|(candidate_owner, _)| candidate_owner == &owner)
-            .map(|(_, given)| given.clone())
-            .ok_or_else(|| {
-                Diagnostic::new(
-                    file,
-                    line.number,
-                    format!(
-                        "'{description}' names no precondition {owner} declares in this chapter \
-                         — {owner} either hasn't declared '{description}', or declared_by: named \
-                         the wrong aggregate"
-                    ),
-                )
-            })?
+        {
+            Some((_, given)) => ChapterGivenLookup::Resolved(given.clone()),
+            None => ChapterGivenLookup::Pending {
+                description,
+                declared_by: Some(owner),
+                file: file.to_string(),
+                line: line.number,
+            },
+        }
     } else {
         match candidates.as_slice() {
-            [] => {
-                return Err(Diagnostic::new(
-                    file,
-                    line.number,
-                    format!(
-                        "'{description}' names no precondition any aggregate in this chapter has \
-                         declared yet — declare it once with a block, before the aggregates that \
-                         reference it"
-                    ),
-                ))
-            }
-            [(_, given)] => given.clone(),
+            [] => ChapterGivenLookup::Pending {
+                description,
+                declared_by: None,
+                file: file.to_string(),
+                line: line.number,
+            },
+            [(_, given)] => ChapterGivenLookup::Resolved(given.clone()),
             _ => {
                 let owners: Vec<&str> =
                     candidates.iter().map(|(owner, _)| owner.as_str()).collect();
@@ -163,13 +179,34 @@ fn try_reference_named_chapter_given(
     Ok(Some(resolved))
 }
 
+/// ONE ENTRY PER UNRESOLVED BARE CHAPTER-GIVEN this aggregate's own file
+/// left pending — `precondition_index` names WHERE in this aggregate's
+/// own `preconditions` the eventual real `Given` gets patched in
+/// (`parse::chapter::parse_chapter`'s own final resolution pass, once
+/// every file in the chapter has loaded and stamped an `aggregate_index`
+/// alongside — this struct alone doesn't know which aggregate it belongs
+/// to; its caller does, the moment this aggregate is pushed onto
+/// `bluebook.aggregates`).
+pub struct PendingChapterGiven {
+    pub precondition_index: usize,
+    pub description: String,
+    pub declared_by: Option<String>,
+    pub file: String,
+    pub line: usize,
+}
+
 pub fn parse_body(
     file: &str,
     lines: &[SourceLine],
     pos: &mut usize,
     name: &str,
     chapter_named_givens: &mut Vec<(String, ir::Given)>,
-) -> ParseResult<(ir::Aggregate, Vec<ir::Policy>)> {
+) -> ParseResult<(
+    ir::Aggregate,
+    Vec<ir::Policy>,
+    Vec<PendingChapterGiven>,
+    Vec<(usize, command::PendingCommandGiven)>,
+)> {
     let mut aggregate = ir::Aggregate {
         name: name.to_string(),
         ..Default::default()
@@ -177,6 +214,10 @@ pub fn parse_body(
     let mut pending_identity: Option<super::PendingIdentity> = None;
     let mut closed_sets: Vec<ir::ValueObject> = Vec::new();
     let mut policies: Vec<ir::Policy> = Vec::new();
+    // EVERY BARE CHAPTER-GIVEN THIS AGGREGATE'S OWN FILE LEFT PENDING —
+    // see `PendingChapterGiven`'s own comment for what each entry means
+    // and where it drains.
+    let mut pending_chapter_givens: Vec<PendingChapterGiven> = Vec::new();
     // DEFERRED CONSTRUCTION — see `parse::mod::PendingBody`'s own header.
     // `entity`/`command`/`query` only QUEUE here; built for real by the
     // drain below, once this aggregate's own top-level line-range is
@@ -205,10 +246,38 @@ pub fn parse_body(
         // unchanged, on purpose, since a FRESH declaration still needs
         // one — so a genuinely bare `given` has to be recognized and
         // consumed HERE, by raw lexing, before that gate would refuse it.
-        if let Some(given) =
+        if let Some(outcome) =
             try_reference_named_chapter_given(file, lines, pos, chapter_named_givens)?
         {
-            aggregate.preconditions.push(given);
+            match outcome {
+                ChapterGivenLookup::Resolved(given) => aggregate.preconditions.push(given),
+                ChapterGivenLookup::Pending {
+                    description,
+                    declared_by,
+                    file,
+                    line,
+                } => {
+                    let precondition_index = aggregate.preconditions.len();
+                    // A PLACEHOLDER — `description` set for readability if
+                    // something inspects the IR mid-parse, `canonical`
+                    // deliberately empty; the final resolution pass
+                    // (`parse::chapter::parse_chapter`) overwrites this
+                    // exact slot once every file has loaded, and nothing
+                    // reads it before then (IR emission/export happens
+                    // strictly after `parse_chapter` returns).
+                    aggregate.preconditions.push(ir::Given {
+                        description: Some(description.clone()),
+                        canonical: String::new(),
+                    });
+                    pending_chapter_givens.push(PendingChapterGiven {
+                        precondition_index,
+                        description,
+                        declared_by,
+                        file,
+                        line,
+                    });
+                }
+            }
             continue;
         }
 
@@ -323,13 +392,15 @@ pub fn parse_body(
                 let target = naming::demodulise(target_raw);
                 let as_name = super::named_symbol(&gated.args, "as");
                 let optional = super::named_flag(&gated.args, "optional");
-                aggregate.attributes.push(references::relationship_attribute(
-                    &target,
-                    "reference_to",
-                    as_name.as_deref(),
-                    optional,
-                    false,
-                ));
+                aggregate
+                    .attributes
+                    .push(references::relationship_attribute(
+                        &target,
+                        "reference_to",
+                        as_name.as_deref(),
+                        optional,
+                        false,
+                    ));
             }
             // `has_one`/`belongs_to` — sugar over `reference_to` minting
             // NO `_id` suffix (`AggregateBuilder#has_one`: `reference_to(type,
@@ -586,10 +657,10 @@ pub fn parse_body(
     }
     aggregate.entities = entities;
 
-    aggregate.commands = pending_commands
+    let built_commands: Vec<(ir::Command, Vec<command::PendingCommandGiven>)> = pending_commands
         .into_iter()
-        .map(|(c_name, from, pending)| {
-            super::build_deferred(file, lines, &pending, |f, l, p| {
+        .map(|(c_name, from, pending_body)| {
+            super::build_deferred(file, lines, &pending_body, |f, l, p| {
                 command::parse_body(
                     f,
                     l,
@@ -606,6 +677,22 @@ pub fn parse_body(
             })
         })
         .collect::<ParseResult<Vec<_>>>()?;
+
+    // BUBBLE EACH COMMAND'S OWN PENDING chapter-given references, STAMPED
+    // WITH THIS COMMAND'S OWN INDEX — `command::parse_body` only knows
+    // its own `given_index`/`precondition_index` (see `PendingCommandGiven`
+    // 's own comment); which COMMAND it belongs to is only known here,
+    // by iteration order, the same reason `pending_chapter_givens`'s own
+    // `aggregate_index` is stamped one level up in `parse::chapter`.
+    let mut pending_command_givens: Vec<(usize, command::PendingCommandGiven)> = Vec::new();
+    aggregate.commands = built_commands
+        .into_iter()
+        .enumerate()
+        .map(|(command_index, (built, pending))| {
+            pending_command_givens.extend(pending.into_iter().map(|entry| (command_index, entry)));
+            built
+        })
+        .collect();
 
     aggregate.queries = pending_queries
         .into_iter()
@@ -655,5 +742,10 @@ pub fn parse_body(
         }
     }
 
-    Ok((aggregate, policies))
+    Ok((
+        aggregate,
+        policies,
+        pending_chapter_givens,
+        pending_command_givens,
+    ))
 }

--- a/rust/parser/src/parse/chapter.rs
+++ b/rust/parser/src/parse/chapter.rs
@@ -46,7 +46,7 @@
 //! discarded `ir::Bluebook`, so a real syntax error inside a sibling
 //! block still refuses rather than being silently skipped.
 
-use super::{aggregate, policy, process_manager, read_model};
+use super::{aggregate, command, policy, process_manager, read_model};
 use crate::diag::{Diagnostic, ParseResult};
 use crate::ir;
 use crate::lex::{self, SourceLine};
@@ -73,6 +73,18 @@ pub fn parse_chapter(chapter_name: &str, files: &[(String, String)]) -> ParseRes
     let mut aggregate_policies: Vec<ir::Policy> = Vec::new();
     let mut chapter_policies: Vec<ir::Policy> = Vec::new();
     let mut chapter_named_givens: Vec<(String, ir::Given)> = Vec::new();
+    // EVERY BARE CHAPTER-GIVEN A FILE PARSED SO FAR LEFT PENDING — see
+    // `aggregate::PendingChapterGiven`'s own comment for what queues here
+    // and this function's own resolution pass (below) for where it
+    // drains, once every file has loaded.
+    let mut pending_chapter_givens: Vec<(usize, aggregate::PendingChapterGiven)> = Vec::new();
+    // ONE LEVEL DEEPER STILL — a COMMAND's own bare reference to the
+    // same not-yet-resolved chapter-given (`command::PendingCommandGiven`
+    // 's own comment). Resolved in a SECOND pass below, after every
+    // `PendingChapterGiven` above has already patched the aggregate's
+    // own `preconditions` — this one COPIES that result rather than
+    // re-resolving from scratch.
+    let mut pending_command_givens: Vec<(usize, usize, command::PendingCommandGiven)> = Vec::new();
     let mut hecksagon_files: Vec<&(String, String)> = Vec::new();
 
     for entry @ (path, source) in files {
@@ -124,6 +136,8 @@ pub fn parse_chapter(chapter_name: &str, files: &[(String, String)]) -> ParseRes
                     &mut aggregate_policies,
                     &mut chapter_policies,
                     &mut chapter_named_givens,
+                    &mut pending_chapter_givens,
+                    &mut pending_command_givens,
                 )?;
             }
             "Hecksagon" => hecksagon_files.push(entry),
@@ -158,6 +172,89 @@ pub fn parse_chapter(chapter_name: &str, files: &[(String, String)]) -> ParseRes
     // complete aggregate graph exists; local paths use this same pass so the
     // inference rule has one implementation and one declaration-order rule.
     crate::build::query_inference::apply(&files[0].0, &mut bluebook)?;
+
+    // THE OTHER HALF OF A CHAPTER-WIDE `given` REFERENCE —
+    // `aggregate::try_reference_named_chapter_given` recognised an
+    // unresolved bare reference and deferred it here, unable to check
+    // further: a later file in this SAME chapter might still declare the
+    // real thing. Resolved now, once and for all, against the
+    // NOW-COMPLETE `chapter_named_givens` — the IDENTICAL lookup that
+    // function already does, just late enough to see every aggregate's
+    // own declarations, not only the ones parsed before the referencing
+    // one. Mirrors `BluebookBuilder#resolve_pending_chapter_givens!`
+    // exactly, one call-site: PATCHES `bluebook.aggregates[aggregate_
+    // index].preconditions[precondition_index]` directly rather than
+    // mutating a shared object in place (Ruby's own trick, not available
+    // here — nothing else in Rust's IR holds a second reference to the
+    // placeholder that would need to see the update; the SECOND pass
+    // below handles the one thing that does, a command's own copy).
+    for (aggregate_index, pending) in pending_chapter_givens {
+        let candidates: Vec<&(String, ir::Given)> = chapter_named_givens
+            .iter()
+            .filter(|(_, given)| given.description.as_deref() == Some(pending.description.as_str()))
+            .collect();
+
+        let resolved = if let Some(owner) = &pending.declared_by {
+            candidates
+                .iter()
+                .find(|(candidate_owner, _)| candidate_owner == owner)
+                .map(|(_, given)| given.clone())
+                .ok_or_else(|| {
+                    Diagnostic::new(
+                        &pending.file,
+                        pending.line,
+                        format!(
+                            "'{}' names no precondition {owner} declares in this chapter — {owner} \
+                             either hasn't declared '{}', or declared_by: named the wrong aggregate",
+                            pending.description, pending.description
+                        ),
+                    )
+                })?
+        } else {
+            match candidates.as_slice() {
+                [] => {
+                    return Err(Diagnostic::new(
+                        &pending.file,
+                        pending.line,
+                        format!(
+                        "'{}' names no precondition any aggregate in this chapter ever declares \
+                             — declare it once with a block",
+                        pending.description
+                    ),
+                    ))
+                }
+                [(_, given)] => given.clone(),
+                _ => {
+                    let owners: Vec<&str> =
+                        candidates.iter().map(|(owner, _)| owner.as_str()).collect();
+                    return Err(Diagnostic::new(
+                        &pending.file,
+                        pending.line,
+                        format!(
+                            "'{}' is ambiguous in this chapter — {} each declare a DIFFERENT \
+                             predicate under this same description; name which one with declared_by:",
+                            pending.description,
+                            owners.join(", ")
+                        ),
+                    ));
+                }
+            }
+        };
+
+        bluebook.aggregates[aggregate_index].preconditions[pending.precondition_index] = resolved;
+    }
+
+    // A THIRD LAYER — a COMMAND's own bare reference to the same
+    // description (`command::PendingCommandGiven`'s own comment). Runs
+    // AFTER the loop above, on purpose — it COPIES the aggregate's own
+    // now-final `preconditions[precondition_index]`, so the aggregate
+    // -level placeholder has to be resolved for real first.
+    for (aggregate_index, command_index, pending) in pending_command_givens {
+        let resolved =
+            bluebook.aggregates[aggregate_index].preconditions[pending.precondition_index].clone();
+        bluebook.aggregates[aggregate_index].commands[command_index].givens[pending.given_index] =
+            resolved;
+    }
 
     for (path, source) in hecksagon_files {
         let joined = lex::join_continuations(source);
@@ -314,6 +411,14 @@ fn parse_body_into(
     aggregate_policies: &mut Vec<ir::Policy>,
     chapter_policies: &mut Vec<ir::Policy>,
     chapter_named_givens: &mut Vec<(String, ir::Given)>,
+    // EVERY BARE CHAPTER-GIVEN A FILE PARSED SO FAR LEFT PENDING — see
+    // `aggregate::PendingChapterGiven`'s own comment; `parse_chapter`
+    // resolves every one of these once every file has loaded.
+    pending_chapter_givens: &mut Vec<(usize, aggregate::PendingChapterGiven)>,
+    // ONE LEVEL DEEPER — a COMMAND's own bare reference to the same
+    // not-yet-resolved chapter-given (`command::PendingCommandGiven`'s
+    // own comment).
+    pending_command_givens: &mut Vec<(usize, usize, command::PendingCommandGiven)>,
 ) -> ParseResult<()> {
     // THE ROOT of the chapter-wide given pool
     // (`docs/implemented/resolution-rules/chapter-given.md`) belongs to the
@@ -361,10 +466,18 @@ fn parse_body_into(
             }
             "aggregate" => {
                 let agg_name = super::positional_text(file, line, "aggregate", &gated.args, 1)?;
-                let (built, policies) =
+                let (built, policies, pending, command_pending) =
                     aggregate::parse_body(file, lines, pos, &agg_name, chapter_named_givens)?;
+                let aggregate_index = bluebook.aggregates.len();
                 bluebook.aggregates.push(built);
                 aggregate_policies.extend(policies);
+                pending_chapter_givens
+                    .extend(pending.into_iter().map(|entry| (aggregate_index, entry)));
+                pending_command_givens.extend(
+                    command_pending
+                        .into_iter()
+                        .map(|(command_index, entry)| (aggregate_index, command_index, entry)),
+                );
             }
             "policy" => {
                 let pol_name = super::positional_text(file, line, "policy", &gated.args, 1)?;

--- a/rust/parser/src/parse/command.rs
+++ b/rust/parser/src/parse/command.rs
@@ -111,13 +111,34 @@ pub fn parse_from(
 /// are populated from disjoint declaration sites, but the order still
 /// matches). Always `&[]` from `parse::aggregate`'s own call — an
 /// aggregate-owned command has no sibling PIECE to reach across.
+/// `preconditions` (for an AGGREGATE-owned command — see this function's
+/// own header) can itself hold a PENDING placeholder: `aggregate
+/// ::try_reference_named_chapter_given`'s own bare chapter-wide
+/// reference, still unresolved when THIS command's own body is reached
+/// (parsing runs top-to-bottom within one aggregate; the chapter-wide
+/// reference may need a file that hasn't loaded yet — see that
+/// function's own header). A placeholder is unambiguous here: an
+/// EXTRACTED `Given` never carries an empty `canonical` (Ruby's own
+/// `build_rule` refuses a predicate that fails to extract; a chapter-wide
+/// PLACEHOLDER is deliberately built with `canonical: String::new()`, so
+/// empty is a safe sentinel for "still pending" — never a real, resolved
+/// one). If the match is a placeholder, this returns `Pending` instead of
+/// cloning it — cloning now would freeze in the empty canonical
+/// permanently; `parse::chapter::parse_chapter`'s own final pass copies
+/// the AGGREGATE's own now-resolved precondition into this command's
+/// `givens` slot once every file in the chapter has loaded.
+enum GivenLookup {
+    Resolved(ir::Given),
+    Pending { precondition_index: usize },
+}
+
 fn try_reference_named_given(
     file: &str,
     lines: &[SourceLine],
     pos: &mut usize,
     preconditions: &[ir::Given],
     entity_shared_givens: &[ir::Given],
-) -> ParseResult<Option<ir::Given>> {
+) -> ParseResult<Option<GivenLookup>> {
     let Some(&line) = lines.get(*pos) else {
         return Ok(None);
     };
@@ -132,25 +153,53 @@ fn try_reference_named_given(
 
     let args = super::argument_gate(file, "given", "Command", &call.args, line.number)?;
     let description = super::positional_text(file, line.number, "given", &args, 1)?;
-    let resolved = preconditions
+
+    // `preconditions.iter().position(...)` first — a placeholder needs
+    // its INDEX, not just the match, to defer correctly; falls back to
+    // `entity_shared_givens` (never holds a placeholder — only an
+    // aggregate's own top-level bare reference can produce one, and an
+    // entity's own commands never receive `aggregate.preconditions` at
+    // all, only `entity.preconditions` — `parse::entity`'s own call
+    // site) the same priority order as before.
+    let resolved = if let Some(precondition_index) = preconditions
         .iter()
-        .chain(entity_shared_givens.iter())
+        .position(|given| given.description.as_deref() == Some(description.as_str()))
+    {
+        let given = &preconditions[precondition_index];
+        if given.canonical.is_empty() {
+            GivenLookup::Pending { precondition_index }
+        } else {
+            GivenLookup::Resolved(given.clone())
+        }
+    } else if let Some(given) = entity_shared_givens
+        .iter()
         .find(|given| given.description.as_deref() == Some(description.as_str()))
-        .cloned()
-        .ok_or_else(|| {
-            Diagnostic::new(
-                file,
-                line.number,
-                format!(
-                    "'{description}' names no precondition the owning aggregate or entity declares, \
-                     and no sibling piece under the same aggregate declares it either — declare it \
-                     once with a block, before the commands that reference it"
-                ),
-            )
-        })?;
+    {
+        GivenLookup::Resolved(given.clone())
+    } else {
+        return Err(Diagnostic::new(
+            file,
+            line.number,
+            format!(
+                "'{description}' names no precondition the owning aggregate or entity declares, \
+                 and no sibling piece under the same aggregate declares it either — declare it \
+                 once with a block, before the commands that reference it"
+            ),
+        ));
+    };
 
     *pos += 1;
     Ok(Some(resolved))
+}
+
+/// ONE ENTRY PER BARE `given(...)` a command left pending — `given_index`
+/// names where in THIS command's own `givens` the eventual real `Given`
+/// gets copied in (`parse::chapter::parse_chapter`'s own final
+/// resolution pass, AFTER it has already resolved the owning aggregate's
+/// `preconditions[precondition_index]` for real — the copy source).
+pub struct PendingCommandGiven {
+    pub given_index: usize,
+    pub precondition_index: usize,
 }
 
 /// Parses a `command "Name" do ... end` body. `owner` is the aggregate
@@ -191,18 +240,39 @@ pub fn parse_body(
     owner_attributes: &[ir::Attribute],
     owner_value_objects: &[ir::ValueObject],
     owner_entities: &[ir::Entity],
-) -> ParseResult<ir::Command> {
+) -> ParseResult<(ir::Command, Vec<PendingCommandGiven>)> {
     let mut command = ir::Command {
         name: name.to_string(),
         from,
         ..Default::default()
     };
+    // EVERY BARE `given(...)` THIS COMMAND ITSELF LEFT PENDING — see
+    // `GivenLookup::Pending`'s own comment; drained by `parse::aggregate
+    // ::parse_body`'s own caller, bubbled up to `parse::chapter
+    // ::parse_chapter`'s final resolution pass.
+    let mut pending: Vec<PendingCommandGiven> = Vec::new();
 
     loop {
-        if let Some(given) =
+        if let Some(outcome) =
             try_reference_named_given(file, lines, pos, preconditions, entity_shared_givens)?
         {
-            command.givens.push(given);
+            match outcome {
+                GivenLookup::Resolved(given) => command.givens.push(given),
+                GivenLookup::Pending { precondition_index } => {
+                    let given_index = command.givens.len();
+                    // Same empty-canonical sentinel as the aggregate's
+                    // own placeholder — nothing reads this before
+                    // `parse_chapter`'s final pass overwrites it.
+                    command.givens.push(ir::Given {
+                        description: None,
+                        canonical: String::new(),
+                    });
+                    pending.push(PendingCommandGiven {
+                        given_index,
+                        precondition_index,
+                    });
+                }
+            }
             continue;
         }
 
@@ -213,7 +283,7 @@ pub fn parse_body(
                 owner_value_objects,
                 owner_entities,
             );
-            return Ok(command);
+            return Ok((command, pending));
         };
         let line = gated.line.number;
 
@@ -649,7 +719,11 @@ fn build_mutation(
 /// — refused here the same way a malformed target is refused in Ruby,
 /// even though the one real fixture (`delegates_to.bluebook`) never
 /// exercises the error path.
-fn build_delegation(file: &str, line: usize, args: &super::ArgumentGateResult) -> ParseResult<ir::Mutation> {
+fn build_delegation(
+    file: &str,
+    line: usize,
+    args: &super::ArgumentGateResult,
+) -> ParseResult<ir::Mutation> {
     let target = super::positional_text(file, line, "delegates_to", args, 1)?;
     let (entity_name, command_name) = target.rsplit_once('.').unwrap_or(("", ""));
     if entity_name.is_empty() || command_name.is_empty() {
@@ -664,7 +738,10 @@ fn build_delegation(file: &str, line: usize, args: &super::ArgumentGateResult) -
     }
 
     let fields = match super::named_raw(args, "with") {
-        Some(raw) => parse_hash_literal_pairs(raw).into_iter().map(|(k, v)| (k, ruby_value::render(&ruby_value::read(&v)))).collect(),
+        Some(raw) => parse_hash_literal_pairs(raw)
+            .into_iter()
+            .map(|(k, v)| (k, ruby_value::render(&ruby_value::read(&v))))
+            .collect(),
         None => Vec::new(),
     };
     Ok(ir::Mutation::Delegate { target, fields })

--- a/rust/parser/src/parse/entity.rs
+++ b/rust/parser/src/parse/entity.rs
@@ -351,6 +351,16 @@ pub fn parse_body(
                 )
             })
         })
+        // `command::parse_body` now also returns any PENDING bare chapter
+        // -given reference it left for later (`PendingCommandGiven`'s
+        // own comment) — always empty here, on purpose: `preconditions`
+        // above is `&entity.preconditions`, which never receives a
+        // chapter-wide placeholder (only an AGGREGATE's own top-level
+        // `given(...)` reaches `try_reference_named_chapter_given` at
+        // all — `parse::aggregate`'s own call site). Discarded rather
+        // than threaded further; a piece's own commands have no chapter
+        // -given resolution path to bubble toward.
+        .map(|result| result.map(|(command, _pending)| command))
         .collect::<ParseResult<Vec<_>>>()?;
 
     entity.queries = pending_queries

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "the DSL surface is fully covered" do
       # `attaches_to`/`aggregate` -> `*_impl` — item #13's full
       # metaprogrammed dispatch (slice 4c).
       %i[vision formerly_known_as attaches_to_impl core supporting generic aggregate_impl report read_model policy
-         process_manager classification]
+         process_manager classification resolve_pending_chapter_givens!]
     ],
     "AggregateBuilder"            => [
       Hecksagain::Bluebook::DSL::AggregateBuilder,

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1079,6 +1079,39 @@ RSpec.describe "the DSL surface" do
       end
     end
 
+    it "resolve_pending_chapter_givens! resolves a bare chapter-given left pending by an earlier file" do
+      # TWO SEPARATE `Hecks.bluebook` calls, same chapter name — the same
+      # shape a chapter split across real files takes. "Referencer" loads
+      # FIRST and bare-references a description "Declarer" (loaded SECOND)
+      # is the one that actually declares — unresolvable at the moment
+      # "Referencer" itself is built, deferred instead of refused
+      # (`AggregateBuilder#pending_chapter_given`), and only resolved once
+      # `MetaValidator.judge_deferred!` runs, after both have loaded.
+      registry = Hecksagain::Runtime::Registry.new
+      Hecks.with_registry(registry) do
+        Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+        Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+        Hecksagain::Bluebook::MetaValidator.defer do
+          Hecks.bluebook("SplitGiven") do
+            aggregate("Referencer") do
+              identified_by :id
+              given("shared fact")
+            end
+          end
+          Hecks.bluebook("SplitGiven") do
+            aggregate("Declarer") do
+              identified_by :id
+              given("shared fact") { true }
+            end
+          end
+        end
+        Hecksagain::Bluebook::MetaValidator.judge_deferred!(registry)
+      end
+
+      referencer = registry.bluebook("SplitGiven").aggregates.find { |a| a.hecks_name == "Referencer" }
+      expect(referencer.preconditions.map(&:canonical)).to eq(["true"])
+    end
+
     it "verbs lists every command as a fully-qualified verb" do
       bluebook = build_bluebook("Verbed") do
         aggregate("Thing") do

--- a/spec/syntax_boot_memo_spec.rb
+++ b/spec/syntax_boot_memo_spec.rb
@@ -70,7 +70,10 @@ RSpec.describe "SyntaxBoot's memo" do
   # the old guard did 42.
   it "boots at most once per distinct chapter set while the grammar registry builds itself from cold" do
     boots = 0
-    allow(SyntaxBootUnderTest).to receive(:boot).and_wrap_original { |m, *args| boots += 1; m.call(*args) }
+    allow(SyntaxBootUnderTest).to(receive(:boot).and_wrap_original { |m, *args|
+      boots += 1
+      m.call(*args)
+    })
 
     MetaValidatorUnderTest.instance_variable_set(:@grammar_registry, nil)
     registry = MetaValidatorUnderTest.grammar_registry

--- a/spec/syntax_conformance_spec.rb
+++ b/spec/syntax_conformance_spec.rb
@@ -126,7 +126,10 @@ RSpec.describe "the declared syntax" do
   #     named per-context below rather than by blanket File-level exclusion.
   NOT_A_WORD = {
     "Bluebook"  => {
-      classification: "an attr_reader BluebookBuilder.build reads when merging one chapter across files"
+      classification:                  "an attr_reader BluebookBuilder.build reads when merging one chapter across files",
+      resolve_pending_chapter_givens!: "called by MetaValidator.judge_deferred! once a chapter split " \
+                                       "across files has fully loaded, to resolve any bare chapter-given " \
+                                       "reference an earlier file left pending"
     },
     "File"      => {
       boot:             "the runtime facade, not a declaration",


### PR DESCRIPTION
## What

Two related, real, pre-existing bugs that surface when a chapter (bluebook) is split across multiple files:

1. **Whole-chapter validations ran eagerly per-file.** Query-hop, projected-field, correlation-key, event-shape, and with-projections validation ran on every single file's `BluebookBuilder#build` instead of once the whole chapter had loaded — a chapter split across files would see these checks run against a partial view of itself. Fixed by moving them into `BluebookBuilder.validate_assembled!`, gated behind `MetaValidator.deferring?` and run from `MetaValidator.judge_deferred!`, mirroring the existing defer/judge pattern `Folder#load_domain` already uses elsewhere.

   Along the way: removed a stale `@event_emitters ||=` memoization (computed once against the first file, never refreshed), and switched its event-shape comparison from name-based to structural (`unwrap_shape`) — a genuine pre-existing bug where two isomorphic but differently-named event shapes were treated as a real conflict.

2. **Chapter-wide bare `given("...")` references (S10/ADR 0025/0028) were order-sensitive.** They resolve by scanning sibling aggregates already declared earlier in the same file-load order. Splitting a chapter across files with no dependency-ordered filenames breaks this the moment a reference lands in a file that loads before its declaration. Fixed with deferred two-phase resolution: an unresolved reference gets a placeholder `Given` immediately (recorded in `@chapter_pending_givens`), and `BluebookBuilder#resolve_pending_chapter_givens!` (called from `MetaValidator.judge_deferred!` once every file has loaded) patches each placeholder in place — by `declared_by:` owner, by single unambiguous candidate, or raises (unknown reference / genuine ambiguity), exactly as before, just later.

Ported the same two-phase resolution to `rust/parser` (`hecks-parse`) for chapter-given references at both the aggregate (`preconditions`) and command (`givens`) level. Rust has no shared-mutable-reference trick like Ruby's `Given` struct, so pending entries carry index paths patched directly into the assembled `ir::Bluebook` after parsing. `chapter_named_givens` and query-argument inference were already correctly chapter-scoped on `main`, so only the given-resolution piece needed porting.

## Verification

- Full Ruby suite: 1738 examples, 0 failures
- rubocop: clean (555 files)
- Rust `hecks-parse`: clean build, 75/75 tests (65 unit + 10 gate), rustfmt clean
- `parser_parity_spec` + `codegen_parity_spec` (`--tag io`): 44/44, byte-identical Ruby/Rust IR incl. real multi-file corpus members (`banking`, `bluebook_language`)
- Fuzzer: 81/81
- Full pre-push gate (docs coverage, rubocop, suite, fuzzer, engine agreement, model checks): clean

## Deliberately excluded

A banking-chapter file split and a Rust codegen `Fielded`-impl fix were part of an earlier attempt at this work but turned out to already be independently merged to `main` under a different shape — excluded here to keep this PR to just the mechanism fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)