### PR TITLE
Fix rubocop debt: extra spacing + a disable/enable pair that should be disable-next

### DIFF
--- a/lib/hecks.rb
+++ b/lib/hecks.rb
@@ -96,8 +96,8 @@ module Hecks
 
     def hecksagon(name, &block) = collect(:add_hecksagon, Bluebook::DSL::HecksagonBuilder.build(name, &block))
     def port(name, &block) = collect(:add_port, Bluebook::DSL::PortBuilder.build(name, &block))
-    def adapter(name, &block)   = collect(:add_adapter,   Bluebook::DSL::AdapterBuilder.build(name, &block))
-    def world(name, &block)     = collect(:add_world,     Bluebook::DSL::WorldBuilder.build(name, &block))
+    def adapter(name, &block)   = collect(:add_adapter, Bluebook::DSL::AdapterBuilder.build(name, &block))
+    def world(name, &block)     = collect(:add_world, Bluebook::DSL::WorldBuilder.build(name, &block))
 
     def data_translation(name, from:, to:, &block)
       collect(:add_translation, Bluebook::DSL::TranslationBuilder.build(name, from: from, to: to, &block))

--- a/lib/hecks/behaviors/expectations.rb
+++ b/lib/hecks/behaviors/expectations.rb
@@ -245,7 +245,7 @@ module Hecks
       end
 
       def pass_result(test) = Result.new(description: test.description, status: :pass, message: nil)
-      def fail_result(test, message)  = Result.new(description: test.description, status: :fail,  message: message)
+      def fail_result(test, message)  = Result.new(description: test.description, status: :fail, message: message)
       def error_result(test, message) = Result.new(description: test.description, status: :error, message: message)
 
       Result = Struct.new(:description, :status, :message, keyword_init: true)

--- a/lib/hecks/bluebook/expression/resolver.rb
+++ b/lib/hecks/bluebook/expression/resolver.rb
@@ -319,8 +319,8 @@ module Hecks
         # found live while building this, not assumed).
         def matches_regex?(receiver_value, pattern, flags)
           text = case receiver_value
-                 when String, Symbol      then receiver_value.to_s
-                 when Integer, Float      then receiver_value.to_s
+                 when String, Symbol then receiver_value.to_s
+                 when Integer, Float then receiver_value.to_s
                  when NilClass then ""
                  else
                    raise EvaluationError, "match? expects a scalar, got #{receiver_value.class}"

--- a/lib/hecks/codemod.rb
+++ b/lib/hecks/codemod.rb
@@ -221,7 +221,7 @@ module Hecks
       # loop for why it can't batch) — splitting it across methods just
       # to satisfy the line count would scatter state four ways for no
       # readability gain.
-      # rubocop:disable Metrics/BlockLength
+      # rubocop:disable-next Metrics/BlockLength
       def run_example_domains(results, dry_run)
         Codemod::EXAMPLE_ROOTS.each do |domain_dir|
           bluebook_files = Dir.glob(File.join(domain_dir, "bluebook", "*.bluebook"))
@@ -274,7 +274,6 @@ module Hecks
           end
         end
       end
-      # rubocop:enable Metrics/BlockLength
 
       # PER-CANDIDATE, not one batched write-then-verify — the
       # meta-domain is ONE shared registry (SyntaxBoot DISPATCHES it

--- a/spec/adapters/query_agreement_spec.rb
+++ b/spec/adapters/query_agreement_spec.rb
@@ -318,15 +318,15 @@ RSpec.describe "adapter agreement — declared queries answer identically across
   # so a case cannot pass by accident on a single-row coincidence, and
   # ordering has a real tie to break among the nulls.
   RECORDS = {
-    "r1" => { status: "open",   balance: { cents: 100 }, box: { price: { cents: 100 } }, name: { value: "Eve" },
+    "r1" => { status: "open", balance: { cents: 100 }, box: { price: { cents: 100 } }, name: { value: "Eve" },
 tags: [{ name: "red" }],   note: { value: "flagged: high, risk today" },      rating: { value: 100 }, label: { value: "alpha" } },
-    "r2" => { status: "open",   balance: { cents: 500 }, box: { price: { cents: 500 } }, name: { value: "Carol" },
+    "r2" => { status: "open", balance: { cents: 500 }, box: { price: { cents: 500 } }, name: { value: "Carol" },
 tags: [{ name: "blue" }],  note: { value: "high risk, but flagged separately" } },
     "r3" => { status: "closed", balance: { cents: 900 }, box: { price: { cents: 900 } }, name: { value: "Alice" },
 tags: [{ name: "green" }], note: { value: "nothing unusual" }, rating: { value: 300 }, label: { value: "beta" } },
     "r4" => { status: "closed", balance: { cents: 300 }, box: { price: { cents: 300 } }, name: { value: "Dave" },
 tags: [{ name: "red" }],   note: { value: "high, risk, reviewed" } },
-    "r5" => { status: "open",   balance: { cents: 700 }, box: { price: { cents: 700 } }, name: { value: "Bob" },
+    "r5" => { status: "open", balance: { cents: 700 }, box: { price: { cents: 700 } }, name: { value: "Bob" },
 tags: [{ name: "blue" }],  note: { value: "low risk" }, rating: { value: 500 }, label: { value: "phase" } }
   }.freeze
 

--- a/spec/runtime/entity_spec.rb
+++ b/spec/runtime/entity_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "an entity" do
                                               kind: { name: "current" }, daily_limit: { cents: 50_000 })
     runtime.dispatch("Banking::Account.Credit", number: { value: "a1" }, amount: { cents: 10_000, currency: "USD" },
 narrative: { text: "Opening" })
-    runtime.dispatch("Banking::Account.Debit", number: { value: "a1" },  amount: { cents: 2_500, currency: "USD" },
+    runtime.dispatch("Banking::Account.Debit", number: { value: "a1" }, amount: { cents: 2_500, currency: "USD" },
 narrative: { text: "Groceries" })
   end
 


### PR DESCRIPTION
Nine `Layout/ExtraSpacing` offenses (accidental extra whitespace), fixed via `rubocop -a` (safe, whitespace-only). One `Style/DirectiveScope` offense in `lib/hecks/codemod.rb` — a disable/enable pair wrapping exactly one `def`, replaced with a single `rubocop:disable-next` on that line, via `rubocop -A --only Style/DirectiveScope` and reviewed by hand (diff is just the two directive comments, no code change).

`bundle exec rubocop`: 568 files, 0 offenses (was 10). Full non-fuzzing suite: 1781 examples, 0 failures. This was blocking every push's pre-push hook regardless of what the push actually touched.