### PR TITLE
ci: parallelize suite (job split + parallel_rspec), pin bin/* to bundle exec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,34 +140,32 @@ jobs:
       - name: "rust coverage: identity"
         run: bin/rust_coverage identity
 
-      # KNOWN RED, ON PURPOSE. Banking declares two `read_model`
-      # constructs (ComplianceDashboard, CustomerPortfolio) and
-      # `read_model` is an entire construct kind bin/project_rust has no
-      # code path for at all (rust/project/domain_generator.rb's own
-      # "QUERIES AND READ MODELS" comment; docs/HECKS_IMPLEMENTATION_PLAN.md
-      # §8 and docs/decisions/0013 both already name this class of gap).
-      # This step is deliberately left un-excepted rather than swallowed
-      # or `continue-on-error`'d: the gap is real and not fixed here —
-      # closing this red means either a real Rust read_model
-      # implementation, or an entry added to bin/rust_coverage's own
-      # ALLOWLIST citing where read_model is already documented as a
-      # deliberate deferral. Not a change to this file.
+      # FORMERLY KNOWN RED — as of 2026-08-23, clean (0 GAP). Banking's two
+      # `read_model` constructs (ComplianceDashboard, CustomerPortfolio) are
+      # now on bin/rust_coverage's own ALLOWLIST, citing rust/project/
+      # read_models.rb's header note on group_by/rootless read models being
+      # a main-only concept this generator doesn't cover, plus rust/project/
+      # queries.rb's own eligibility argument. The underlying gap class
+      # (read_model has no Rust code path at all —
+      # rust/project/domain_generator.rb's "QUERIES AND READ MODELS"
+      # comment; docs/HECKS_IMPLEMENTATION_PLAN.md §8, docs/decisions/0013)
+      # is unchanged; what's new is the citation that lets the allowlist
+      # legitimately defer it instead of leaving it an unallowlisted GAP.
       - name: "rust coverage: banking"
         run: bin/rust_coverage banking
 
-      # ALSO KNOWN RED — discovered wiring this step in, not previously
-      # documented anywhere. Bluebook (the language's own self-hosting
-      # meta chapter) fails this same check for two reasons: its own
-      # `WholeBluebook` read_model (the same whole-kind gap as banking's,
-      # above), plus 19 per-instance gaps with no existing doc citation
-      # — mostly "optional argument feeds a non-optional target" on
-      # `then_set append` shapes, plus two commands whose identity needs
-      # an extra caller-supplied parameter no JSON step shape carries.
-      # Unlike banking's read_model gap, bin/rust_coverage's own
-      # ALLOWLIST correctly refuses to swallow these (its header
-      # requires a doc citation, not an invented one) — left red and
-      # unallowlisted here for the same reason, not investigated or
-      # fixed as part of wiring this CI step.
+      # FORMERLY ALSO KNOWN RED — as of 2026-08-23, also clean (0 GAP).
+      # Bluebook's own `WholeBluebook` read_model (same whole-kind gap as
+      # banking's, above) and its 19 per-instance gaps (mostly "optional
+      # argument feeds a non-optional target" on `then_set append` shapes,
+      # plus two commands needing an extra caller-supplied identity
+      # parameter no JSON step shape carries) are now all on
+      # bin/rust_coverage's ALLOWLIST with doc citations — see rust/project/
+      # commands.rb's #optional_source_mismatches, rust/project/
+      # read_models.rb's header, and rust/project/domain_generator.rb's
+      # manifest_entry gap_class: "structural" comment. Nothing here was
+      # swallowed without a citation; the allowlist's own requirement for
+      # one still held.
       - name: "rust coverage: meta"
         run: bin/rust_coverage meta
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,22 @@ jobs:
       # discipline this workflow already holds Postgres/SQLite to.
       # ubuntu-latest ships a Rust toolchain already; no separate setup
       # action needed.
+      #
+      # `bundle exec` matters here even though bin/project_rust never
+      # touches Bundler itself: run bare, `require "json"` resolves
+      # against whatever `json` gem is highest on the default load path
+      # (ruby/setup-ruby's bundled default, not Gemfile.lock's pinned
+      # 2.7.2) rather than the locked one — harmless to THIS build (its
+      # output feeds `cargo build`, and nothing byte-compares the ir.json/
+      # metadata.rs it writes against git), but confirmed live to reformat
+      # empty-array pretty-printing differently across `json` versions —
+      # `[]` vs `[\n\n]` — which reads as a 900+ line "drift" against the
+      # committed fixtures if anyone naively regenerates+diffs the same
+      # way this step does. `bundle exec` pins it to Gemfile.lock's
+      # version, matching what actually produced the committed files.
       - name: Build the Rust conformance binary
         run: |
-          bin/project_rust examples/banking
+          bundle exec bin/project_rust examples/banking
           cd rust && cargo build --release
 
       # rust/src/exemplar/** — real Rust the codegen in rust/project/*.rb
@@ -98,13 +111,33 @@ jobs:
       - name: Build the exemplar module
         run: cd rust && cargo test --lib
 
-      # The whole suite — corpus, adapters (Postgres and SQLite both
-      # reachable here, so neither skips itself), the guides' own doctests,
-      # the reference golden, the Rust conformance check above (also
-      # provisioned, not skipped), everything bundle exec rspec already
-      # runs locally and at the pre-push hook.
-      - name: rspec
-        run: bundle exec rspec
+      # The whole suite, SPLIT IN TWO the same way .githooks/pre-push
+      # already splits it locally — not by tag content, by SAFETY under
+      # concurrency. `io: true` and `fuzzing: true` specs do real,
+      # uncontrolled things against this ONE checkout: cargo builds
+      # writing into the shared rust/ tree, and — for
+      # spec/project_rust_pipeline_spec.rb and friends — a
+      # before(:context)/after(:context) backup-and-restore of
+      # rust/src/generated and rust/Cargo.toml itself. Running those
+      # under parallel_rspec's multiple worker processes would race two
+      # workers over the same files; running everything else serially
+      # would waste the runner's other cores for no reason. So: the
+      # `~io ~fuzzing` majority runs under parallel_rspec (auto-detects
+      # this runner's core count), then the two tagged categories run
+      # single-process, exactly like the pre-push hook already treats
+      # them. `--tag io --tag fuzzing` on its own (no CI=true reliance)
+      # is what makes the second step run them regardless of environment
+      # — spec_helper.rb's config-level exclusion only fires `unless
+      # ENV["CI"]`, but an explicit `--tag` inclusion always wins over
+      # it either way. Measured locally: the parallel step alone cut
+      # ~172s to ~15s for its 1738 examples; the serial step's 309
+      # examples (real Postgres + cargo work) still take ~118s — ~133s
+      # combined, down from ~165-172s serial-only.
+      - name: "rspec: parallel (everything safe to run concurrently)"
+        run: bundle exec parallel_rspec spec -o "--tag ~io --tag ~fuzzing"
+
+      - name: "rspec: io + fuzzing (serial — real I/O, shared-file mutation)"
+        run: bundle exec rspec --tag io --tag fuzzing
 
   checks:
     runs-on: ubuntu-latest
@@ -135,7 +168,7 @@ jobs:
       # same way every other gate in this workflow does — no special
       # handling here.
       - name: bin/fuzz
-        run: bin/fuzz
+        run: bundle exec bin/fuzz
 
       # Static analysis over the IR — unreachable lifecycle states, dead
       # transitions, saga states no handler chain reaches — facts the
@@ -143,7 +176,7 @@ jobs:
       # member the same way corpus_spec does, plus the language's own
       # meta chapters.
       - name: model check
-        run: bin/model_check
+        run: bundle exec bin/model_check
 
       # THE COVERAGE CHECKER, PER DOMAIN — a different question than the
       # `rspec` job's "Build the Rust conformance binary" and "rspec"
@@ -158,16 +191,16 @@ jobs:
       # on any un-allowlisted GAP finding; that exit code IS the gate,
       # nothing here massages it.
       - name: "rust coverage: pizzas"
-        run: bin/rust_coverage pizzas
+        run: bundle exec bin/rust_coverage pizzas
 
       - name: "rust coverage: embryonaut"
-        run: bin/rust_coverage embryonaut
+        run: bundle exec bin/rust_coverage embryonaut
 
       - name: "rust coverage: governance"
-        run: bin/rust_coverage governance
+        run: bundle exec bin/rust_coverage governance
 
       - name: "rust coverage: identity"
-        run: bin/rust_coverage identity
+        run: bundle exec bin/rust_coverage identity
 
       # FORMERLY KNOWN RED — as of 2026-08-23, clean (0 GAP). Banking's two
       # `read_model` constructs (ComplianceDashboard, CustomerPortfolio) are
@@ -181,7 +214,7 @@ jobs:
       # is unchanged; what's new is the citation that lets the allowlist
       # legitimately defer it instead of leaving it an unallowlisted GAP.
       - name: "rust coverage: banking"
-        run: bin/rust_coverage banking
+        run: bundle exec bin/rust_coverage banking
 
       # FORMERLY ALSO KNOWN RED — as of 2026-08-23, also clean (0 GAP).
       # Bluebook's own `WholeBluebook` read_model (same whole-kind gap as
@@ -196,7 +229,7 @@ jobs:
       # swallowed without a citation; the allowlist's own requirement for
       # one still held.
       - name: "rust coverage: meta"
-        run: bin/rust_coverage meta
+        run: bundle exec bin/rust_coverage meta
 
       # THE KERNEL HALF of the same guarantee. bin/project_kernel_
       # capabilities' own enums (AttributeShape/OperatorCategory) already
@@ -209,4 +242,4 @@ jobs:
       # clean but has no rust/src/kernel/<category>/<name>.rs file behind
       # it at all — see bin/rust_kernel_coverage's own header.
       - name: rust kernel coverage
-        run: bin/rust_kernel_coverage
+        run: bundle exec bin/rust_kernel_coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,29 @@ name: CI
 # check their own reachability and skip themselves silently otherwise,
 # which would mean this workflow "passing" without ever having run them.
 
+# TWO JOBS, RUN CONCURRENTLY (no `needs:` between them, so GitHub Actions
+# schedules both the moment the workflow starts). Split along the one
+# dependency edge that actually exists: `rspec`'s `io: true` specs
+# (rust_conformance_spec.rb, rust_host_lineage_conformance_spec.rb,
+# codegen_parity_spec.rb, parser_parity_spec.rb) build and run real Rust
+# against Postgres, so that job keeps the Postgres service and the Rust
+# build steps. Everything in `checks` — bin/fuzz, bin/model_check, every
+# bin/rust_coverage call, bin/rust_kernel_coverage — reads only Ruby, the
+# example domains' own IR, and already-committed rust/src/generated/
+# manifests; none of them shell out to cargo or touch Postgres (verified
+# by grepping each for cargo/postgres references — none found), so moving
+# them off the `rspec` job's critical path costs nothing. Locally this
+# split cut wall-clock from ~236s serial to ~187s (rspec-bound, since
+# `checks`'s own ~50s finishes underneath it); in Actions the saving is
+# usually bigger still since the two jobs get separate runners.
+
 on:
   push:
     branches: [main]
   pull_request:
 
 jobs:
-  test:
+  rspec:
     runs-on: ubuntu-latest
 
     services:
@@ -90,6 +106,17 @@ jobs:
       - name: rspec
         run: bundle exec rspec
 
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
       # DYNAMIC — generates random-but-valid command/query sequences from
       # EVERY example domain's own IR (plus the self-hosted grammar
       # meta-domain) and replays each one, checking every declared
@@ -119,15 +146,17 @@ jobs:
         run: bin/model_check
 
       # THE COVERAGE CHECKER, PER DOMAIN — a different question than the
-      # "Build the Rust conformance binary" and "rspec" steps above ask.
-      # Those check "did Ruby and Rust agree on this script"; this checks
-      # "did bin/project_rust generate SOMETHING for every construct
-      # this domain's own IR declares, at all" — a gap class equivalence
-      # checking is structurally blind to (see bin/rust_coverage's own
-      # header). Reads each domain's already-committed rust/src/
-      # generated/<domain>/manifest.json + ir.json — no build needed
-      # first. Exits non-zero on any un-allowlisted GAP finding; that
-      # exit code IS the gate, nothing here massages it.
+      # `rspec` job's "Build the Rust conformance binary" and "rspec"
+      # steps ask. Those check "did Ruby and Rust agree on this script";
+      # this checks "did bin/project_rust generate SOMETHING for every
+      # construct this domain's own IR declares, at all" — a gap class
+      # equivalence checking is structurally blind to (see
+      # bin/rust_coverage's own header). Reads each domain's
+      # already-committed rust/src/generated/<domain>/manifest.json +
+      # ir.json — no build needed first, which is exactly why this can
+      # live in a job with no Rust build step of its own. Exits non-zero
+      # on any un-allowlisted GAP finding; that exit code IS the gate,
+      # nothing here massages it.
       - name: "rust coverage: pizzas"
         run: bin/rust_coverage pizzas
 
@@ -172,11 +201,12 @@ jobs:
       # THE KERNEL HALF of the same guarantee. bin/project_kernel_
       # capabilities' own enums (AttributeShape/OperatorCategory) already
       # make an exhaustive match over them a compile error the moment the
-      # grammar admits a new capability — enforced for free by "Build the
-      # exemplar module" above, since kernel code isn't behind a domain
-      # feature flag. What THIS step catches is the other half: a
-      # capability whose enum variant compiles clean but has no
-      # rust/src/kernel/<category>/<name>.rs file behind it at all — see
-      # bin/rust_kernel_coverage's own header.
+      # grammar admits a new capability — enforced for free by the `rspec`
+      # job's "Build the exemplar module" step, since kernel code isn't
+      # behind a domain feature flag (and that step running in a different
+      # job doesn't weaken this one — both jobs must pass). What THIS step
+      # catches is the other half: a capability whose enum variant compiles
+      # clean but has no rust/src/kernel/<category>/<name>.rs file behind
+      # it at all — see bin/rust_kernel_coverage's own header.
       - name: rust kernel coverage
         run: bin/rust_kernel_coverage


### PR DESCRIPTION
## Summary
- Split `.github/workflows/ci.yml` into two concurrent jobs: `rspec` (Postgres + Rust build + rspec) and `checks` (bin/fuzz, model_check, all rust_coverage calls, rust_kernel_coverage) — the latter touches neither Postgres nor the Rust build, verified by grep.
- Split the `rspec` job's own step further: `parallel_rspec` for the ~1738 examples safe to run concurrently, then a serial step for `io:`/`fuzzing:`-tagged specs (real cargo builds + in-place mutation of the shared `rust/src/generated` tree — unsafe across parallel workers), mirroring how `.githooks/pre-push` already treats them.
- Every bare `bin/*` call in `ci.yml` now goes through `bundle exec`, closing a real (if previously harmless) gem-version pinning gap — confirmed live: running `bin/project_rust` unpinned resolves a newer `json` gem than Gemfile.lock's 2.7.2, which pretty-prints empty arrays as `[]` instead of `[\n\n]`. Investigated what looked like 900+ line "fixture drift" in `rust/src/generated/{banking,governance,identity,meta}` down to exactly this — re-diffing a `bundle exec`-pinned regeneration against `HEAD` comes back byte-identical. No fixture changes needed.
- Also fixed two stale "known red" comments on the banking/meta `rust coverage` steps — both are clean (0 GAP) now via allowlist entries with doc citations that didn't exist when those comments were written.

## Measured locally (mirroring the workflow)
| Stage | Before | After |
|---|---|---|
| Full serial suite | ~236s | — |
| + concurrent job split | — | ~191s |
| + parallel_rspec split | — | ~152s (rspec job, `checks` job's ~50s hides underneath) |

All steps green throughout, including the pre-push hook on every push in this branch's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)