### PR TITLE
Build a native .behaviors DSL and runner for hecksagain

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ own examples run against the real runtime on every push.
 
 <!-- generated:begin id=guides -->
 - [Aggregates and value objects](docs/implemented/guides/aggregates-and-value-objects.md)
+- [Behaviors](docs/implemented/guides/behaviors.md)
 - [Commands](docs/implemented/guides/commands.md)
 - [Entities](docs/implemented/guides/entities.md)
 - [Extending Hecks](docs/implemented/guides/extending-hecks.md)
@@ -381,6 +382,7 @@ Every domain this repository's own tests and docs draw examples from:
 | tool | |
 |---|---|
 | `bin/backfill_era_projections` | Proactively backfills `hecks_eras.held_projection` for every row of one domain that predates that column — an explicit, operator-run vers... |
+| `bin/behaviors` | Runs `.behaviors` files — hand-curated examples of how to use a domain, in domain vocabulary — and reports pass/fail/error per test. bin/... |
 | `bin/canonicalise` | Sorts a JSON document's object keys, recursively — key order is not semantics, so a diff a human reads should not have to notice it moved. |
 | `bin/codemod_hoist_local_givens` | A CODEMOD, not an agent — for the corpus duplication `bin/query_ir duplicates` surfaces directly: two or more commands under the SAME own... |
 | `bin/codemod_implicit_append_fields` | A CODEMOD, not an agent — for the class of redundancy `CommandBuilder#resolve_append_fields!` (lib/hecksagain/bluebook/dsl/ command_build... |

--- a/bin/behaviors
+++ b/bin/behaviors
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+# Runs `.behaviors` files — hand-curated examples of how to use a domain,
+# in domain vocabulary — and reports pass/fail/error per test.
+#
+#   bin/behaviors path/to/domain.behaviors
+#   bin/behaviors path/to/directory              # sweeps **/*.behaviors
+#
+# A `.behaviors` file names its own scope with `loads "a.bluebook", …`
+# (relative to the file), booted fresh per test through
+# `Hecks.boot_files` — no directory convention, no copying into a temp
+# dir. See docs/guides/behaviors.md for the DSL itself.
+#
+# Exit code is nonzero if any test failed, errored, or a file failed to
+# parse — the same convention bin/fuzz uses.
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "hecksagain"
+require "hecksagain/behaviors"
+
+USAGE = "usage: bin/behaviors <file.behaviors | directory>".freeze
+
+target = ARGV.first or abort USAGE
+abort "no such file or directory: #{target}" unless File.exist?(target)
+
+def report_file(result)
+  puts result.path
+  if result.parse_error
+    puts "  PARSE ERROR — #{result.parse_error}"
+    return
+  end
+
+  result.runs.each do |run|
+    marker = { pass: "ok", fail: "FAIL", error: "ERROR" }.fetch(run.status)
+    puts "  #{marker.ljust(5)} #{run.description}"
+    puts "        #{run.message}" if run.message
+  end
+end
+
+def bad?(summary)
+  ((summary[:failed] || 0) + (summary[:errored] || 0) + (summary[:parse_errors] || 0)).positive?
+end
+
+if File.directory?(target)
+  sweep = Hecksagain::Behaviors.run_all(target)
+  sweep.files.each { |file| report_file(file) }
+  s = sweep.summary
+  puts
+  puts "#{sweep.files_swept} file(s) swept — #{s[:total]} test(s): " \
+       "#{s[:passed]} passed, #{s[:failed]} failed, #{s[:errored]} errored, " \
+       "#{s[:parse_errors]} file(s) failed to parse"
+  exit(bad?(s) ? 1 : 0)
+else
+  result = Hecksagain::Behaviors.run(target)
+  report_file(result)
+  summary = Hecksagain::Behaviors.summarize([result])
+  exit(bad?(summary) ? 1 : 0)
+end

--- a/docs/implemented/guides/behaviors.md
+++ b/docs/implemented/guides/behaviors.md
@@ -1,0 +1,194 @@
+# Behaviors
+
+A `.behaviors` file is a set of hand-curated examples of how a domain is
+used, written in the domain's own vocabulary: one situation, one command
+(or query), one expectation, per test. It is not a fuzzer, not a
+parameterized test matrix, not a fixture format — there are no loops, no
+`cases` block, no generating examples from JSON. If a situation can't be
+written as a `.behaviors` test, that's a finding about the bluebook (a
+missing command, a missing query), not a gap in this DSL.
+
+This guide teaches the DSL's own vocabulary using chess as the running
+example — turn order, blocking, occupancy, capture, and a graveyard that
+records what fell — because those are real rules worth showing refused,
+not because chess ships with hecksagain. The examples this page actually
+*runs* are `examples/pizzas/bluebook/pizzas.behaviors`, the real,
+in-repo corpus member.
+
+## `vision` and `loads`
+
+Every `.behaviors` file opens with a one-line `vision` (what these
+examples are examples *of*) and a `loads` line naming the exact files to
+boot — relative to the `.behaviors` file itself, not to a directory
+convention or a same-stem guess:
+
+```ruby skip
+Hecks.behaviors "Chess" do
+  vision "Examples of how a game of chess is played through this domain."
+  loads "chess.bluebook", "chess.hecksagon"
+
+  # ... tests go here
+end
+```
+
+Both are required. A file with no `loads` refuses to parse, naming the
+fix directly, because scope is a fact the file declares — never inferred
+from the filesystem or from a bluebook sharing its stem.
+
+## `test`, `tests`, `setup`, `input`, `expect`
+
+One `test "description" do ... end` block is one example. Inside it:
+
+- `tests` names the command or query under test — `on:` an aggregate for
+  a bare name, or a dotted string taken as a literal fully-qualified
+  name (`"Chess::Graveyard.Fallen.OfSide"`). `kind:` is `:command`
+  (the default) or `:query`.
+- `setup` dispatches commands, in order, to put the domain into the
+  situation the test is about. Arguments pass through verbatim.
+- `input` supplies the arguments for the command or query actually under
+  test.
+- `expect` checks the result — see below.
+
+```ruby skip
+test "Black may not move first" do
+  tests "MoveKnight", on: "Game"
+  setup  "CreateGame",  label: "g"
+  setup  "PlaceKnight", label: "g", id: "bn", square: { file: 1, rank: 7 }, color: { value: "black" }
+  input  label: "g", id: "bn", to: { file: 2, rank: 5 }
+  expect refused: "it is that color's turn"
+end
+```
+
+## `expect`
+
+Five things, and only these:
+
+| key | checks |
+|---|---|
+| `ok: true` | the dispatch or query succeeded |
+| `refused: "substring"` | the dispatch or query refused, with a message containing this text |
+| `emits: [ordered, exact]` | exactly these event names, in this order |
+| `count: N` | a query returned this many rows (queries only) |
+| `<field>: value` | an aggregate-level field equals this, value-object-aware — bare (`kind: "bishop"`) and wrapped (`kind: { value: "bishop" }`) both compare equal |
+
+Any other key names none of these five and fails, naming them.
+
+```ruby skip
+test "a move cascades into PlyAdvanced" do
+  tests "MoveKnight", on: "Game"
+  setup  "CreateGame",  label: "g"
+  setup  "PlaceKnight", label: "g", id: "wn", square: { file: 1, rank: 0 }, color: { value: "white" }
+  input  label: "g", id: "wn", to: { file: 2, rank: 2 }
+  expect emits: ["KnightMoved", "PlyAdvanced"]
+end
+```
+
+`emits:` sees a real policy cascade, not just the tested command's own
+immediate event — there is no `kind: :cascade` in this DSL because a
+cascade is not a special case here, it is simply on, always. A domain
+where moving a piece triggers a policy that advances the game's own ply
+is exactly the case `emits:` is written to see through.
+
+## Refusals
+
+Every `Hecksagain::Runtime` refusal class (`GivenNotMet`, `EnsuresNotMet`,
+`LifecycleRefused`, `InvariantViolation`, `AlreadyExists`, `NotFound`, and
+the rest of `Hecksagain::Runtime::DOMAIN_REFUSALS`) satisfies `refused:`.
+Where the refusal happens matters: a refusal raised by a `setup` dispatch
+is always an **error** — the example never reached the situation it
+claims to test — while a refusal from the command or query actually
+under test is checked against `expect refused:` as a **fail** or a
+**pass**, depending on whether it matches.
+
+```ruby skip
+test "a capture refuses a piece already captured" do
+  tests "CaptureBishop", on: "Game"
+  setup  "CreateGame",    label: "g"
+  setup  "PlaceBishop",   label: "g", id: "bb", square: { file: 2, rank: 2 }, color: { value: "black" }
+  setup  "CaptureBishop", label: "g", id: "bb", side: { value: "black" }
+  input  label: "g", id: "bb", side: { value: "black" }
+  expect refused: "status is"
+end
+```
+
+## Reading state back
+
+A `.behaviors` test never invents a new way to read state — the only
+read is a **declared query**, dispatched exactly like a command:
+
+```ruby skip
+test "a captured piece is recorded in the graveyard" do
+  tests "Chess::Graveyard.Fallen.OfSide", kind: :query
+  setup  "CreateGame",    label: "g"
+  setup  "PlaceBishop",   label: "g", id: "bb", square: { file: 2, rank: 2 }, color: { value: "black" }
+  setup  "CaptureBishop", label: "g", id: "bb", side: { value: "black" }
+  input  side: { value: "black" }
+  expect count: 1
+end
+```
+
+If the domain has no query that can answer what a test wants to check,
+that is a missing word in the bluebook, not a reason to add a sixth
+`expect` key.
+
+## Running it
+
+`Hecksagain::Behaviors.run(path)` runs one file and returns one result
+per test — `:pass`, `:fail`, or `:error`, each with a message.
+`Hecksagain::Behaviors.run_all(dir)` sweeps every `.behaviors` file under
+a directory. Boot is a fresh `Hecks.boot_files` call per test — cheap,
+and never shared, so one test's state can never leak into the next's.
+
+```ruby
+require "hecksagain/behaviors"
+
+path   = File.join(InMemoryDomain::ROOT, "examples/pizzas/bluebook/pizzas.behaviors")
+result = Hecksagain::Behaviors.run(path)
+
+result.parse_error                              # => nil
+result.runs.size                                 # => 6
+result.runs.map(&:status).uniq                   # => [:pass]
+result.runs.first.description                    # => "CreatePizza puts a fresh pizza on the menu, available for sale"
+```
+
+`bin/behaviors` is the command-line form — one file or a directory to
+sweep, human-readable output, a nonzero exit on any fail, error, or
+parse error:
+
+```
+bin/behaviors examples/pizzas/bluebook/pizzas.behaviors
+bin/behaviors examples/
+```
+
+For a consumer whose own test suite runs on rspec,
+`hecksagain/behaviors/rspec` turns a `.behaviors` file into ordinary
+examples — one `it` per test, named by the test's own description — the
+same shape this repo's own `spec/behaviors_examples_spec.rb` uses to run
+`examples/pizzas/bluebook/pizzas.behaviors` as part of `bundle exec
+rspec`:
+
+```ruby skip
+require "hecksagain/behaviors/rspec"
+
+Dir.glob("bluebook/**/*.behaviors").each do |path|
+  Hecksagain::Behaviors::RSpec.describe_file(path)
+end
+```
+
+## A fuller worked example
+
+Chess is the domain this DSL was actually proven against while it was
+being built — turn order enforced through a `given`, four sliding and
+leaping pieces each checking every occupant list before a `Move`
+succeeds, a two-dispatch `Capture`-then-`Move` protocol, and a
+`Graveyard` aggregate fed entirely by policy from the board's own
+`Captured` events. Every example on this page is drawn from that
+domain's real `chess.behaviors` file — turn order, blocking, occupancy,
+capture, and the graveyard, the same five categories `spec/chess_spec.rb`
+groups its own direct assertions under in the project that domain lives
+in. It is not part of this repo's own corpus (`examples/` stays domains
+hecksagain itself owns and ships), which is why every snippet above is
+marked "shown, never run" rather than boot the game for real — but it is
+real, and it is the shape a `.behaviors` file takes once a domain has
+more than one aggregate, entities with their own commands, and a
+projection fed by policy.

--- a/docs/implemented/guides/index.md
+++ b/docs/implemented/guides/index.md
@@ -43,3 +43,6 @@ you're not.
     it: the canonical IR's exact shape, the dispatch order, and how
     the expression grammar `given`/`ensures`/`invariant` compile down
     to.
+14. **[Behaviors](behaviors.md)** — hand-curated examples of how a domain
+    is used, in its own vocabulary, run as tests: `bin/behaviors`, the
+    rspec shim, and what `emits:` sees through a real policy cascade.

--- a/examples/pizzas/bluebook/pizzas.behaviors
+++ b/examples/pizzas/bluebook/pizzas.behaviors
@@ -1,0 +1,65 @@
+Hecks.behaviors "Pizzas" do
+  vision "Examples of how a pizza is built, sold, and found through this domain."
+
+  # `pizzas_behaviors.hecksagon` (not `pizzas.hecksagon`, which binds the
+  # real PostgresEra adapter this domain actually deploys with) — a
+  # Memory-persisted sibling that lives OUTSIDE bluebook/, so an ordinary
+  # directory boot of examples/pizzas never globs it up alongside the
+  # real one.
+  loads "pizzas.bluebook", "../pizzas_behaviors.hecksagon"
+
+  test "CreatePizza puts a fresh pizza on the menu, available for sale" do
+    tests "CreatePizza", on: "Order"
+    input  name: { value: "Margherita" }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } }
+    expect status: "available", customer_name: nil
+  end
+
+  test "AddTopping refuses more than ten toppings" do
+    tests "AddTopping", on: "Order"
+    setup  "CreatePizza", name: { value: "Loaded" }, pizza: { price_cents: { cents: 1500 }, size: { value: "large" } }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Basil" },     amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Olives" },    amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Mushroom" }, amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Onion" },     amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Pepper" },    amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Sausage" },   amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Bacon" },     amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Pineapple" }, amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Anchovy" },   amount: { value: 1 }
+    setup  "AddTopping",  name: "Loaded", topping: { value: "Jalapeno" },  amount: { value: 1 }
+    input  name: "Loaded", topping: { value: "Extra Cheese" }, amount: { value: 1 }
+    expect refused: "at most 10 toppings"
+  end
+
+  test "Purchase refuses a pizza with no toppings on it" do
+    tests "Purchase", on: "Order"
+    setup  "CreatePizza", name: { value: "Bare" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+    input  name: "Bare", customer_name: { value: "Chris" }, amount: { cents: 900 }
+    expect refused: "at least one topping"
+  end
+
+  test "Purchase sells the pizza and closes its lifecycle" do
+    tests "Purchase", on: "Order"
+    setup  "CreatePizza", name: { value: "Sold Out" }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } }
+    setup  "AddTopping",  name: "Sold Out", topping: { value: "Basil" }, amount: { value: 2 }
+    input  name: "Sold Out", customer_name: { value: "Chris" }, amount: { cents: 1200 }
+    expect emits: ["PizzaPurchased"]
+  end
+
+  test "a sold pizza is no longer Available" do
+    tests "Available", on: "Order", kind: :query
+    setup  "CreatePizza", name: { value: "Fresh" },     pizza: { price_cents: { cents: 1000 }, size: { value: "small" } }
+    setup  "CreatePizza", name: { value: "Also Sold" }, pizza: { price_cents: { cents: 1100 }, size: { value: "small" } }
+    setup  "AddTopping",  name: "Also Sold", topping: { value: "Basil" }, amount: { value: 1 }
+    setup  "Purchase",    name: "Also Sold", customer_name: { value: "Chris" }, amount: { cents: 1100 }
+    expect count: 1
+  end
+
+  test "CostingLessThan finds a pizza under the ceiling named" do
+    tests "CostingLessThan", on: "Order", kind: :query
+    setup  "CreatePizza", name: { value: "Bargain" }, pizza: { price_cents: { cents: 800 }, size: { value: "small" } }
+    setup  "CreatePizza", name: { value: "Splurge" }, pizza: { price_cents: { cents: 1800 }, size: { value: "large" } }
+    input  ceiling: { cents: 1000 }
+    expect count: 1
+  end
+end

--- a/examples/pizzas/pizzas_behaviors.hecksagon
+++ b/examples/pizzas/pizzas_behaviors.hecksagon
@@ -13,7 +13,6 @@ Hecks.hecksagon "Pizzas" do
 
   Pizzas::Order.port "PaymentGateway" do
     operation "Receive" do
-      reference_to Order, as: :name
       attribute :customer_name, CustomerName
       attribute :amount, Price
       emits "PizzaPaymentReceived"

--- a/examples/pizzas/pizzas_behaviors.hecksagon
+++ b/examples/pizzas/pizzas_behaviors.hecksagon
@@ -1,0 +1,27 @@
+# MEMORY, NOT `pizzas.hecksagon`'s OWN POSTGRESERA BIND — a `.behaviors`
+# example boots a fresh runtime per test (Hecksagain::Behaviors's own
+# design), so it wants an adapter with no real database to reach at all.
+# `pizzas.hecksagon` binds `PostgresEra` against `pizzas.world`'s real
+# connection string, which is right for the actual deployed domain and
+# wrong for a throwaway per-test boot — so `pizzas.behaviors` `loads`
+# THIS sibling hecksagon instead of the real one, the same Memory
+# override `spec_helper.rb`'s own `boot_in_memory` uses for the exact
+# same reason.
+Hecks.hecksagon "Pizzas" do
+  uses_framework "Governance"
+  Pizzas::Order.persisted_by("Memory")
+
+  Pizzas::Order.port "PaymentGateway" do
+    operation "Receive" do
+      reference_to Order, as: :name
+      attribute :customer_name, CustomerName
+      attribute :amount, Price
+      emits "PizzaPaymentReceived"
+    end
+  end
+end
+
+Hecks.hecksagon "Governance" do
+  Governance::RoleAssignment.persisted_by("Memory")
+  Governance::RoleTransition.persisted_by("Memory")
+end

--- a/lib/hecksagain.rb
+++ b/lib/hecksagain.rb
@@ -65,6 +65,14 @@ module Hecksagain
       Runtime.boot(path, shared: shared, install_facade: install_facade, environment: environment)
     end
 
+    # `paths` — an explicit list of files to boot (a `.bluebook`, its
+    # `.hecksagon`, optionally a `.world`), loaded in place from wherever
+    # they actually live — see Runtime::Loader.boot_files's own header for
+    # why this exists beside `boot` rather than as a special case of it.
+    def boot_files(paths, shared: nil, install_facade: true, environment: nil)
+      Runtime.boot_files(paths, shared: shared, install_facade: install_facade, environment: environment)
+    end
+
     def with_registry(registry, &block) = Runtime.with_registry(registry, &block)
 
     def current_registry = Runtime.current_registry

--- a/lib/hecksagain/adapters/driven/folder.rb
+++ b/lib/hecksagain/adapters/driven/folder.rb
@@ -77,6 +77,42 @@ module Hecksagain
         Bluebook::MetaValidator.judge_deferred!(Hecksagain.current_registry)
       end
 
+      # THE EXPLICIT-FILE SIBLING OF `load_domain` — for a caller that names
+      # its own exact files rather than a directory to glob (`Loader.boot_files`,
+      # behind `Hecks.boot_files`). No `Dir.glob`, no copying: every path here
+      # is a real file on disk, wherever it actually lives, loaded in place —
+      # a `.behaviors` file's `loads` scopes a boot this way specifically so a
+      # per-test boot never has to fake isolation by staging bluebooks into a
+      # tmpdir (see Loader.boot_files's own header for why that pattern is a
+      # hazard, not a convenience).
+      #
+      # ORDERED BY CATEGORY, NOT BY THE CALLER'S OWN LIST ORDER — same four
+      # groups `Vocabulary.fetch("LoadOrder")` walks a directory in
+      # (bluebook chapters, translations, hecksagons, worlds), because a
+      # hecksagon can reference a bluebook's own constants and must not load
+      # first regardless of which order a caller happened to write `loads
+      # "x.hecksagon", "x.bluebook"` in. Bluebook chapters are judged as one
+      # deferred group exactly like `load_domain` does, for the identical
+      # forward-reference reason (MetaValidator.defer's own header).
+      def load_selected(files, environment: nil)
+        bluebooks, rest = files.partition { |f| f.end_with?(".bluebook") }
+
+        if bluebooks.any?
+          Bluebook::MetaValidator.defer { bluebooks.sort.each { |f| Kernel.load(f) } }
+          Bluebook::MetaValidator.judge_deferred!(Hecksagain.current_registry)
+        end
+
+        %w[.hecksagon .world].each do |ext|
+          rest.select { |f| f.end_with?(ext) }.sort.each { |f| Kernel.load(f) }
+        end
+
+        return unless environment
+
+        directory = File.dirname(files.first)
+        load_each(directory, [File.join("environments", "#{environment}.hecksagon")])
+        load_each(directory, [File.join("environments", "#{environment}.world")])
+      end
+
       def load_each(directory, patterns)
         return unless File.directory?(directory)
 

--- a/lib/hecksagain/behaviors.rb
+++ b/lib/hecksagain/behaviors.rb
@@ -1,0 +1,25 @@
+require_relative "behaviors/dsl"
+require_relative "behaviors/expectations"
+require_relative "behaviors/runner"
+
+# The `.behaviors` toolkit `bin/behaviors` and a consumer's own rspec shim
+# (`hecksagain/behaviors/rspec`) drive. Not required by lib/hecksagain.rb on
+# purpose — a booted domain never needs it, the same reason `Fuzzing` (see
+# lib/hecksagain/fuzzing.rb, the shape this file mirrors) is opt-in too.
+module Hecksagain
+  class << self
+    # `Hecks.behaviors "Name" do ... end` — deliberately NOT routed
+    # through `collect` the way `bluebook`/`hecksagon`/`world` are: a
+    # behaviors suite is a test artifact a runner reads on demand, never
+    # a thing a live domain boot needs, so it has no business landing in
+    # `Runtime.current_registry`.
+    def behaviors(name, &)
+      path = Behaviors.loading_path or
+        raise Behaviors::LoadOutsideRunner,
+              "Hecks.behaviors called outside Hecksagain::Behaviors.run(path) — " \
+              "a .behaviors file is only ever loaded by the behaviors runner"
+
+      Behaviors.last_suite = Behaviors::BehaviorsBuilder.build(name, source_path: path, &)
+    end
+  end
+end

--- a/lib/hecksagain/behaviors/dsl.rb
+++ b/lib/hecksagain/behaviors/dsl.rb
@@ -1,0 +1,96 @@
+require_relative "ir"
+
+# The authoring surface for `Hecks.behaviors "Name" do ... end` — one
+# `test "description" do ... end` block per case, `tests`/`setup`/`input`/
+# `expect` inside. `instance_eval`-based, the same shape every other
+# hecksagain DSL builder uses (`WorldBuilder`, `HecksagonBuilder`).
+module Hecksagain
+  module Behaviors
+    # Raised at `Hecks.behaviors` build time — a missing `vision` or
+    # `loads` line names the fix directly rather than failing later, deep
+    # inside a boot, over a suite that was never going to be scoped.
+    class Malformed < StandardError; end
+
+    class TestCaseBuilder
+      def initialize(description)
+        @description   = description
+        @tests_command = nil
+        @on_aggregate  = nil
+        @kind          = :command
+        @setups        = []
+        @input         = {}
+        @expect        = {}
+      end
+
+      def tests(command, on: nil, kind: :command)
+        @tests_command = command
+        @on_aggregate  = on
+        @kind          = kind
+      end
+
+      def setup(command, **kwargs)
+        @setups << TestSetup.new(command: command, args: kwargs)
+      end
+
+      def input(**kwargs)  = @input.merge!(kwargs)
+      def expect(**kwargs) = @expect.merge!(kwargs)
+
+      def build
+        unless @tests_command
+          raise Malformed, "test #{@description.inspect} never calls `tests` — " \
+                           "say which command or query this example exercises"
+        end
+
+        TestCase.new(description: @description, tests_command: @tests_command,
+                     on_aggregate: @on_aggregate, kind: @kind,
+                     setups: @setups, input: @input, expect: @expect)
+      end
+    end
+
+    class BehaviorsBuilder
+      def initialize(name, source_path:)
+        @name        = name
+        @source_path = source_path
+        @source_dir  = File.dirname(source_path)
+        @vision      = nil
+        @loads       = nil
+        @tests       = []
+      end
+
+      def vision(text) = @vision = text
+
+      # Relative to THIS `.behaviors` file, never to the filesystem's cwd
+      # or a same-stem convention — scope is a fact this file declares,
+      # not one a runner infers.
+      def loads(*paths)
+        @loads = paths.map { |path| File.expand_path(path, @source_dir) }
+      end
+
+      def test(description, &block)
+        builder = TestCaseBuilder.new(description)
+        builder.instance_eval(&block) if block
+        @tests << builder.build
+      end
+
+      def build
+        unless @vision
+          raise Malformed, "#{@source_path}: no `vision \"...\"` — say in one line " \
+                           "what this suite is examples of"
+        end
+        unless @loads
+          raise Malformed, "#{@source_path}: no `loads \"...\"` — a behaviors file " \
+                           "must declare exactly which files to boot"
+        end
+
+        BehaviorsSuite.new(name: @name, vision: @vision, loads: @loads,
+                           tests: @tests, path: @source_path)
+      end
+
+      def self.build(name, source_path:, &block)
+        builder = new(name, source_path: source_path)
+        builder.instance_eval(&block) if block
+        builder.build
+      end
+    end
+  end
+end

--- a/lib/hecksagain/behaviors/expectations.rb
+++ b/lib/hecksagain/behaviors/expectations.rb
@@ -1,0 +1,198 @@
+require_relative "ir"
+require_relative "../runtime/loader"
+require_relative "../runtime/errors"
+require_relative "../runtime/value"
+
+# Hecksagain::Behaviors::Expectations
+#
+# One test case, start to finish: boot a fresh runtime scoped to exactly
+# what the suite's own `loads` names, replay `setup` dispatches, dispatch
+# (or query) the command under test, check `expect`. Split out of
+# runner.rb the same way the file-count/sweep concern is split from a
+# single test's own execution.
+#
+# TWO DELIBERATE DEVIATIONS from a prior port of this same idea (read
+# before writing this, not reinvented):
+#
+# 1. A `setup` refusal and a refusal from the command under test are
+#    caught in SEPARATE rescue scopes. The prior port wrapped the whole
+#    test body — setups included — in one `rescue *REFUSAL_CLASSES`, so a
+#    broken setup could spuriously satisfy `expect refused: "..."` if its
+#    own refusal happened to match the expected substring. Here, any
+#    domain refusal during `setup` is unconditionally an ERROR — the
+#    example never got to the situation it claims to test.
+#
+# 2. `emits:` is read off a `registry.event_log` DIFF around the tested
+#    dispatch, not off `Result#events` alone. `Result#events` only holds
+#    the events the OUTERMOST dispatch announced; a policy's own cascade
+#    reenters through the same `Dispatcher#dispatch` (`PolicyInterpreter
+#    #deliver` → `door.reenter` → `dispatch`), and every dispatch's
+#    events — outer and reentrant alike — land in the one shared
+#    `registry.event_log`, in order (`CommandRules::Emission#emit`,
+#    `PortOperationInterpreter#emit`/`#call`). Diffing that log's length
+#    before/after the tested dispatch is the one read that actually sees
+#    a cascade — this DSL has no `kind: :cascade` because cascades are
+#    always on and `emits:` is expected to see them.
+module Hecksagain
+  module Behaviors
+    module Expectations
+      module_function
+
+      REFUSAL_CLASSES = Hecksagain::Runtime::DOMAIN_REFUSALS
+      SPECIAL_KEYS = %i[ok refused emits count].freeze
+
+      def run_one(test, suite)
+        runtime = Hecksagain::Runtime::Loader.boot_files(suite.loads, install_facade: false)
+        bluebooks = runtime.registry.bluebooks.values
+
+        current_setup = nil
+        begin
+          test.setups.each do |setup|
+            current_setup = setup
+            runtime.dispatch(qualify(setup.command, nil, bluebooks, kind: :command), **setup.args)
+          end
+        rescue *REFUSAL_CLASSES => e
+          return error_result(test, "setup #{current_setup&.command.inspect} refused: #{e.message}")
+        end
+
+        run_tested(test, runtime, bluebooks)
+      rescue StandardError => e
+        error_result(test, "#{e.class}: #{e.message}")
+      end
+
+      def run_tested(test, runtime, bluebooks)
+        verb = qualify(test.tests_command, test.on_aggregate, bluebooks, kind: test.kind)
+
+        if test.query?
+          run_query(test, runtime, verb)
+        else
+          run_command(test, runtime, verb)
+        end
+      rescue *REFUSAL_CLASSES => e
+        check_refusal(test, e)
+      end
+
+      def run_command(test, runtime, verb)
+        before = runtime.registry.event_log.length
+        result = runtime.dispatch(verb, **test.input)
+
+        return fail_result(test, "expected refused: #{test.expect[:refused].inspect} but dispatch succeeded") if test.expect.key?(:refused)
+
+        if (expected_emits = test.expect[:emits])
+          actual = runtime.registry.event_log[before..].map(&:name)
+          return fail_result(test, "expected emits: #{expected_emits.inspect}, got #{actual.inspect}") unless actual == expected_emits
+        end
+
+        check_ok(test) || check_fields(test, result.state || {}) || pass_result(test)
+      end
+
+      def run_query(test, runtime, verb)
+        rows = runtime.query(verb, **test.input)
+
+        return fail_result(test, "expected refused: #{test.expect[:refused].inspect} but the query succeeded") if test.expect.key?(:refused)
+
+        if (expected = test.expect[:count])
+          count = if rows.is_a?(Array)
+                    rows.size
+                  else
+                    (rows.nil? ? 0 : 1)
+                  end
+          return fail_result(test, "expected count: #{expected}, got #{count}") if count != expected
+        end
+
+        check_ok(test) || pass_result(test)
+      end
+
+      def check_ok(test)
+        return unless test.expect.key?(:ok)
+
+        expected = test.expect[:ok]
+        return if expected == true || expected.nil?
+
+        fail_result(test, "expect ok: only accepts true — got #{expected.inspect}")
+      end
+
+      def check_fields(test, state)
+        test.expect.each do |key, expected|
+          next if SPECIAL_KEYS.include?(key)
+
+          unless state.key?(key) || state.key?(key.to_s)
+            return fail_result(test, "expect #{key}: names no field on the tested aggregate — " \
+                                     "valid expect keys are ok:, refused:, emits:, count: (queries only), " \
+                                     "or a real field name")
+          end
+
+          actual = normalize(state.key?(key) ? state[key] : state[key.to_s])
+          exp    = normalize(expected)
+          return fail_result(test, "expected #{key}: #{expected.inspect}, got #{actual.inspect}") unless actual == exp
+        end
+        nil
+      end
+
+      def check_refusal(test, error)
+        expected = test.expect[:refused]
+        return error_result(test, "unexpected refusal (#{error.class}): #{error.message}") unless expected
+
+        msg = error.message.to_s
+        # hecksagain's given/ensures refusals render "Command refused —
+        # <description>" (RefusalWording) ; a behaviors file names just
+        # the description — end_with?/include? bridges the prefix.
+        return pass_result(test) if msg == expected || msg.end_with?(expected) || msg.include?(expected)
+
+        fail_result(test, "expected refused: #{expected.inspect}, got #{msg.inspect}")
+      end
+
+      # The real corpus this DSL is proven against writes VO-typed
+      # `expect` values both ways — bare (`expect kind: "bishop"`) and
+      # wrapped (`expect kind: { value: "bishop" }`). A live record's
+      # field always comes back as a `Hecksagain::Runtime::Value`;
+      # normalizing BOTH sides to the same bare-scalar-or-plain-hash
+      # shape is the one comparison that accepts either spelling.
+      def normalize(value)
+        return Hecksagain::Runtime::Value.materialize_unwrapped(value) if value.is_a?(Hecksagain::Runtime::Value)
+        return normalize(value[:value]) if value.is_a?(Hash) && value.keys == [:value]
+
+        value
+      end
+
+      # A bare `tests`/`setup` command name carries no domain — `loads`
+      # can name more than one bluebook, so resolution searches every
+      # aggregate across every bluebook the suite booted for the one that
+      # actually declares the command. `on:` (when given, only ever on
+      # the TESTED command — `setup` never receives it, see the DSL
+      # contract) narrows the search to one aggregate by name instead of
+      # searching all of them.
+      def qualify(command, on_aggregate, bluebooks, kind:)
+        return command.to_s if command.to_s.include?(".")
+
+        members = kind == :query ? :queries : :commands
+        pairs =
+          if on_aggregate
+            bluebooks.filter_map { |bb| (agg = bb.aggregate(on_aggregate)) && [bb, agg] }
+          else
+            bluebooks.flat_map { |bb| bb.aggregates.map { |agg| [bb, agg] } }
+          end
+        candidates = pairs.select { |_, agg| agg.public_send(members).any? { |m| m.hecks_name == command.to_s } }
+
+        case candidates.size
+        when 0
+          raise ArgumentError, "no aggregate among #{bluebooks.map(&:name).inspect} declares a #{kind} " \
+                               "named #{command.inspect} — say `on:` if it's ambiguous, or check the spelling"
+        when 1
+          bluebook, aggregate = candidates.first
+          "#{bluebook.name}::#{aggregate.name}.#{command}"
+        else
+          owners = candidates.map { |bb, agg| "#{bb.name}::#{agg.name}" }
+          raise ArgumentError, "#{command.inspect} is declared on more than one aggregate (#{owners.join(', ')}) " \
+                               "— say `on:` to disambiguate, or use the dotted FQN"
+        end
+      end
+
+      def pass_result(test) = Result.new(description: test.description, status: :pass, message: nil)
+      def fail_result(test, message)  = Result.new(description: test.description, status: :fail,  message: message)
+      def error_result(test, message) = Result.new(description: test.description, status: :error, message: message)
+
+      Result = Struct.new(:description, :status, :message, keyword_init: true)
+    end
+  end
+end

--- a/lib/hecksagain/behaviors/ir.rb
+++ b/lib/hecksagain/behaviors/ir.rb
@@ -1,0 +1,31 @@
+# Hecksagain::Behaviors::{TestSetup,TestCase,BehaviorsSuite}
+#
+# The `.behaviors` authoring surface's own IR — plain Structs, holding
+# exactly what `Hecks.behaviors "Name" do ... end` collected. Deliberately
+# NOT part of `Hecksagain::IR`/`emits_ir` — a behaviors suite is never
+# collected into a domain Registry (see `Hecksagain.behaviors`), never
+# dispatched through MetaValidator, and carries none of the self-hosted
+# round-trip machinery a real bluebook construct does. It is a test
+# artifact a runner reads on demand, not a domain a boot needs.
+module Hecksagain
+  module Behaviors
+    TestSetup = Struct.new(:command, :args, keyword_init: true)
+
+    TestCase = Struct.new(:description, :tests_command, :on_aggregate, :kind,
+                          :setups, :input, :expect, keyword_init: true) do
+      # An already-dotted tests_command is a literal FQN; otherwise `on:`
+      # composes with the domain name resolved once setups/the tested
+      # dispatch actually run (see Expectations — the domain isn't known
+      # until `loads` is booted, so it's a runtime concern, not a field
+      # here).
+      def dotted? = tests_command.to_s.include?(".")
+
+      def query? = kind == :query
+    end
+
+    # `loads` — absolute paths, already resolved against the `.behaviors`
+    # file's own directory by the DSL (`BehaviorsBuilder#loads`). `path` is
+    # the `.behaviors` file itself, kept for error messages.
+    BehaviorsSuite = Struct.new(:name, :vision, :loads, :tests, :path, keyword_init: true)
+  end
+end

--- a/lib/hecksagain/behaviors/rspec.rb
+++ b/lib/hecksagain/behaviors/rspec.rb
@@ -1,0 +1,42 @@
+require_relative "../behaviors"
+
+# Hecksagain::Behaviors::RSpec.describe_file(path) — the shim a consumer's
+# `bundle exec rspec` uses to run `.behaviors` files as ordinary examples,
+# one `it` per test, named by the test's own description string. Same
+# shape `spec/guides_spec.rb` uses for doctested guides: the file is
+# PARSED at collection time (cheap — `Behaviors.parse`, no test actually
+# run yet, just enough to know the `it` names), and each test's own
+# `Expectations.run_one` runs lazily inside its own `it`, exactly when
+# rspec actually executes it.
+#
+#   require "hecksagain/behaviors/rspec"
+#
+#   Dir.glob("bluebook/**/*.behaviors").each do |path|
+#     Hecksagain::Behaviors::RSpec.describe_file(path)
+#   end
+module Hecksagain
+  module Behaviors
+    module RSpec
+      module_function
+
+      def describe_file(path)
+        parsed = Behaviors.parse(path)
+
+        ::RSpec.describe(File.basename(path)) do
+          if parsed.parse_error
+            it "loads without a parse error" do
+              raise parsed.parse_error
+            end
+          else
+            parsed.suite.tests.each do |test|
+              it(test.description) do
+                run = Expectations.run_one(test, parsed.suite)
+                raise run.message if run.status != :pass
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hecksagain/behaviors/runner.rb
+++ b/lib/hecksagain/behaviors/runner.rb
@@ -1,0 +1,96 @@
+require_relative "expectations"
+
+# Hecksagain::Behaviors.run(path) / .run_all(dir)
+#
+# Discovery + aggregation. `run_one` (expectations.rb) is the impure edge
+# that actually touches a live runtime; this file finds `.behaviors`
+# files, loads them, and maps their tests through it.
+module Hecksagain
+  module Behaviors
+    FileResult = Struct.new(:path, :parse_error, :runs, keyword_init: true)
+    SweepResult = Struct.new(:root, :files_swept, :files, :summary, keyword_init: true)
+    ParseResult = Struct.new(:path, :suite, :parse_error, keyword_init: true)
+
+    class LoadOutsideRunner < StandardError; end
+
+    class << self
+      # The `.behaviors` file currently being `Kernel.load`ed, if any —
+      # bound only for the duration of that load (`run`'s own `ensure`),
+      # never left set. `Hecks.behaviors` (lib/hecksagain/behaviors.rb)
+      # reads this to resolve its own `loads` line relative to the right
+      # file, and to refuse a `.behaviors` file loaded any other way.
+      attr_accessor :loading_path
+
+      # The suite the most recent `Hecks.behaviors` call built — read
+      # once, right after `Kernel.load`, by `run` below, which resets it
+      # to nil before every load so a file that loads without calling
+      # `Hecks.behaviors` at all is never confused for a stale previous
+      # suite (a real bug in a prior port of this idea: compared only
+      # against nil, so after the first successful file in a sweep it
+      # stayed non-nil forever).
+      attr_accessor :last_suite
+
+      # `Kernel.load`s one `.behaviors` file and returns its suite, with
+      # NO test actually executed yet — the cheap half, split out so a
+      # caller that only needs to know what tests exist (the rspec shim,
+      # naming its `it`s at collection time) doesn't pay for running them
+      # until it actually wants to. `Behaviors.loading_path` is bound only
+      # for the duration of the load, and `last_suite` is reset to nil
+      # BEFORE it — a file that loads without ever calling
+      # `Hecks.behaviors` is unambiguously a parse error, never a stale
+      # suite from whatever loaded before it in a sweep (a real bug in a
+      # prior port of this idea: compared only against nil, so after the
+      # first successful file in a sweep it stayed non-nil forever).
+      def parse(path)
+        path = File.expand_path(path)
+        previous_path = loading_path
+        self.loading_path = path
+        self.last_suite = nil
+
+        begin
+          Kernel.load(path)
+        rescue StandardError, ScriptError => e
+          return ParseResult.new(path: path, suite: nil, parse_error: "#{e.class}: #{e.message}")
+        ensure
+          self.loading_path = previous_path
+        end
+
+        suite = last_suite
+        return ParseResult.new(path: path, suite: nil, parse_error: "file loaded but called no Hecks.behaviors") unless suite
+
+        ParseResult.new(path: path, suite: suite, parse_error: nil)
+      end
+
+      # One `.behaviors` file → `FileResult`, every test actually run.
+      def run(path)
+        parsed = parse(path)
+        return FileResult.new(path: parsed.path, parse_error: parsed.parse_error, runs: []) if parsed.parse_error
+
+        runs = parsed.suite.tests.map { |test| Expectations.run_one(test, parsed.suite) }
+        FileResult.new(path: parsed.path, parse_error: nil, runs: runs)
+      end
+
+      # Sweeps every `.behaviors` file under `dir`. Reports the file count
+      # it actually found — a sweep that goes green without saying how
+      # much it looked at is indistinguishable from one that found
+      # nothing to look at.
+      def run_all(dir)
+        files = Dir.glob(File.join(dir, "**", "*.behaviors"))
+        results = files.map { |path| run(path) }
+        SweepResult.new(root: dir, files_swept: files.size, files: results, summary: summarize(results))
+      end
+
+      def summarize(results)
+        runs = results.flat_map(&:runs)
+        {
+          files:        results.size,
+          parse_errors: results.count(&:parse_error),
+          total:        runs.size,
+          passed:       runs.count { |r| r.status == :pass },
+          failed:       runs.count { |r| r.status == :fail },
+          errored:      runs.count { |r| r.status == :error }
+        }
+      end
+    end
+  end
+end

--- a/lib/hecksagain/runtime.rb
+++ b/lib/hecksagain/runtime.rb
@@ -71,6 +71,11 @@ module Hecksagain
         Loader.boot(path, shared: shared, install_facade: install_facade, environment: environment)
       end
 
+      # `paths` form — see Loader.boot_files.
+      def boot_files(paths, shared: nil, install_facade: true, environment: nil)
+        Loader.boot_files(paths, shared: shared, install_facade: install_facade, environment: environment)
+      end
+
       # Bind the ambient registry for the duration of the block, restoring
       # whatever was there before. Nesting is safe ; a raise still restores.
       def with_registry(registry)

--- a/lib/hecksagain/runtime/dispatcher.rb
+++ b/lib/hecksagain/runtime/dispatcher.rb
@@ -146,7 +146,7 @@ module Hecksagain
           head, = command_name.split(".", 2)
           if aggregate.port(head)
             raise WiringError,
-                  "#{verb} names a port operation — dry_run has no in-memory form for one, " \
+                  "#{verb} names a port operation — dry_run? has no in-memory form for one, " \
                   "only for aggregate and entity commands"
           end
 

--- a/lib/hecksagain/runtime/loader.rb
+++ b/lib/hecksagain/runtime/loader.rb
@@ -60,6 +60,48 @@ module Hecksagain
         install_facade ? bind_runtime(dispatcher) : dispatcher
       end
 
+      # THE EXPLICIT-FILE FORM — `paths` names the exact bluebook/hecksagon/
+      # world files to boot, in place, wherever they actually live. `boot`
+      # above only ever takes a directory and globs it; that is the right
+      # shape for a real deployment (`examples/banking`, a domain someone
+      # `cd`s into), and the wrong one for a caller that wants to declare a
+      # narrow, explicit scope and have it booted exactly as declared — a
+      # `.behaviors` file's own `loads` line is the motivating caller
+      # (`Hecksagain::Behaviors`), but this carries no behaviors-specific
+      # logic and is not gated behind requiring that module.
+      #
+      # NO COPYING, NO TEMP DIRECTORY. A prior port of this same idea
+      # (vendored into a downstream consumer, read before writing this)
+      # scoped a per-test boot by copying files into `Dir.mktmpdir` — which
+      # destroys real relative paths, and worse, makes a `persisted_by`
+      # path resolve against the TEMP copy's root instead of the project's
+      # own (confirmed there: a file adapter kept reading and writing the
+      # same deterministic tmp copy across an entire session, because
+      # `Hecks.boot`'s own `root` is always `File.dirname` of whatever
+      # directory it was handed). `directory` here is `File.dirname` of the
+      # FIRST real path in `paths` — genuinely on disk, not a copy — so
+      # every downstream path (`EraCheck`, `persisted_by`, `shared_root`)
+      # resolves exactly as an ordinary directory boot's would.
+      def self.boot_files(paths, shared: nil, install_facade: true, environment: nil)
+        loading   = Ports::Loading.bootstrap
+        files     = Array(paths).map { |path| File.expand_path(path) }
+        directory = File.dirname(files.first)
+        root      = loading.shared_root(shared, directory)
+        registry  = Registry.new(root: File.dirname(directory))
+
+        Hecksagain.with_registry(registry) do
+          loading.load_library
+          loading.load_project(root)
+          loading.load_selected(files, environment: environment)
+        end
+
+        EraCheck.check!(registry, directory)
+        registry.verify!
+        registry.rehydrate_sagas!
+        dispatcher = dispatcher_for(registry)
+        install_facade ? bind_runtime(dispatcher) : dispatcher
+      end
+
       # `RemoteDispatcher` for a domain routed through Lambda,
       # `Dispatcher` otherwise — the ONE place this decision gets
       # made, so everything built on top (`Handle`, `AggregateDoor`,

--- a/spec/behaviors/expectations_spec.rb
+++ b/spec/behaviors/expectations_spec.rb
@@ -1,0 +1,95 @@
+require "hecksagain/behaviors/expectations"
+
+RSpec.describe Hecksagain::Behaviors::Expectations do
+  let(:root) { File.join(InMemoryDomain::ROOT, "examples/pizzas/bluebook") }
+  let(:memory_hecksagon) { File.join(InMemoryDomain::ROOT, "examples/pizzas/pizzas_behaviors.hecksagon") }
+  let(:runtime) { Hecks.boot_files([File.join(root, "pizzas.bluebook"), memory_hecksagon], install_facade: false) }
+  let(:bluebooks) { runtime.registry.bluebooks.values }
+
+  describe ".qualify" do
+    it "passes a dotted name through as a literal FQN" do
+      expect(described_class.qualify("Pizzas::Order.CreatePizza", nil, bluebooks, kind: :command))
+        .to eq("Pizzas::Order.CreatePizza")
+    end
+
+    it "resolves a bare command name to its declaring aggregate" do
+      expect(described_class.qualify("CreatePizza", nil, bluebooks, kind: :command))
+        .to eq("Pizzas::Order.CreatePizza")
+    end
+
+    it "resolves a bare query name to its declaring aggregate" do
+      expect(described_class.qualify("Available", nil, bluebooks, kind: :query))
+        .to eq("Pizzas::Order.Available")
+    end
+
+    it "narrows the search with on: when given" do
+      expect(described_class.qualify("CreatePizza", "Order", bluebooks, kind: :command))
+        .to eq("Pizzas::Order.CreatePizza")
+    end
+
+    it "raises naming the command when no aggregate declares it" do
+      expect { described_class.qualify("NoSuchVerb", nil, bluebooks, kind: :command) }
+        .to raise_error(ArgumentError, /no aggregate.*declares a command named "NoSuchVerb"/)
+    end
+  end
+
+  describe ".normalize" do
+    it "treats a bare scalar and a wrapped value object as equal" do
+      value_object = runtime.registry.bluebook("Pizzas").aggregate("Order").value_object("PizzaName")
+      wrapped = Hecksagain::Runtime::Value.new(value_object, { value: "Margherita" })
+
+      expect(described_class.normalize(wrapped)).to eq(described_class.normalize({ value: "Margherita" }))
+      expect(described_class.normalize({ value: "Margherita" })).to eq(described_class.normalize("Margherita"))
+    end
+  end
+
+  describe "refused: matching" do
+    let(:suite) { Hecksagain::Behaviors::BehaviorsSuite.new(loads: [File.join(root, "pizzas.bluebook"), memory_hecksagon]) }
+
+    def test_case(tests_command:, on_aggregate:, input:, expect:, setups: [])
+      Hecksagain::Behaviors::TestCase.new(description: "t", tests_command: tests_command, on_aggregate: on_aggregate,
+                                          kind: :command, setups: setups, input: input, expect: expect)
+    end
+
+    it "passes ok: true for a command that succeeds" do
+      test = test_case(tests_command: "CreatePizza", on_aggregate: "Order",
+                       input: { name: { value: "Ok" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } } },
+                       expect: { ok: true })
+      expect(described_class.run_one(test, suite).status).to eq(:pass)
+    end
+
+    it "passes when the refusal message includes the expected substring" do
+      test = test_case(tests_command: "AddTopping", on_aggregate: "Order",
+                       setups: [Hecksagain::Behaviors::TestSetup.new(
+                         command: "CreatePizza",
+                         args:    { name: { value: "Sealed" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } } }
+                       )],
+                       input: { name: "Sealed", topping: { value: "Basil" }, amount: { value: 0 } },
+                       expect: { refused: "an amount is positive" })
+      run = described_class.run_one(test, suite)
+      expect(run.status).to eq(:pass)
+    end
+
+    it "fails when the refusal happened but the message doesn't match, showing both" do
+      test = test_case(tests_command: "AddTopping", on_aggregate: "Order",
+                       setups: [Hecksagain::Behaviors::TestSetup.new(
+                         command: "CreatePizza",
+                         args:    { name: { value: "Sealed2" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } } }
+                       )],
+                       input: { name: "Sealed2", topping: { value: "Basil" }, amount: { value: 0 } },
+                       expect: { refused: "a sold pizza cannot be changed" })
+      run = described_class.run_one(test, suite)
+      expect(run.status).to eq(:fail)
+      expect(run.message).to include("an amount is positive")
+    end
+
+    it "fails when expect refused: is set but the dispatch actually succeeded" do
+      test = test_case(tests_command: "CreatePizza", on_aggregate: "Order",
+                       input: { name: { value: "Succeeds" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } } },
+                       expect: { refused: "anything" })
+      run = described_class.run_one(test, suite)
+      expect(run.status).to eq(:fail)
+      expect(run.message).to include("dispatch succeeded")
+    end
+  end
+end

--- a/spec/behaviors/fixtures/no_loads.behaviors
+++ b/spec/behaviors/fixtures/no_loads.behaviors
@@ -1,0 +1,9 @@
+Hecks.behaviors "NoLoads" do
+  vision "Has no loads line — a parse error should name the fix."
+
+  test "never reached" do
+    tests "CreatePizza", on: "Order"
+    input  name: { value: "X" }, pizza: { price_cents: { cents: 100 }, size: { value: "small" } }
+    expect ok: true
+  end
+end

--- a/spec/behaviors/fixtures/no_op.behaviors
+++ b/spec/behaviors/fixtures/no_op.behaviors
@@ -1,0 +1,3 @@
+# Loads without ever calling Hecks.behaviors — the "file loaded but
+# called no Hecks.behaviors" parse-error path.
+1 + 1

--- a/spec/behaviors/fixtures/no_vision.behaviors
+++ b/spec/behaviors/fixtures/no_vision.behaviors
@@ -1,0 +1,9 @@
+Hecks.behaviors "NoVision" do
+  loads "../../../examples/pizzas/bluebook/pizzas.bluebook", "../../../examples/pizzas/pizzas_behaviors.hecksagon"
+
+  test "never reached" do
+    tests "CreatePizza", on: "Order"
+    input  name: { value: "X" }, pizza: { price_cents: { cents: 100 }, size: { value: "small" } }
+    expect ok: true
+  end
+end

--- a/spec/behaviors/fixtures/pizzas_edge_cases.behaviors
+++ b/spec/behaviors/fixtures/pizzas_edge_cases.behaviors
@@ -14,7 +14,7 @@ Hecks.behaviors "PizzasEdgeCases" do
     tests "Pizzas::Order.PaymentGateway.Receive"
     setup  "CreatePizza", name: { value: "Cascade" }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } }
     setup  "AddTopping",  name: "Cascade", topping: { value: "Basil" }, amount: { value: 1 }
-    input  name: "Cascade", customer_name: { value: "Chris" }, amount: { cents: 1200 }
+    input  to: "Cascade", with: { customer_name: { value: "Chris" }, amount: { cents: 1200 } }
     expect emits: ["PizzaPaymentReceived", "PizzaPurchased"]
   end
 

--- a/spec/behaviors/fixtures/pizzas_edge_cases.behaviors
+++ b/spec/behaviors/fixtures/pizzas_edge_cases.behaviors
@@ -1,0 +1,32 @@
+Hecks.behaviors "PizzasEdgeCases" do
+  vision "Exercises the runner's own edge cases against the real pizzas domain."
+  loads "../../../examples/pizzas/bluebook/pizzas.bluebook", "../../../examples/pizzas/pizzas_behaviors.hecksagon"
+
+  test "a setup refusal is an error, never a fail or a pass" do
+    tests "CreatePizza", on: "Order"
+    setup  "CreatePizza", name: { value: "Dup" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+    setup  "CreatePizza", name: { value: "Dup" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+    input  name: { value: "Whatever" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+    expect ok: true
+  end
+
+  test "emits sees a policy cascade through a port operation, in order" do
+    tests "Pizzas::Order.PaymentGateway.Receive"
+    setup  "CreatePizza", name: { value: "Cascade" }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } }
+    setup  "AddTopping",  name: "Cascade", topping: { value: "Basil" }, amount: { value: 1 }
+    input  name: "Cascade", customer_name: { value: "Chris" }, amount: { cents: 1200 }
+    expect emits: ["PizzaPaymentReceived", "PizzaPurchased"]
+  end
+
+  test "an unknown expect field fails, naming the five valid keys" do
+    tests "CreatePizza", on: "Order"
+    input  name: { value: "Unknown" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+    expect not_a_real_field: 1
+  end
+
+  test "a field expectation accepts both the bare and the wrapped value-object spelling" do
+    tests "CreatePizza", on: "Order"
+    input  name: { value: "Wrapped" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+    expect status: "available", name: { value: "Wrapped" }
+  end
+end

--- a/spec/behaviors/rspec_shim_spec.rb
+++ b/spec/behaviors/rspec_shim_spec.rb
@@ -1,0 +1,19 @@
+require "hecksagain/behaviors/rspec"
+
+RSpec.describe "Hecksagain::Behaviors::RSpec.describe_file" do
+  def fixture(name) = File.join(File.expand_path("fixtures", __dir__), name)
+
+  it "names one example per test, by the test's own description" do
+    group = Hecksagain::Behaviors::RSpec.describe_file(fixture("pizzas_edge_cases.behaviors"))
+
+    expect(group.examples.map(&:description)).to eq(
+      Hecksagain::Behaviors.parse(fixture("pizzas_edge_cases.behaviors")).suite.tests.map(&:description)
+    )
+  end
+
+  it "turns a parse error into one example naming the problem" do
+    group = Hecksagain::Behaviors::RSpec.describe_file(fixture("no_loads.behaviors"))
+
+    expect(group.examples.map(&:description)).to eq(["loads without a parse error"])
+  end
+end

--- a/spec/behaviors/runner_spec.rb
+++ b/spec/behaviors/runner_spec.rb
@@ -1,0 +1,73 @@
+require "hecksagain/behaviors"
+
+RSpec.describe Hecksagain::Behaviors do
+  def fixture(name) = File.join(File.expand_path("fixtures", __dir__), name)
+
+  describe "parse errors" do
+    it "names the fix for a missing vision" do
+      result = described_class.run(fixture("no_vision.behaviors"))
+      expect(result.parse_error).to include("no `vision")
+    end
+
+    it "names the fix for a missing loads" do
+      result = described_class.run(fixture("no_loads.behaviors"))
+      expect(result.parse_error).to include("no `loads")
+    end
+
+    it "reports a file that loads without ever calling Hecks.behaviors" do
+      result = described_class.run(fixture("no_op.behaviors"))
+      expect(result.parse_error).to eq("file loaded but called no Hecks.behaviors")
+    end
+
+    it "refuses Hecks.behaviors called outside the runner" do
+      expect { Hecks.behaviors("Direct") { vision "x" } }.to raise_error(Hecksagain::Behaviors::LoadOutsideRunner)
+    end
+  end
+
+  describe "a sweep that never confuses a stale suite for a fresh one" do
+    it "does not let a no-op file after a real one reuse the prior suite" do
+      real  = described_class.run(fixture("pizzas_edge_cases.behaviors"))
+      no_op = described_class.run(fixture("no_op.behaviors"))
+
+      expect(real.parse_error).to be_nil
+      expect(no_op.parse_error).to eq("file loaded but called no Hecks.behaviors")
+    end
+  end
+
+  describe "one test, start to finish" do
+    let(:runs) do
+      described_class.run(fixture("pizzas_edge_cases.behaviors")).runs.to_h { |r| [r.description, r] }
+    end
+
+    it "reports a setup refusal as an error, never a fail or a pass" do
+      run = runs.fetch("a setup refusal is an error, never a fail or a pass")
+      expect(run.status).to eq(:error)
+      expect(run.message).to include('setup "CreatePizza" refused')
+    end
+
+    it "sees a policy cascade in emits:, in order" do
+      run = runs.fetch("emits sees a policy cascade through a port operation, in order")
+      expect(run.status).to eq(:pass)
+    end
+
+    it "fails an unknown expect field, naming the five valid keys" do
+      run = runs.fetch("an unknown expect field fails, naming the five valid keys")
+      expect(run.status).to eq(:fail)
+      expect(run.message).to include("ok:, refused:, emits:, count:")
+    end
+
+    it "accepts both the bare and the wrapped value-object spelling" do
+      run = runs.fetch("a field expectation accepts both the bare and the wrapped value-object spelling")
+      expect(run.status).to eq(:pass)
+    end
+  end
+
+  describe ".run_all" do
+    it "sweeps every .behaviors file under a directory and reports how many it found" do
+      sweep = described_class.run_all(File.expand_path("fixtures", __dir__))
+
+      expect(sweep.files_swept).to eq(4)
+      expect(sweep.summary[:parse_errors]).to eq(3) # no_vision, no_loads, no_op
+    end
+  end
+end

--- a/spec/behaviors_examples_spec.rb
+++ b/spec/behaviors_examples_spec.rb
@@ -1,0 +1,9 @@
+require "hecksagain/behaviors/rspec"
+
+# Every `.behaviors` file the corpus carries, run as ordinary rspec
+# examples through the shim a consumer's own suite would use — the
+# sibling of spec/guides_spec.rb's doctests and spec/corpus_spec.rb's
+# JSON step-lists.
+Dir.glob(File.join(InMemoryDomain::ROOT, "examples", "**", "*.behaviors")).each do |path|
+  Hecksagain::Behaviors::RSpec.describe_file(path)
+end

--- a/spec/dsl_coverage_spec.rb
+++ b/spec/dsl_coverage_spec.rb
@@ -1,4 +1,10 @@
 require "hecksagain"
+# `Hecksagain.behaviors` is opt-in (lib/hecksagain/behaviors.rb's own
+# header), but once loaded ANYWHERE in the process it is a real,
+# permanent singleton method — required here directly so this file's own
+# coverage list is correct whether or not it happens to run alongside
+# something else that also requires it.
+require "hecksagain/behaviors"
 
 RSpec.describe "the DSL surface is fully covered" do
   PLUMBING = %i[initialize build].freeze
@@ -6,7 +12,12 @@ RSpec.describe "the DSL surface is fully covered" do
   COVERED = {
     "Hecksagain (module surface)" => [
       Hecksagain.singleton_class,
-      %i[boot with_registry bluebook hecksagon port adapter world data_translation current_registry as_caller]
+      # `boot_files` — Loader.boot_files's explicit-file sibling of `boot`.
+      # `behaviors` — lib/hecksagain/behaviors.rb, opt-in (see its own
+      # header) but a process-global singleton method the moment anything
+      # in the suite requires it, same as `boot_files`.
+      %i[boot boot_files with_registry bluebook hecksagon port adapter world data_translation current_registry
+         as_caller behaviors]
     ],
     "BluebookBuilder"             => [
       Hecksagain::Bluebook::DSL::BluebookBuilder,

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -298,6 +298,32 @@ RSpec.describe "the DSL surface" do
       expect { Hecks.bluebook("Orphan") { vision "x" } }
         .to raise_error(Hecksagain::LoadOutsideBoot, /outside a boot/)
     end
+
+    # `.boot_files` — the explicit-file sibling of `.boot`. Memory-persisted
+    # (unlike `.boot`'s own pizzas example above), so this needs no
+    # Postgres: the real pizzas.bluebook, paired with the sibling
+    # Memory-persisted hecksagon behaviors examples boot through
+    # (examples/pizzas/pizzas_behaviors.hecksagon), named exactly, not
+    # discovered by globbing a directory.
+    it ".boot_files loads exactly the files named, in place" do
+      root = File.expand_path("../examples/pizzas", __dir__)
+      runtime = Hecks.boot_files(
+        [File.join(root, "bluebook/pizzas.bluebook"), File.join(root, "pizzas_behaviors.hecksagon")],
+        install_facade: false
+      )
+
+      expect(runtime).to be_a(Hecksagain::Runtime::Dispatcher)
+      expect(runtime.registry.bluebooks.keys).to eq(%w[Pizzas Governance])
+    end
+  end
+
+  describe "Hecks.behaviors" do
+    it "refuses a call outside the behaviors runner" do
+      require "hecksagain/behaviors"
+
+      expect { Hecks.behaviors("Orphan") { vision "x" } }
+        .to raise_error(Hecksagain::Behaviors::LoadOutsideRunner, /outside/)
+    end
   end
 
   describe "declarations that cannot mean what they say" do

--- a/spec/runtime/boot_files_spec.rb
+++ b/spec/runtime/boot_files_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Hecks.boot_files" do
+  let(:root) { File.join(InMemoryDomain::ROOT, "examples/pizzas/bluebook") }
+  let(:memory_hecksagon) { File.join(InMemoryDomain::ROOT, "examples/pizzas/pizzas_behaviors.hecksagon") }
+
+  def boot_files_runtime
+    Hecks.boot_files([File.join(root, "pizzas.bluebook"), memory_hecksagon], install_facade: false)
+  end
+
+  it "dispatches identically to a directory boot of the same domain" do
+    runtime = boot_files_runtime
+    result = runtime.dispatch("Pizzas::Order.CreatePizza",
+                              name:  { value: "Margherita" },
+                              pizza: { price_cents: { cents: 1200 }, size: { value: "large" } })
+
+    expect(result.events.map(&:name)).to eq(["PizzaCreated"])
+    expect(runtime.query("Pizzas::Order.Available").map { |row| row[:id] }).to eq(["Margherita"])
+  end
+
+  it "loads the exact files named — no directory glob, no sibling file picked up by accident" do
+    runtime = boot_files_runtime
+
+    # "Governance" arrives via `uses_framework` inside the hecksagon, not
+    # from a directory glob — the point this proves is that nothing else
+    # under examples/pizzas/bluebook/ (the REAL pizzas.hecksagon, say)
+    # snuck in.
+    expect(runtime.registry.bluebooks.keys).to eq(["Pizzas", "Governance"])
+  end
+
+  it "boots against the real file paths, not a copy — no side effects between calls" do
+    first  = boot_files_runtime
+    second = boot_files_runtime
+
+    first.dispatch("Pizzas::Order.CreatePizza", name:  { value: "First" },
+                                                pizza: { price_cents: { cents: 900 }, size: { value: "small" } })
+
+    expect(second.query("Pizzas::Order.Available")).to eq([])
+  end
+
+  it "raises the ordinary LoadError for a file that doesn't exist" do
+    expect do
+      Hecks.boot_files([File.join(root, "nope.bluebook")], install_facade: false)
+    end.to raise_error(LoadError)
+  end
+end

--- a/spec/runtime/dry_run_spec.rb
+++ b/spec/runtime/dry_run_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Dispatcher#dry_run?" do
   # THE SHAPE dry_run WAS BUILT FOR — a `delegates_to` command's own
   # in-memory mutation, reached through EntityElement.locate_chain the
   # same way a real dispatch reaches it, discarded because step_save
-  # never runs. Proves dry_run sees straight through the delegation,
+  # never runs. Proves dry_run? sees straight through the delegation,
   # not just a plain entity command.
   it "sees through delegates_to too — persists nothing from the delegated entity's own mutation" do
     runtime = boot

--- a/spec/syntax_conformance_spec.rb
+++ b/spec/syntax_conformance_spec.rb
@@ -133,9 +133,16 @@ RSpec.describe "the declared syntax" do
     },
     "File"      => {
       boot:             "the runtime facade, not a declaration",
+      boot_files:       "the runtime facade, not a declaration — the explicit-file sibling of boot",
       with_registry:    "the runtime facade, not a declaration",
       current_registry: "the runtime facade, not a declaration",
-      as_caller:        "the runtime facade, not a declaration"
+      as_caller:        "the runtime facade, not a declaration",
+      # `behaviors` — lib/hecksagain/behaviors.rb, opt-in and never
+      # collected into a domain Registry (its own header says so
+      # plainly) — a `.behaviors` file is a test artifact a runner
+      # reads, never a bluebook declaration, so it carries no syntax
+      # row of its own.
+      behaviors:        "the behaviors-suite entry point, not a bluebook declaration"
       # `port`/`adapter`/`data_translation` are REMOVED from here
       # (whole-project table-unification survey, item #13's remaining
       # builders) — all three are genuine, closed-set File words now,


### PR DESCRIPTION
## What

A native `.behaviors` file format + runner (`Hecksagain::Behaviors`) — a lighter-weight, domain-language-native way to write acceptance tests against a bluebook domain, alongside the existing RSpec-based specs. `bin/behaviors` runs a suite directly; `Hecksagain::Behaviors::RSpec.describe_file` turns one into ordinary RSpec examples (see `lib/hecksagain/behaviors/rspec.rb` and the `pizzas.behaviors` fixture wired through both paths).

Also carries a small, real fix along the way: `Dispatcher#dry_run?`, previously named `#dry_run`, renamed per rubocop's `Naming/PredicateMethod` — it always raises rather than returning `false`, which makes it genuinely a predicate, not a query. 6 call sites + its own spec's describe string updated to match.

## Rebased

This branch predates PR #335 (identified_by / relationship cardinality / routing-payload separation) and PR #340 (deferred chapter validation). Rebased onto current `main`; conflicts were in files both changes also touched:

- `README.md`, a doc-path conflict (`docs/guides/` → `docs/implemented/guides/`) — took the current path scheme, added the new Behaviors guide entry into it
- `lib/hecksagain/adapters/driven/folder.rb` — two independently-added methods (`load_bluebooks` extracted on `main`, `load_selected` new here) landing at the same spot — kept both
- `spec/runtime/dry_run_spec.rb` — one dispatch call still used the pre-#335 flat-kwarg shape; updated to `to:`/`with:`

One real fixup needed after the rebase itself: `examples/pizzas/pizzas_behaviors.hecksagon` (the Memory-adapter sibling `.behaviors` boots for a fresh-per-test run) still declared `reference_to Order, as: :name` on `PaymentGateway`'s `Receive` operation — refused outright post-#335 ("behavioral routing, not retained domain state"). Dropped it to match the real `pizzas.hecksagon`, which in turn meant `pizzas_edge_cases.behaviors`' own port-operation test needed `to:`/`with:` in its `input` line instead of flat kwargs, same shape `port_operation_interpreter_spec.rb` already uses.

## Verification

- Full suite: 1773 examples, 0 failures
- rubocop: clean (567 files)
- Fuzzer: 81/81
- Full pre-push gate: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)