### PR TITLE
vscode extension: fix server path resolution, add real Ruby-grammar syntax highlighting

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,9 +3,25 @@
 A thin client that wires VS Code to `rust/lsp`'s `hecks-lsp` for
 `.bluebook`/`.hecksagon` files. All the real behavior — diagnostics,
 `documentSymbol`, `definition` — lives server-side; see
-`rust/lsp/README.md` for what it does and doesn't support yet (there's
-no syntax highlighting grammar contributed here either — files open as
-plain text, just with live diagnostics/outline/go-to-definition).
+`rust/lsp/README.md` for what it does and doesn't support yet.
+
+**Syntax highlighting is real Ruby's**, not a second, hand-maintained
+grammar: `.bluebook`/`.hecksagon` files are literal Ruby, so
+`syntaxes/hecks-bluebook.tmLanguage.json` just includes VS Code's own
+built-in `source.ruby` grammar under our own scope name. Every real
+Ruby token (`do`/`end`, strings, symbols, comments, string
+interpolation) colors correctly with nothing here to fall out of sync
+as Ruby's own grammar improves upstream. `language-configuration.json`
+(bracket matching, comment toggling, `do`/`end`-aware indentation) is
+copied from VS Code's own bundled Ruby extension for the same reason.
+
+**If files still open in a different language mode** (most likely
+Ruby) — check your own `files.associations` setting
+(`Cmd+,` → search "file associations", or global `settings.json`
+directly). A `"*.bluebook": "ruby"` entry from before this extension
+existed will always beat this extension's own language contribution;
+either remove it or switch the language mode per file (bottom-right
+status bar, or `Cmd+K M`).
 
 ## 1. Build the server
 

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -13,6 +13,31 @@ const { LanguageClient, TransportKind } = require("vscode-languageclient/node");
 
 let client;
 
+/**
+ * Walks upward from `startDir` toward the filesystem root, checking at
+ * every level for a built `hecks-lsp` — handles both a workspace folder
+ * that IS the repo root (matches on the first try) and one opened
+ * several directories below it, without needing to know the checkout's
+ * own depth.
+ * @returns {string | undefined}
+ */
+function findServerUpwardFrom(startDir) {
+  let dir = startDir;
+  for (;;) {
+    for (const profile of ["debug", "release"]) {
+      const guess = path.join(dir, "rust", "lsp", "target", profile, "hecks-lsp");
+      if (fs.existsSync(guess)) {
+        return guess;
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return undefined; // reached the filesystem root
+    }
+    dir = parent;
+  }
+}
+
 /** @returns {string} */
 function resolveServerPath() {
   const configured = vscode.workspace.getConfiguration("hecks").get("lsp.serverPath");
@@ -20,21 +45,28 @@ function resolveServerPath() {
     return configured;
   }
 
-  // rust/lsp's own README documents this exact lookup order for
-  // hecks-parse (its own PATH -> $HECKS_PARSE_BIN -> relative sibling
-  // build); mirrored here for hecks-lsp itself, one level up, since
-  // there's no equivalent env var a VS Code extension host would
-  // already have set.
-  const folders = vscode.workspace.workspaceFolders;
-  if (folders && folders.length > 0) {
-    for (const profile of ["debug", "release"]) {
-      const guess = path.join(folders[0].uri.fsPath, "rust", "lsp", "target", profile, "hecks-lsp");
-      if (fs.existsSync(guess)) {
-        return guess;
-      }
+  // Two sources of a starting directory, tried in order: every open
+  // workspace folder, then the ACTIVE FILE's own directory. The second
+  // one matters more than it looks — opening a single `.bluebook` file
+  // with File > Open File (no folder open at all) is a completely
+  // ordinary way to try this out, and leaves `workspaceFolders` empty;
+  // without this, that case silently falls through to the bare
+  // `hecks-lsp` $PATH lookup below and fails with ENOENT (confirmed:
+  // that's exactly what happened testing this against a loose file).
+  const candidates = (vscode.workspace.workspaceFolders || []).map((f) => f.uri.fsPath);
+  if (vscode.window.activeTextEditor) {
+    candidates.push(path.dirname(vscode.window.activeTextEditor.document.uri.fsPath));
+  }
+  for (const start of candidates) {
+    const found = findServerUpwardFrom(start);
+    if (found) {
+      return found;
     }
   }
 
+  // rust/lsp's own README documents this exact lookup order for
+  // hecks-parse (its own PATH -> $HECKS_PARSE_BIN -> relative sibling
+  // build); this is the equivalent last resort for hecks-lsp itself.
   return "hecks-lsp"; // fall back to $PATH
 }
 

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,31 @@
+{
+  "comments": {
+    "lineComment": "#",
+    "blockComment": ["=begin", "=end"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "`", "close": "`", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"],
+    ["`", "`"]
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|in|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|(\"|'|/).*\\4)*(#.*)?$",
+    "decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif)\\b|(in|when)\\s)"
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -25,7 +25,15 @@
         ],
         "aliases": [
           "Hecks Bluebook"
-        ]
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "hecks-bluebook",
+        "scopeName": "source.hecks-bluebook",
+        "path": "./syntaxes/hecks-bluebook.tmLanguage.json"
       }
     ],
     "configuration": {

--- a/editors/vscode/syntaxes/hecks-bluebook.tmLanguage.json
+++ b/editors/vscode/syntaxes/hecks-bluebook.tmLanguage.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "_comment": "hecks-bluebook is real Ruby (.bluebook/.hecksagon files are literal Ruby, executed via instance_eval — README.md's own opening: 'a .bluebook file IS the running system'). Rather than write and maintain a second grammar, this one just includes VS Code's own built-in Ruby grammar (source.ruby, bundled with every standard VS Code install — extensions/ruby/syntaxes/ruby.tmLanguage.json) under our own scope name, so every real Ruby token (do/end, strings, symbols, comments, numbers, string interpolation, heredocs) colors correctly for free, with nothing here to fall out of sync as Ruby's own grammar improves upstream.",
+  "name": "Hecks Bluebook",
+  "scopeName": "source.hecks-bluebook",
+  "patterns": [
+    {
+      "include": "source.ruby"
+    }
+  ]
+}


### PR DESCRIPTION
Two fixes found live-testing the extension in a real VS Code session:

**1. Server path resolution.** Opening a single `.bluebook` file with no folder open left `workspace.workspaceFolders` empty, so `resolveServerPath` fell through to a bare `hecks-lsp` `$PATH` lookup and failed to spawn — confirmed in the Hecks Language Server output channel (`couldn't create connection to server ... spawn hecks-lsp ENOENT`), and visibly as VS Code's own "No definition found" on a real, valid reference. `findServerUpwardFrom` now walks from either an open workspace folder OR the active editor's own file directory, up toward the filesystem root, looking for `rust/lsp/target/{debug,release}/hecks-lsp` at each level.

**2. Real syntax highlighting.** `.bluebook`/`.hecksagon` files are literal Ruby, so `syntaxes/hecks-bluebook.tmLanguage.json` just includes VS Code's own built-in `source.ruby` grammar under our own scope name, rather than writing and maintaining a second grammar. `language-configuration.json` (bracket matching, `#` comments, `do`/`end`-aware indentation) is copied from VS Code's own bundled Ruby extension for the same reason.

Also found and documented: a pre-existing `"*.bluebook": "ruby"` in `files.associations` silently overrides this extension's own language contribution (user-level associations always win) — noted in the README with the fix.

Verified for real: reproduced the ENOENT server-side before fixing it, and ran the actual `vscode-textmate` + `vscode-oniguruma` tokenizer engine against `examples/pizzas/bluebook/pizzas.bluebook` with this exact grammar file and VS Code's own installed `ruby.tmLanguage.json` — confirmed real Ruby scopes came back (`keyword.control.ruby` on `do`/`end`, `string.quoted.double.interpolated.ruby` on string literals, `entity.name.function.ruby` on method calls, `comment.line.number-sign.ruby` on `#` comments).
