### PR TITLE
Add editor navigation to hecks-lsp, plus VS Code wiring

### DIFF
--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,67 @@
+# Hecks Language Support (VS Code)
+
+A thin client that wires VS Code to `rust/lsp`'s `hecks-lsp` for
+`.bluebook`/`.hecksagon` files. All the real behavior — diagnostics,
+`documentSymbol`, `definition` — lives server-side; see
+`rust/lsp/README.md` for what it does and doesn't support yet (there's
+no syntax highlighting grammar contributed here either — files open as
+plain text, just with live diagnostics/outline/go-to-definition).
+
+## 1. Build the server
+
+```
+cd ../../rust/parser && cargo build
+cd ../lsp            && cargo build
+```
+
+(`--release` works too — the extension checks both `target/debug/` and
+`target/release/`.)
+
+## 2. Install this extension's own dependency
+
+```
+cd editors/vscode
+npm install
+```
+
+## 3. Try it, without installing anything globally
+
+Open `editors/vscode/` as its own folder in VS Code and press F5 (or
+Run → Start Debugging). That launches an Extension Development Host
+window with this extension active — open any `.bluebook`/`.hecksagon`
+file in a workspace that has `rust/lsp/target/{debug,release}/hecks-lsp`
+built (step 1) and it activates automatically.
+
+## 4. Or install it for real, locally
+
+There's no marketplace listing — copy (or symlink) this folder into
+your extensions directory and reload:
+
+```
+cp -r editors/vscode "$HOME/.vscode/extensions/hecks-lsp-client-0.1.0"
+cd "$HOME/.vscode/extensions/hecks-lsp-client-0.1.0" && npm install
+```
+
+Then reload VS Code (Cmd+Shift+P → "Developer: Reload Window").
+
+## Settings
+
+Both are optional — the defaults match a normal `cargo build` done
+right in this checkout (see step 1):
+
+- `hecks.lsp.serverPath` — absolute path to `hecks-lsp`. Empty searches
+  `$PATH`, then `rust/lsp/target/{debug,release}/hecks-lsp` relative to
+  the first workspace folder.
+- `hecks.parse.binaryPath` — absolute path to `hecks-parse`, passed to
+  `hecks-lsp` as `$HECKS_PARSE_BIN`. Empty lets `hecks-lsp` find it
+  itself (its own README documents that lookup order).
+
+## Checking it's actually working
+
+Open a real corpus file (`examples/pizzas/bluebook/pizzas.bluebook`) —
+the View → Output panel's "Hecks Language Server" channel should show
+the client starting with no errors. Break the file (misspell a keyword)
+and save — a red squiggle should appear with `hecks-parse`'s own error
+message on hover. Cmd-click (or F12) on a `reference_to`/`belongs_to`
+target should jump to its declaration, including across files in the
+same directory.

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -1,0 +1,64 @@
+// The VS Code side of hecks-lsp: a thin client that spawns rust/lsp's
+// `hecks-lsp` over stdio and hands it every open `.bluebook`/
+// `.hecksagon` file. All the real logic (diagnostics, documentSymbol,
+// definition) lives server-side in rust/lsp — see that crate's own
+// README for what it does and doesn't support yet. This file's only
+// job is finding the server binary and wiring vscode-languageclient to
+// it; no bundler, no TypeScript build step, plain CommonJS.
+
+const fs = require("fs");
+const path = require("path");
+const vscode = require("vscode");
+const { LanguageClient, TransportKind } = require("vscode-languageclient/node");
+
+let client;
+
+/** @returns {string} */
+function resolveServerPath() {
+  const configured = vscode.workspace.getConfiguration("hecks").get("lsp.serverPath");
+  if (configured) {
+    return configured;
+  }
+
+  // rust/lsp's own README documents this exact lookup order for
+  // hecks-parse (its own PATH -> $HECKS_PARSE_BIN -> relative sibling
+  // build); mirrored here for hecks-lsp itself, one level up, since
+  // there's no equivalent env var a VS Code extension host would
+  // already have set.
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) {
+    for (const profile of ["debug", "release"]) {
+      const guess = path.join(folders[0].uri.fsPath, "rust", "lsp", "target", profile, "hecks-lsp");
+      if (fs.existsSync(guess)) {
+        return guess;
+      }
+    }
+  }
+
+  return "hecks-lsp"; // fall back to $PATH
+}
+
+function activate(context) {
+  const command = resolveServerPath();
+  const hecksParseBin = vscode.workspace.getConfiguration("hecks").get("parse.binaryPath");
+
+  const serverOptions = {
+    command,
+    transport: TransportKind.stdio,
+    options: hecksParseBin ? { env: { ...process.env, HECKS_PARSE_BIN: hecksParseBin } } : undefined,
+  };
+
+  const clientOptions = {
+    documentSelector: [{ scheme: "file", language: "hecks-bluebook" }],
+    outputChannelName: "Hecks Language Server",
+  };
+
+  client = new LanguageClient("hecksLsp", "Hecks Language Server", serverOptions, clientOptions);
+  context.subscriptions.push(client.start());
+}
+
+function deactivate() {
+  return client ? client.stop() : undefined;
+}
+
+module.exports = { activate, deactivate };

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,106 @@
+{
+  "name": "hecks-lsp-client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hecks-lsp-client",
+      "version": "0.1.0",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.1"
+      },
+      "devDependencies": {
+        "@types/vscode": "^1.85.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.134.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.134.0.tgz",
+      "integrity": "sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "hecks-lsp-client",
+  "displayName": "Hecks Language Support",
+  "description": "Diagnostics, outline, and go-to-definition for .bluebook/.hecksagon files, via rust/lsp's hecks-lsp",
+  "version": "0.1.0",
+  "private": true,
+  "publisher": "hecks",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:hecks-bluebook"
+  ],
+  "main": "./extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "hecks-bluebook",
+        "extensions": [
+          ".bluebook",
+          ".hecksagon"
+        ],
+        "aliases": [
+          "Hecks Bluebook"
+        ]
+      }
+    ],
+    "configuration": {
+      "title": "Hecks Language Support",
+      "properties": {
+        "hecks.lsp.serverPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the hecks-lsp binary (rust/lsp). Leave empty to search $PATH, then rust/lsp/target/{debug,release}/hecks-lsp relative to the first workspace folder."
+        },
+        "hecks.parse.binaryPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the hecks-parse binary (rust/parser), passed to hecks-lsp as HECKS_PARSE_BIN. Leave empty to let hecks-lsp locate it itself — see rust/lsp/README.md's own lookup order."
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0"
+  }
+}

--- a/rust/lsp/README.md
+++ b/rust/lsp/README.md
@@ -22,9 +22,33 @@ is setup + roadmap.
   ...` list, at `severity: Warning` when the cause is
   `not_yet_implemented` (a real Stage 1 gap, not a bug in your file) and
   `severity: Error` otherwise.
+- `textDocument/documentSymbol` — an outline of every
+  `aggregate`/`entity`/`value_object`/`command`/`query`/`policy`/
+  `process_manager`/`read_model` in the open file, nested by `do`/`end`
+  depth. Sourced from a text scan of the buffer (`outline.rs`), not from
+  `hecks-parse`'s own IR — see that file's header for why (short version:
+  the IR carries no source line for anything, and often fails to build
+  at all under Stage 1's still-partial coverage, so this needed to work
+  independently of a parse succeeding).
+- `textDocument/definition` — resolves the bare identifier under the
+  cursor (a `reference_to Customer` / `belongs_to Account` usage) to
+  wherever that aggregate/entity/value_object is actually declared,
+  first in the same file, then across sibling `.bluebook`/`.hecksagon`
+  files in the same directory (a chapter routinely spans several files —
+  `parse::chapter`'s own header — and the declaration is often in one of
+  them, not the file doing the referencing).
 
 ## What it doesn't do yet
 
+- **`documentSymbol`/`definition` are text-scanned, not grammar-verified.**
+  Real, but a second, unverified idea of the grammar rather than a
+  projection of `syntax.bluebook` the way `rust/parser`'s own
+  `keywords.rs` is — see `outline.rs`'s header for the reasoning and its
+  one real failure mode (a buffer with unbalanced `do`/`end` mid-edit).
+  Only `aggregate`/`entity`/`value_object` names are valid `definition`
+  targets (`outline::is_reference_target`) — a `command`/`query` name
+  is never referenced by a bare identifier elsewhere in the corpus the
+  way a type name is, so it isn't one.
 - **No column info.** `rust/parser`'s own `Diagnostic` only tracks a
   line, so every diagnostic underlines the whole line. Real squiggle
   precision needs `rust/parser` to track columns first — nothing to fix

--- a/rust/lsp/README.md
+++ b/rust/lsp/README.md
@@ -116,13 +116,12 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 ```
 
-**VS Code**: there's no packaged extension yet. The generic-LSP-client
-extensions on the marketplace (e.g. one that runs an arbitrary command
-over stdio for a configured file glob) work against this binary as-is —
-point them at `rust/lsp/target/debug/hecks-lsp` for `**/*.bluebook` and
-`**/*.hecksagon`. A real extension would just be that config plus a
-`languages`/`grammars` contribution (see the top-level tooling report
-for the syntax-highlighting gap this would also want to close).
+**VS Code**: `editors/vscode/` (repo root) is a minimal real extension —
+see its own README for build/install steps. Not published to the
+marketplace; installed locally (copy into your extensions directory, or
+F5 an Extension Development Host). It contributes no syntax highlighting
+grammar (a separate gap — see the top-level tooling report), just the
+language client wiring.
 
 ## Testing it without an editor
 

--- a/rust/lsp/src/json.rs
+++ b/rust/lsp/src/json.rs
@@ -67,6 +67,13 @@ impl Json {
         }
     }
 
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            Json::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
     pub fn as_array(&self) -> Option<&[Json]> {
         match self {
             Json::Array(items) => Some(items.as_slice()),

--- a/rust/lsp/src/main.rs
+++ b/rust/lsp/src/main.rs
@@ -17,12 +17,13 @@
 
 mod diagnostics;
 mod json;
+mod outline;
 mod rpc;
 
 use json::Json;
 use std::collections::HashMap;
 use std::io::{self, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 struct Server {
     hecks_parse: Option<PathBuf>,
@@ -81,6 +82,8 @@ impl Server {
                                 // — no incremental-patch bookkeeping to get
                                 // wrong for a scaffold this size.
                                 ("textDocumentSync", Json::Number(1)),
+                                ("documentSymbolProvider", Json::Bool(true)),
+                                ("definitionProvider", Json::Bool(true)),
                             ]),
                         ),
                         (
@@ -140,6 +143,28 @@ impl Server {
                     .and_then(Json::as_str)
                 {
                     self.check_document(uri, out);
+                }
+            }
+            "textDocument/documentSymbol" => {
+                if let Some(id) = id {
+                    let uri = message
+                        .get("params")
+                        .and_then(|p| p.get("textDocument"))
+                        .and_then(|t| t.get("uri"))
+                        .and_then(Json::as_str);
+                    let result = match uri.and_then(|u| self.documents.get(u)) {
+                        Some(text) => {
+                            Json::Array(outline::outline(text).iter().map(document_symbol_json).collect())
+                        }
+                        None => Json::Array(Vec::new()),
+                    };
+                    let _ = rpc::write_message(out, &rpc::response(id, result));
+                }
+            }
+            "textDocument/definition" => {
+                if let Some(id) = id {
+                    let result = self.find_definition(message).unwrap_or(Json::Null);
+                    let _ = rpc::write_message(out, &rpc::response(id, result));
                 }
             }
             "textDocument/didClose" => {
@@ -207,6 +232,149 @@ impl Server {
             Err(e) => log(out, 1, &format!("hecks-lsp: {e}")),
         }
     }
+
+    /// `textDocument/definition`: resolve the bare identifier under the
+    /// cursor (a `reference_to Customer`/`belongs_to Account`-style
+    /// usage) to wherever that aggregate/entity/value_object is
+    /// declared — first in the buffer itself, then across sibling
+    /// `.bluebook`/`.hecksagon` files in the same directory, since a
+    /// chapter routinely spans several files (`parse::chapter`'s own
+    /// header) and the thing being referenced is frequently declared in
+    /// one of them, not the file doing the referencing.
+    fn find_definition(&self, message: &Json) -> Option<Json> {
+        let params = message.get("params")?;
+        let uri = params.get("textDocument")?.get("uri")?.as_str()?;
+        let position = params.get("position")?;
+        let line = position.get("line")?.as_i64()? as usize;
+        let character = position.get("character")?.as_i64()? as usize;
+
+        let text = self.documents.get(uri)?;
+        let line_text = text.lines().nth(line)?;
+        let identifier = identifier_at(line_text, character)?;
+
+        let local_roots = outline::outline(text);
+        if let Some(symbol) = outline::find_by_name(&local_roots, &identifier) {
+            return Some(location(uri, symbol.start_line));
+        }
+
+        let path = uri_to_path(uri)?;
+        let dir = path.parent()?;
+        let mut siblings: Vec<PathBuf> = std::fs::read_dir(dir)
+            .ok()?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                *p != path
+                    && matches!(p.extension().and_then(|e| e.to_str()), Some("bluebook") | Some("hecksagon"))
+            })
+            .collect();
+        // Sorted for determinism — a name genuinely declared in more
+        // than one sibling would otherwise resolve to whichever order
+        // `read_dir` happened to hand back.
+        siblings.sort();
+
+        for sibling in siblings {
+            let Ok(sibling_text) = std::fs::read_to_string(&sibling) else { continue };
+            let roots = outline::outline(&sibling_text);
+            if let Some(symbol) = outline::find_by_name(&roots, &identifier) {
+                return Some(location(&path_to_uri(&sibling), symbol.start_line));
+            }
+        }
+        None
+    }
+}
+
+/// The identifier touching character offset `character` (0-indexed, LSP
+/// convention) on `line_text` — extends in both directions over
+/// `[A-Za-z0-9_]` so a cursor anywhere inside or at either edge of a
+/// word resolves it, matching how every real LSP client already
+/// positions the cursor for a "go to definition" request.
+fn identifier_at(line_text: &str, character: usize) -> Option<String> {
+    let chars: Vec<char> = line_text.chars().collect();
+    let is_ident = |c: char| c.is_ascii_alphanumeric() || c == '_';
+
+    let mut start = character;
+    if start >= chars.len() || !is_ident(chars[start]) {
+        if start > 0 && is_ident(chars[start - 1]) {
+            start -= 1;
+        } else {
+            return None;
+        }
+    }
+    while start > 0 && is_ident(chars[start - 1]) {
+        start -= 1;
+    }
+    let mut end = start;
+    while end < chars.len() && is_ident(chars[end]) {
+        end += 1;
+    }
+    Some(chars[start..end].iter().collect())
+}
+
+/// A zero-width `Location` at a symbol's declaring line — like
+/// `lsp_diagnostic`, there's no column to be more precise with (this
+/// crate's own outline is line-based; see `outline.rs`'s header), and a
+/// zero-width range still lands the cursor on the right line in every
+/// client that matters here.
+fn location(uri: &str, line_1_indexed: usize) -> Json {
+    let line0 = line_1_indexed.saturating_sub(1) as i64;
+    let point = Json::object(vec![("line", Json::Number(line0)), ("character", Json::Number(0))]);
+    Json::object(vec![
+        ("uri", Json::string(uri)),
+        ("range", Json::object(vec![("start", point.clone()), ("end", point)])),
+    ])
+}
+
+fn document_symbol_json(symbol: &outline::Symbol) -> Json {
+    let start0 = symbol.start_line.saturating_sub(1) as i64;
+    let end0 = symbol.end_line.max(symbol.start_line).saturating_sub(1) as i64;
+    let range = Json::object(vec![
+        ("start", Json::object(vec![("line", Json::Number(start0)), ("character", Json::Number(0))])),
+        ("end", Json::object(vec![("line", Json::Number(end0)), ("character", Json::Number(0))])),
+    ]);
+    Json::object(vec![
+        ("name", Json::string(symbol.name.clone())),
+        ("kind", Json::Number(lsp_symbol_kind(symbol.kind))),
+        ("range", range.clone()),
+        ("selectionRange", range),
+        ("children", Json::Array(symbol.children.iter().map(document_symbol_json).collect())),
+    ])
+}
+
+/// LSP `SymbolKind` (the spec's own fixed numeric enum) — picked for
+/// how each construct reads to a developer skimming an outline, not for
+/// any deeper claim of equivalence: `Struct` for the three constructs
+/// that are pure data shapes (`value_object`/`entity`/`read_model`),
+/// `Class` for the two that hold behavior an outline groups other
+/// things under (`aggregate`/`process_manager`), `Method`/`Function`
+/// for the two callable-shaped constructs, `Interface` for `policy`
+/// (it reacts to an event the way a handler implementation would).
+fn lsp_symbol_kind(kind: outline::Kind) -> i64 {
+    use outline::Kind::*;
+    match kind {
+        Aggregate => 5,      // Class
+        ProcessManager => 5, // Class
+        Entity => 23,        // Struct
+        ValueObject => 23,   // Struct
+        ReadModel => 23,     // Struct
+        Command => 6,        // Method
+        Query => 12,         // Function
+        Policy => 11,        // Interface
+    }
+}
+
+/// Only handles a plain `file://` URI with no percent-escapes — every
+/// real URI this server is ever handed (this repo's own checkout paths
+/// have no spaces or non-ASCII characters), and the one thing that
+/// actually matters here (`find_definition`'s sibling-file search) only
+/// needs the DIRECTORY, which survives even if the filename portion
+/// were escaped.
+fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    uri.strip_prefix("file://").map(PathBuf::from)
+}
+
+fn path_to_uri(path: &Path) -> String {
+    format!("file://{}", path.display())
 }
 
 fn publish_diagnostics(out: &mut impl Write, uri: &str, diagnostics: Vec<Json>) {

--- a/rust/lsp/src/outline.rs
+++ b/rust/lsp/src/outline.rs
@@ -1,0 +1,223 @@
+//! A text-only outline of a `.bluebook`/`.hecksagon` buffer — every
+//! named top-level construct (`aggregate "Order" do` ... `end`), nested
+//! by `do`/`end` depth, with the line range each spans. Backs both
+//! `textDocument/documentSymbol` and `textDocument/definition`
+//! (`main.rs` resolves a bare identifier by searching outlines for a
+//! symbol of that name).
+//!
+//! DELIBERATELY NOT SOURCED FROM `hecks-parse`'s OWN IR, unlike
+//! `diagnostics.rs`: `rust/parser/src/ir.rs` carries no source line for
+//! any construct (confirmed — there is no `line` field anywhere in it),
+//! so there is nothing to navigate to even when a parse fully succeeds.
+//! And a parse often DOESN'T fully succeed yet — Stage 1 stubs return
+//! `not_yet_implemented` for whole construct kinds
+//! (`rust/parser/src/main.rs::COVERED_PAIRS`'s own header), which would
+//! leave `documentSymbol` empty for most of the real corpus if it only
+//! ever ran after a clean parse. This scans the buffer directly instead
+//! — line-based, no dependency on `hecks-parse` succeeding at all — at
+//! the cost of being a second, unverified idea of the grammar rather
+//! than a projection of `syntax.bluebook` the way `rust/parser`'s own
+//! `keywords.rs` is (see that file's header, and `rust/lsp/README.md`'s
+//! own note on this trade-off). The eight keywords below are read
+//! straight off `syntax.bluebook`'s own `Bluebook`/`Aggregate` argument
+//! lists, not guessed, and kept to exactly the constructs worth jumping
+//! to — this is an outline, not a parser.
+//!
+//! THE GRAMMAR'S OWN REGULARITY IS WHAT MAKES THIS SAFE: `rust/parser`'s
+//! own lexer refuses any line that isn't one of a small fixed set of
+//! shapes (`lex.rs::classify` — no bare Ruby expressions, no `if`, no
+//! local assignment ever admitted), so a real, well-formed `.bluebook`
+//! file only ever opens a block with a line ending in `do` and closes it
+//! with a line that is bare `end` — no one-line `do ... end`, no
+//! `do |args|` block parameters anywhere in the real corpus (confirmed:
+//! `grep -n 'do |' examples/**/*.bluebook` finds none). A do/end depth
+//! counter is a much shakier idea in general Ruby; it's a reasonably
+//! safe one here.
+//!
+//! A BUFFER MID-EDIT CAN HAVE UNBALANCED `do`/`end` — the one real
+//! failure mode: a stack that never pops (later symbols nest under a
+//! long-since-should-have-closed one) or pops early. Self-corrects the
+//! next time depth balances out; never panics either way.
+
+pub struct Symbol {
+    pub name: String,
+    pub kind: Kind,
+    pub start_line: usize, // 1-indexed, the declaring line itself
+    pub end_line: usize,   // 1-indexed, the line holding this block's own closing `end`
+    pub children: Vec<Symbol>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Aggregate,
+    Entity,
+    ValueObject,
+    Command,
+    Query,
+    Policy,
+    ProcessManager,
+    ReadModel,
+}
+
+const CONSTRUCTS: &[(&str, Kind)] = &[
+    ("aggregate", Kind::Aggregate),
+    ("entity", Kind::Entity),
+    ("value_object", Kind::ValueObject),
+    ("command", Kind::Command),
+    ("query", Kind::Query),
+    ("policy", Kind::Policy),
+    ("process_manager", Kind::ProcessManager),
+    ("read_model", Kind::ReadModel),
+];
+
+/// Kinds a `reference_to`/`belongs_to` bare identifier can legally name
+/// — the only symbols `main.rs`'s `find_definition` resolves against.
+/// `command`/`query`/`policy`/`process_manager`/`read_model` names are
+/// never referenced by a bare constant elsewhere in the corpus the way
+/// a type name is, so they're left out of definition lookup (they still
+/// appear in `documentSymbol`'s full outline).
+pub fn is_reference_target(kind: Kind) -> bool {
+    matches!(kind, Kind::Aggregate | Kind::Entity | Kind::ValueObject)
+}
+
+struct Frame {
+    name: String,
+    kind: Kind,
+    start_line: usize,
+    depth_at_push: usize,
+    children: Vec<Symbol>,
+}
+
+pub fn outline(text: &str) -> Vec<Symbol> {
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut roots: Vec<Symbol> = Vec::new();
+    let mut depth: usize = 0;
+
+    for (idx, raw_line) in text.lines().enumerate() {
+        let line_no = idx + 1;
+        let trimmed = raw_line.trim();
+
+        if let Some((name, kind)) = opens_construct(trimmed) {
+            stack.push(Frame { name, kind, start_line: line_no, depth_at_push: depth, children: Vec::new() });
+            depth += 1;
+            continue;
+        }
+
+        if trimmed == "do" || trimmed.ends_with(" do") {
+            depth += 1;
+            continue;
+        }
+
+        if trimmed == "end" {
+            depth = depth.saturating_sub(1);
+            if matches!(stack.last(), Some(frame) if frame.depth_at_push == depth) {
+                let frame = stack.pop().expect("just matched Some(frame) above");
+                let symbol = Symbol {
+                    name: frame.name,
+                    kind: frame.kind,
+                    start_line: frame.start_line,
+                    end_line: line_no,
+                    children: frame.children,
+                };
+                match stack.last_mut() {
+                    Some(parent) => parent.children.push(symbol),
+                    None => roots.push(symbol),
+                }
+            }
+        }
+    }
+
+    roots
+}
+
+fn opens_construct(trimmed: &str) -> Option<(String, Kind)> {
+    for (keyword, kind) in CONSTRUCTS {
+        let Some(after) = trimmed.strip_prefix(keyword).and_then(|r| r.strip_prefix(" \"")) else {
+            continue;
+        };
+        let Some(end_quote) = after.find('"') else { continue };
+        if after[end_quote + 1..].trim() == "do" {
+            return Some((after[..end_quote].to_string(), *kind));
+        }
+    }
+    None
+}
+
+/// Depth-first search for a symbol named exactly `name` among `symbols`
+/// and their descendants — `reference_to`/`belongs_to` targets are
+/// looked up by bare name regardless of nesting depth (the language
+/// names one idea one way, ADR 0025: a type name is unique across the
+/// chapter it's declared in, not just within its immediate parent).
+pub fn find_by_name<'a>(symbols: &'a [Symbol], name: &str) -> Option<&'a Symbol> {
+    for symbol in symbols {
+        if symbol.name == name && is_reference_target(symbol.kind) {
+            return Some(symbol);
+        }
+        if let Some(found) = find_by_name(&symbol.children, name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PIZZAS: &str = r#"Hecks.bluebook "Pizzas" do
+  aggregate "Order" do
+    value_object "PizzaName" do
+      attribute :value, String
+    end
+
+    command "CreatePizza" do
+      given "must be positive" do
+        amount > 0
+      end
+    end
+
+    query "Available" do
+    end
+  end
+
+  policy "OnPizzaPaymentReceived" do
+    on "PizzaPaymentReceived"
+    trigger Order::Purchase
+  end
+end
+"#;
+
+    #[test]
+    fn nests_constructs_by_do_end_depth() {
+        let roots = outline(PIZZAS);
+        assert_eq!(roots.len(), 2); // Order, OnPizzaPaymentReceived
+        let order = &roots[0];
+        assert_eq!(order.name, "Order");
+        assert!(matches!(order.kind, Kind::Aggregate));
+        assert_eq!(order.children.len(), 3); // PizzaName, CreatePizza, Available
+        assert_eq!(order.children[1].name, "CreatePizza");
+        assert!(matches!(order.children[1].kind, Kind::Command));
+    }
+
+    #[test]
+    fn a_nested_do_end_block_does_not_split_its_parent() {
+        let roots = outline(PIZZAS);
+        let create_pizza = &roots[0].children[1];
+        // The `given ... do ... end` block inside CreatePizza must not
+        // close CreatePizza's own block early.
+        assert_eq!(create_pizza.end_line, 11);
+    }
+
+    #[test]
+    fn finds_a_value_object_by_bare_name_anywhere_in_the_tree() {
+        let roots = outline(PIZZAS);
+        let found = find_by_name(&roots, "PizzaName").expect("finds it");
+        assert!(matches!(found.kind, Kind::ValueObject));
+    }
+
+    #[test]
+    fn a_command_is_not_a_reference_target() {
+        let roots = outline(PIZZAS);
+        assert!(find_by_name(&roots, "CreatePizza").is_none());
+    }
+}


### PR DESCRIPTION
Adds real editor navigation to hecks-lsp on top of the diagnostics from #344, and the VS Code wiring that actually makes it reachable.

**textDocument/documentSymbol** — a nested outline of every aggregate/entity/value_object/command/query/policy/process_manager/read_model in the open file, by do/end depth.

**textDocument/definition** — resolves a bare `reference_to`/`belongs_to` identifier to its declaration, checking the current file first, then sibling `.bluebook`/`.hecksagon` files in the same directory (a chapter routinely spans several files).

Both are sourced from a text scan (`rust/lsp/src/outline.rs`), not `hecks-parse`'s IR — the IR carries no source line for anything, and Stage 1's partial coverage means many real files don't fully parse yet, so this needed to work independently of a clean parse. Reasoning and known limitations are in that file's header and `rust/lsp/README.md`.

**`editors/vscode/`** — a minimal, real VS Code extension (not a stub): `vscode-languageclient` spawning `hecks-lsp` over stdio for `.bluebook`/`.hecksagon` files, two settings for pointing at non-default binary locations, its own README with build/install steps. This is what makes any of the above reachable from an editor at all.

Verified against the real banking corpus: `documentSymbol` lists all 5 read_models in `customer_and_compliance_views.bluebook` with correct line ranges; `goToDefinition` on `reference_to Account` correctly jumps cross-file to `deposit_accounts.bluebook:2`. 11 unit tests pass, `cargo build` clean. The VS Code extension's `npm install`/`node --check` pass, but it hasn't been exercised inside an actual VS Code GUI session (not available in this environment) — see `editors/vscode/README.md` for what to check once it's loaded for real.
