### PR TITLE
word_coverage_spec.rb: exclude the runtime era store from the corpus scan

### DIFF
--- a/spec/word_coverage_spec.rb
+++ b/spec/word_coverage_spec.rb
@@ -54,8 +54,25 @@ RSpec.describe "every live DSL word, used somewhere real" do
     File.join(InMemoryDomain::ROOT, "lib/hecksagain/adapters/driven", "*.adapter")
   ].freeze
 
+  # `examples/*/**/*.bluebook`'s own `**` has to be recursive — a
+  # nested sub-language file (`examples/pizzas/bluebook/translations/
+  # 2-77625c.bluebook`) is a real corpus source one directory deeper
+  # than `examples/pizzas/bluebook/*.bluebook` itself — but that same
+  # recursion also reaches `examples/*/data/eras/**`, the RUNTIME era
+  # store a file adapter writes locally (.gitignore's own `**/data/
+  # eras/` entry, anchored to `data/` for the identical reason: era
+  # snapshots are real generated content, not committed corpus source,
+  # and an environment that has actually minted an era — running
+  # bin/evolve/project_deploy against a real domain, say — would see
+  # this scanner "find" a word only ever frozen into a historical
+  # snapshot, on a machine where nobody else could ever reproduce it).
+  # Excluded here the same way corpus_spec.rb's own walk never has the
+  # problem in the first place — its own glob never descends into
+  # `data/` at all.
   def corpus_files
-    @corpus_files ||= CORPUS_GLOBS.flat_map { |glob| Dir.glob(glob) }.sort.freeze
+    @corpus_files ||= CORPUS_GLOBS.flat_map { |glob| Dir.glob(glob) }
+                                  .reject { |path| path.include?("/data/eras/") }
+                                  .sort.freeze
   end
 
   # A REAL DECLARATION, not a mention — the word as a whole token


### PR DESCRIPTION
## What

Found while cleaning up branches after PR #340: `main`'s local dev environment (which has actually minted era data via `bin/evolve`/`project_deploy` — the lifeadelics migration work) fails `spec/word_coverage_spec.rb`'s "carries no exemption the corpus has outgrown" check. A fresh checkout doesn't reproduce it, which made it look like a flake at first — it isn't.

`CORPUS_GLOBS`'s `examples/*/**/*.bluebook` has to be recursive (a nested sub-language file like `examples/pizzas/bluebook/translations/2-77625c.bluebook` is real corpus source one directory deeper than `examples/pizzas/bluebook/*.bluebook`), but that same recursion also reaches `examples/*/data/eras/**` — the RUNTIME era store a file adapter writes locally. `.gitignore` already excludes this directory for the identical reason (`**/data/eras/`, anchored to `data/` deliberately): era snapshots are real generated content, never committed corpus source.

On a machine that's actually minted an era, a snapshot can freeze a pre-rename spelling verbatim — `examples/pizzas/data/eras/pizzas/1.bluebook` genuinely contains bareword `then_set` calls from before ADR 0025 renamed the word to `sets`. The scanner correctly found this real content and flagged the `then_set (Command)` `EXEMPT` entry as stale — but it was reading a frozen historical snapshot (loaded via `EraGuard`'s own shadow-parse path) as if it were a live present-day declaration. `spec/corpus_spec.rb`'s own walk never has this problem — it never globs past each domain's `bluebook/` directory in the first place.

## Fix

Reject any `/data/eras/` path from `corpus_files`, mirroring `.gitignore`'s own reasoning.

## Verification

- Standalone glob check against this repo's own real `data/eras/` content: zero `then_set` hits after the fix (confirms the actual reproducing condition, not just a clean checkout where the bug never triggers)
- Full suite: 1738 examples, 0 failures
- rubocop: clean (555 files)
- Fuzzer: 81/81
- Full pre-push gate: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)