### PR TITLE
delegates_to reaches Rust: a door's dispatch runs its entity command inside its own closure, parent and all

### DIFF
--- a/examples/roster/bluebook/roster.bluebook
+++ b/examples/roster/bluebook/roster.bluebook
@@ -50,6 +50,28 @@ Hecks.bluebook "Roster" do
       attribute :age, Age
 
       identified_by :id
+
+      lifecycle :status, default: "active" do
+        transition "Retire" => "retired", from: "active"
+      end
+
+      # THE ENTITY COMMAND A DOOR DELEGATES TO — see `Roster.Retire` below.
+      # Its given and its ensures both read `parent`: the given the
+      # roster as it stands (a front-row holder may not leave), the
+      # ensures the roster AFTER this member's own status has changed
+      # (someone must still be serving) — the second is only right if the
+      # parent seen by the ensures already carries the mutated element.
+      command "Retire" do
+        goal "Leave the crew — unless seated in the front row, and never as the last one serving"
+
+        given("a front-row holder may not retire") do
+          parent.assignments.none? { |a| a.member.value == id.value && parent.seats.any? { |s| s.number.value == a.number.value && s.row.value == "front" } }
+        end
+
+        ensures("someone still serves") { parent.crew.any? { |m| m.status == "active" } }
+
+        emits "MemberRetired"
+      end
     end
 
     command "Open" do
@@ -112,6 +134,20 @@ Hecks.bluebook "Roster" do
       sets :assignments, append: { member: :member, number: :number }
 
       emits "SeatAssigned"
+    end
+
+    # THE DOOR — `delegates_to`: the roster-level command a caller
+    # dispatches, handing the SAME dispatch to one member's own Retire,
+    # atomically: the member's refusal is this command's refusal, its
+    # event is this command's event. `with:` names which door argument
+    # feeds which target argument (here the element's own identity).
+    command "Retire" do
+      goal "Retire one member, on the caller's behalf"
+
+      reference_to Roster
+      attribute :id, MemberId
+
+      delegates_to "Member.Retire", with: { id: :id }
     end
   end
 end

--- a/rust/codegen/src/commands.rs
+++ b/rust/codegen/src/commands.rs
@@ -37,12 +37,16 @@ pub fn command_skip_reason(command: &Json, aggregate: &Json, value_objects_by_na
     let mut unsupported_ops: Vec<String> = Vec::new();
     for m in mutations_list {
         let op = m.get("op").map(Json::to_s).unwrap_or_default();
-        if !["append", "set", "increment", "decrement"].contains(&op.as_str()) && !unsupported_ops.contains(&op) {
+        if !["append", "set", "increment", "decrement", "delegate"].contains(&op.as_str()) && !unsupported_ops.contains(&op) {
             unsupported_ops.push(op);
         }
     }
     if !unsupported_ops.is_empty() {
-        return Some(format!("sets op(s) {} not generated yet (only append/set/increment/decrement are)", unsupported_ops.join(", ")));
+        return Some(format!("sets op(s) {} not generated yet (only append/set/increment/decrement/delegate are)", unsupported_ops.join(", ")));
+    }
+
+    if let Some(problem) = delegate_skip_reason(command, aggregate, value_objects_by_name) {
+        return Some(problem);
     }
 
     let append_problems = mutations::append_field_problems(command, aggregate, value_objects_by_name);
@@ -326,11 +330,20 @@ pub fn emit_command(exemplar: &Exemplar, command: &Json, aggregate: &Json, domai
     let mutations_list = command.get("mutations").map(Json::each).unwrap_or(&[]);
     let mut mutation_lines: Vec<String> = mutations_list.iter().map(|m| mutations::emit_mutation_line(exemplar, m, aggregate, command, value_objects_by_name, true)).collect();
     if let Some(t) = &transition {
-        mutation_lines.push(format!("        record.{} = {}.to_string();", naming::rust_ident_field(&t.field), naming::ruby_inspect_string(&t.to_state)));
+        if !t.to_state.is_empty() {
+            mutation_lines.push(format!("        record.{} = {}.to_string();", naming::rust_ident_field(&t.field), naming::ruby_inspect_string(&t.to_state)));
+        }
     }
     if mutation_lines.is_empty() {
         mutation_lines = vec!["        let _ = record;".to_string()];
     }
+    let delegation = delegation_of(exemplar, command, aggregate, value_objects_by_name);
+    if let Some(d) = &delegation {
+        assert!(!creates, "{cmd}: a creating command cannot delegate — nothing exists to delegate to");
+        mutation_lines = vec![d.apply.clone()];
+    }
+    let prelude = delegation.as_ref().map(|d| d.prelude.clone()).unwrap_or_default();
+    let payload = if delegation.is_some() { "delegate_facts.clone()," } else { "args.to_json()," }.to_string();
 
     let (hydrate, fn_signature);
     let record_agg_attrs = aggregate.get("attributes").map(Json::each).unwrap_or(&[]);
@@ -410,8 +423,10 @@ pub fn emit_command(exemplar: &Exemplar, command: &Json, aggregate: &Json, domai
         fn_signature = sig_parts.join(", ");
     }
 
-    let emits = command.get("emits").map(Json::each).unwrap_or(&[]);
-    let emits_expr = emits.iter().map(|e| naming::ruby_inspect_string(&e.to_s())).collect::<Vec<_>>().join(", ");
+    let emits_expr = match &delegation {
+        Some(d) => d.emits.iter().map(|e| naming::ruby_inspect_string(e)).collect::<Vec<_>>().join(", "),
+        None => command.get("emits").map(Json::each).unwrap_or(&[]).iter().map(|e| naming::ruby_inspect_string(&e.to_s())).collect::<Vec<_>>().join(", "),
+    };
 
     let dispatch_fn = exemplar.render(
         "dispatch_fn",
@@ -423,6 +438,7 @@ pub fn emit_command(exemplar: &Exemplar, command: &Json, aggregate: &Json, domai
             ("let tmpl_eval_fielded = tmpl_with_references_placeholder();", with_references_binding()),
             ("&tmpl_eval_fielded,", "&with_references,".to_string()),
             ("tmpl_hydrate_placeholder()", hydrate),
+            ("tmpl_prelude_placeholder();", prelude),
             ("\"TmplCmdName\"", naming::ruby_inspect_string(&cmd)),
             ("\"TmplQualifiedName\"", naming::ruby_inspect_string(&format!("{domain_name}::{}", aggregate.get("name").and_then(Json::as_str).unwrap_or("")))),
             ("\"TmplAggregateName\"", naming::ruby_inspect_string(&aggregate_name)),
@@ -432,10 +448,191 @@ pub fn emit_command(exemplar: &Exemplar, command: &Json, aggregate: &Json, domai
             ("tmpl_mutation_lines_placeholder(record);", mutation_lines.join("\n")),
             ("tmpl_ensures_spec_placeholder(),", ensures_specs.join("\n")),
             ("tmpl_emit_placeholder()", emits_expr),
+            ("args.to_json(),", payload),
         ],
     );
 
     format!("{}\n\n#[derive(Debug, Clone)]\n{}\n\n{dispatch_fn}", crate::fielded::emit_fielded_flat(exemplar, &format!("{cmd}Args"), attrs, value_objects_by_name, &[]), args_struct.join("\n"))
+}
+
+/// Port of commands.rb's `delegate_of`/`delegate_mapping`/
+/// `delegate_target`/`delegate_skip_reason`/`delegation_of` — the
+/// `:delegate` mutation (`delegates_to`), see the exemplar's own
+/// `delegate_prelude`/`delegate_apply` comment for the shape.
+fn delegate_of(command: &Json) -> Option<&Json> {
+    command.get("mutations").map(Json::each).unwrap_or(&[]).iter().find(|m| m.get("op").map(Json::to_s).unwrap_or_default() == "delegate")
+}
+
+fn delegate_mapping(delegation: &Json) -> Vec<(String, String)> {
+    match delegation.get("fields") {
+        Some(Json::Object(pairs)) => pairs.iter().map(|(k, v)| (k.clone(), v.to_s().trim_start_matches(':').to_string())).collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn delegate_target<'a>(delegation: &Json, aggregate: &'a Json) -> (Option<&'a Json>, Option<&'a Json>) {
+    let target = delegation.get("target").map(Json::to_s).unwrap_or_default();
+    let (entity_name, command_name) = match target.rfind('.') {
+        Some(dot) => (&target[..dot], &target[dot + 1..]),
+        None => ("", target.as_str()),
+    };
+    let entity = aggregate.get("entities").map(Json::each).unwrap_or(&[]).iter().find(|e| e.get("name").map(Json::to_s).unwrap_or_default() == entity_name);
+    let command = entity.and_then(|e| e.get("commands").map(Json::each).unwrap_or(&[]).iter().find(|c| c.get("name").map(Json::to_s).unwrap_or_default() == command_name));
+    (entity, command)
+}
+
+pub fn delegate_skip_reason(command: &Json, aggregate: &Json, value_objects_by_name: &HashMap<String, &Json>) -> Option<String> {
+    let delegation = delegate_of(command)?;
+    let label = format!("delegates_to {}", delegation.get("target").map(Json::to_s).unwrap_or_default());
+    if command.get("mutations").map(Json::each).unwrap_or(&[]).len() > 1 {
+        return Some(format!("{label} alongside other sets — not generated yet"));
+    }
+    let (entity, target) = delegate_target(delegation, aggregate);
+    let Some(entity) = entity else {
+        return Some(format!("{label}: {} has no such entity", aggregate.get("name").map(Json::to_s).unwrap_or_default()));
+    };
+    let entity_name = entity.get("name").map(Json::to_s).unwrap_or_default();
+    let Some(target) = target else {
+        return Some(format!("{label}: {entity_name} declares no such command"));
+    };
+    if !crate::json_codec::extract_id_supported(entity) {
+        return Some(format!("{label}: {entity_name} cannot be addressed by identity"));
+    }
+    if let Some(problem) = entity_command_skip_reason(target, entity, value_objects_by_name) {
+        return Some(format!("{label}: {problem}"));
+    }
+    let mapping = delegate_mapping(delegation);
+    let source_name_for = |name: &str| mapping.iter().find(|(t, _)| t == name).map(|(_, s)| s.clone()).unwrap_or_else(|| name.to_string());
+    let door_attrs = command.get("attributes").map(Json::each).unwrap_or(&[]);
+    for attr in target.get("attributes").map(Json::each).unwrap_or(&[]) {
+        let name = crate::attr::name(attr);
+        let source_name = source_name_for(name);
+        let source = door_attrs.iter().find(|a| crate::attr::name(a) == source_name);
+        let Some(source) = source else {
+            if crate::attr::optional(attr) {
+                continue;
+            }
+            return Some(format!("{label}: target argument {name} has no source on the door"));
+        };
+        if crate::attr::type_name(source) != crate::attr::type_name(attr) || crate::attr::list(source) != crate::attr::list(attr) {
+            return Some(format!("{label}: door argument {source_name} is {}, target wants {} — not generated yet", crate::attr::type_name(source), crate::attr::type_name(attr)));
+        }
+        if crate::attr::optional(source) && !crate::attr::optional(attr) {
+            return Some(format!("{label}: optional door argument {source_name} feeds required {name}"));
+        }
+    }
+    for path in entity.get("identified_by").map(Json::each).unwrap_or(&[]) {
+        let path = path.to_s();
+        let head = path.split('.').next().unwrap_or("").to_string();
+        let source_name = source_name_for(&head);
+        if door_attrs.iter().any(|a| crate::attr::name(a) == source_name && !crate::attr::optional(a)) {
+            continue;
+        }
+        return Some(format!("{label}: the element's identity {head} has no source on the door"));
+    }
+    None
+}
+
+struct Delegation {
+    prelude: String,
+    apply: String,
+    emits: Vec<String>,
+}
+
+fn indent_block(text: &str, indent: &str) -> String {
+    text.lines().map(|l| format!("{indent}{l}")).collect::<Vec<_>>().join("\n").trim_end().to_string()
+}
+
+fn delegation_of(exemplar: &Exemplar, command: &Json, aggregate: &Json, value_objects_by_name: &HashMap<String, &Json>) -> Option<Delegation> {
+    let delegation = delegate_of(command)?;
+    let (entity, target) = delegate_target(delegation, aggregate);
+    let (entity, target) = (entity.expect("delegate_skip_reason admitted the entity"), target.expect("delegate_skip_reason admitted the target"));
+    let entity_name = entity.get("name").map(Json::to_s).unwrap_or_default();
+    let aggregate_name = aggregate.get("name").map(Json::to_s).unwrap_or_default();
+    let list_attr = aggregate
+        .get("attributes")
+        .map(Json::each)
+        .unwrap_or(&[])
+        .iter()
+        .find(|a| crate::attr::list(a) && crate::attr::type_name(a) == entity_name)
+        .unwrap_or_else(|| panic!("{entity_name}: no list attribute on {aggregate_name} holds it"));
+
+    let element_record = naming::rust_ident(&entity_name);
+    let target_args_name = format!("{element_record}{}Args", naming::rust_ident(&target.get("name").map(Json::to_s).unwrap_or_default()));
+    let aliases: Vec<String> = delegate_mapping(delegation).iter().map(|(t, s)| format!("({}, {})", naming::ruby_inspect_string(t), naming::ruby_inspect_string(s))).collect();
+    let given_specs: Vec<String> = target
+        .get("givens")
+        .map(Json::each)
+        .unwrap_or(&[])
+        .iter()
+        .map(|g| {
+            let description = g.get("description").and_then(Json::as_str).unwrap_or("");
+            let canonical = g.get("canonical").and_then(Json::as_str).unwrap_or("");
+            format!("            crate::kernel::GivenSpec {{ description: {}, expr: {} }},", naming::ruby_inspect_string(description), crate::expr_emitter::emit_predicate(canonical))
+        })
+        .collect();
+    let ensures_specs: Vec<String> = target
+        .get("ensures")
+        .map(Json::each)
+        .unwrap_or(&[])
+        .iter()
+        .map(|e| {
+            let description = e.get("description").and_then(Json::as_str).unwrap_or("");
+            let canonical = e.get("canonical").and_then(Json::as_str).unwrap_or("");
+            format!("            crate::kernel::EnsuresSpec {{ description: {}, expr: {} }},", naming::ruby_inspect_string(description), crate::expr_emitter::emit_predicate(canonical))
+        })
+        .collect();
+    let transition = mutations::lifecycle_transition_for(target, entity);
+    let transition_arg = match &transition {
+        Some(t) => format!(
+            "Some(crate::kernel::TransitionCheck {{ field: {}, from_states: &[{}] }})",
+            naming::ruby_inspect_string(&t.field),
+            t.from_states.iter().map(|s| naming::ruby_inspect_string(s)).collect::<Vec<_>>().join(", ")
+        ),
+        None => "None".to_string(),
+    };
+    let mut mutation_lines: Vec<String> = target
+        .get("mutations")
+        .map(Json::each)
+        .unwrap_or(&[])
+        .iter()
+        .map(|m| mutations::emit_mutation_line(exemplar, m, entity, target, value_objects_by_name, false))
+        .collect();
+    if let Some(t) = &transition {
+        if !t.to_state.is_empty() {
+            mutation_lines.push(format!("        record.{} = {}.to_string();", naming::rust_ident_field(&t.field), naming::ruby_inspect_string(&t.to_state)));
+        }
+    }
+    if mutation_lines.is_empty() {
+        mutation_lines = vec!["        let _ = record;".to_string()];
+    }
+    let identity_reading = entity.get("identified_by").map(Json::each).unwrap_or(&[]).iter().map(Json::to_s).collect::<Vec<_>>().join(", ");
+
+    let prelude = exemplar.render(
+        "delegate_prelude",
+        &[("tmpl_aliases_placeholder()", aliases.join(", ")), ("TmplTargetArgs", target_args_name), ("TmplElement", element_record.clone())],
+    );
+    let apply = exemplar.render(
+        "delegate_apply",
+        &[
+            ("TmplRecord", naming::rust_ident(&aggregate_name)),
+            ("tmpl_list_field", naming::rust_ident_field(crate::attr::name(list_attr))),
+            ("TmplElement", element_record),
+            ("\"TmplQualifiedCommandName\"", naming::ruby_inspect_string(&format!("{entity_name}.{}", target.get("name").map(Json::to_s).unwrap_or_default()))),
+            ("\"TmplAggregateName\"", naming::ruby_inspect_string(&aggregate_name)),
+            ("\"TmplEntityName\"", naming::ruby_inspect_string(&entity_name)),
+            ("\"TmplEntityIdentityReading\"", naming::ruby_inspect_string(&identity_reading)),
+            ("tmpl_given_spec_placeholder(),", given_specs.join("\n")),
+            ("tmpl_transition_placeholder()", transition_arg),
+            ("tmpl_entity_mutation_lines_placeholder(record);", mutation_lines.join("\n")),
+            ("tmpl_ensures_spec_placeholder(),", ensures_specs.join("\n")),
+        ],
+    );
+    Some(Delegation {
+        prelude: indent_block(&prelude, "    "),
+        apply: indent_block(&apply, "        "),
+        emits: target.get("emits").map(Json::each).unwrap_or(&[]).iter().map(Json::to_s).collect(),
+    })
 }
 
 /// `entity_command_skip_reason` — `command_skip_reason` with `entity`
@@ -526,7 +723,9 @@ pub fn emit_entity_command(
     let mutations_list = command.get("mutations").map(Json::each).unwrap_or(&[]);
     let mut mutation_lines: Vec<String> = mutations_list.iter().map(|m| mutations::emit_mutation_line(exemplar, m, entity, command, value_objects_by_name, false)).collect();
     if let Some(t) = &transition {
-        mutation_lines.push(format!("        record.{} = {}.to_string();", naming::rust_ident_field(&t.field), naming::ruby_inspect_string(&t.to_state)));
+        if !t.to_state.is_empty() {
+            mutation_lines.push(format!("        record.{} = {}.to_string();", naming::rust_ident_field(&t.field), naming::ruby_inspect_string(&t.to_state)));
+        }
     }
     if mutation_lines.is_empty() {
         mutation_lines = vec!["        let _ = record;".to_string()];

--- a/rust/codegen/src/mutations.rs
+++ b/rust/codegen/src/mutations.rs
@@ -168,7 +168,25 @@ pub fn lifecycle_transition_for(command: &Json, aggregate: &Json) -> Option<Tran
     let transitions = lifecycle.get("transitions").map(Json::each).unwrap_or(&[]);
     let rows: Vec<&Json> = transitions.iter().filter(|t| t.get("command").map(Json::to_s).unwrap_or_default() == command_name).collect();
     if rows.is_empty() {
-        return None;
+        // `from:` WITHOUT a transition — see mutations.rb's own
+        // `lifecycle_transition_for`: a guard on the current state that
+        // moves nothing; `to_state` empty is that "moves nothing".
+        let froms: Vec<String> = match command.get("from") {
+            Some(Json::Null) | None => Vec::new(),
+            Some(Json::String(s)) => vec![s.clone()],
+            Some(list) => list.each().iter().map(Json::to_s).collect(),
+        };
+        if froms.is_empty() {
+            return None;
+        }
+        let mut from_states: Vec<String> = Vec::new();
+        for from in froms {
+            if !from_states.contains(&from) {
+                from_states.push(from);
+            }
+        }
+        let field = lifecycle.get("field").and_then(Json::as_str).unwrap_or("").to_string();
+        return Some(Transition { field, to_state: String::new(), from_states });
     }
 
     let field = lifecycle.get("field").and_then(Json::as_str).unwrap_or("").to_string();

--- a/rust/project/commands.rb
+++ b/rust/project/commands.rb
@@ -43,8 +43,11 @@ module RustProjection
     end
 
     def command_skip_reason(command, aggregate, value_objects_by_name)
-      unsupported_ops = command[:mutations].reject { |m| %w[append set increment decrement].include?(m[:op].to_s) }.map { |m| m[:op] }.uniq
-      return "sets op(s) #{unsupported_ops.join(', ')} not generated yet (only append/set/increment/decrement are)" if unsupported_ops.any?
+      unsupported_ops = command[:mutations].reject { |m| %w[append set increment decrement delegate].include?(m[:op].to_s) }.map { |m| m[:op] }.uniq
+      return "sets op(s) #{unsupported_ops.join(', ')} not generated yet (only append/set/increment/decrement/delegate are)" if unsupported_ops.any?
+
+      delegate_problem = delegate_skip_reason(command, aggregate, value_objects_by_name)
+      return delegate_problem if delegate_problem
 
       append_problems = append_field_problems(command, aggregate, value_objects_by_name)
       return "sets append field(s): #{append_problems.join('; ')}" if append_problems.any?
@@ -333,8 +336,17 @@ module RustProjection
       # dispatch() step. Covers commands with no explicit sets on the
       # lifecycle field (Banking's Freeze/Unfreeze have none) — Purchase's
       # own explicit sets above already covers itself, redundantly.
-      mutation_lines << "        record.#{rust_ident_field(transition[:field])} = #{transition[:to_state].inspect}.to_string();" if transition
+      mutation_lines << "        record.#{rust_ident_field(transition[:field])} = #{transition[:to_state].inspect}.to_string();" if transition && transition[:to_state]
       mutation_lines = ["        let _ = record;"] if mutation_lines.empty? # nothing to apply — silence the unused-param warning
+      delegation = delegation_of(command, aggregate, value_objects_by_name)
+      if delegation
+        raise "#{command[:name]}: a creating command cannot delegate — nothing exists to delegate to" if creates
+
+        mutation_lines = [delegation[:apply]]
+      end
+      prelude   = delegation ? delegation[:prelude] : ""
+      payload   = delegation ? "delegate_facts.clone()," : "args.to_json(),"
+      emits_out = delegation ? delegation[:emits] : command[:emits]
 
       if creates
         record_fields = aggregate[:attributes].map do |attr|
@@ -406,6 +418,7 @@ module RustProjection
         "let tmpl_eval_fielded = tmpl_with_references_placeholder();" => with_references_binding,
         "&tmpl_eval_fielded," => "&with_references,",
         "tmpl_hydrate_placeholder()" => hydrate,
+        "tmpl_prelude_placeholder();" => prelude,
         '"TmplCmdName"' => cmd.inspect,
         '"TmplQualifiedName"' => "#{domain_name}::#{aggregate[:name]}".inspect,
         '"TmplAggregateName"' => aggregate_name.inspect,
@@ -414,10 +427,117 @@ module RustProjection
         "tmpl_transition_placeholder()" => transition_arg,
         "tmpl_mutation_lines_placeholder(record);" => mutation_lines.join("\n"),
         "tmpl_ensures_spec_placeholder()," => ensures_specs.join("\n"),
-        "tmpl_emit_placeholder()" => command[:emits].map(&:inspect).join(", ")
+        "tmpl_emit_placeholder()" => emits_out.map(&:inspect).join(", "),
+        "args.to_json()," => payload
       )
 
       "#{emit_fielded_flat("#{cmd}Args", command[:attributes], value_objects_by_name)}\n\n#[derive(Debug, Clone)]\n#{args_struct.join("\n")}\n\n#{dispatch_fn}"
+    end
+
+    # `delegates_to "Entity.Command", with: { … }` — the `:delegate`
+    # mutation (`CommandInterpreter#step_delegate_to_entity`, read
+    # directly; the exemplar's own `delegate_prelude`/`delegate_apply`
+    # comment has the shape). One per command, and the command's only
+    # mutation: the door's entire effect IS the target entity command,
+    # run on the record inside the door's own `dispatch` closure.
+    def delegate_of(command) = command[:mutations].find { |m| m[:op].to_s == "delegate" }
+
+    def delegate_mapping(delegation)
+      (delegation[:fields] || {}).to_h { |target_key, source_key| [target_key.to_s, source_key.to_s.delete_prefix(":")] }
+    end
+
+    def delegate_target(delegation, aggregate)
+      entity_name, _dot, command_name = delegation[:target].to_s.rpartition(".")
+      entity = (aggregate[:entities] || []).find { |e| e[:name].to_s == entity_name }
+      target = entity && entity[:commands].find { |c| c[:name].to_s == command_name }
+      [entity, target]
+    end
+
+    def delegate_skip_reason(command, aggregate, value_objects_by_name)
+      delegation = delegate_of(command)
+      return nil unless delegation
+
+      label = "delegates_to #{delegation[:target]}"
+      return "#{label} alongside other sets — not generated yet" if command[:mutations].size > 1
+
+      entity, target = delegate_target(delegation, aggregate)
+      return "#{label}: #{aggregate[:name]} has no such entity" unless entity
+      return "#{label}: #{entity[:name]} declares no such command" unless target
+      return "#{label}: #{entity[:name]} cannot be addressed by identity" unless extract_id_supported?(entity)
+
+      target_problem = entity_command_skip_reason(target, entity, value_objects_by_name)
+      return "#{label}: #{target_problem}" if target_problem
+
+      mapping = delegate_mapping(delegation)
+      target[:attributes].each do |attr|
+        source_name = mapping.fetch(attr[:name].to_s, attr[:name].to_s)
+        source = command[:attributes].find { |a| a[:name].to_s == source_name }
+        next if source.nil? && attr[:optional]
+        return "#{label}: target argument #{attr[:name]} has no source on the door" unless source
+        unless source[:type].to_s == attr[:type].to_s && !!source[:list] == !!attr[:list]
+          return "#{label}: door argument #{source_name} is #{source[:type]}, target wants #{attr[:type]} — not generated yet"
+        end
+        return "#{label}: optional door argument #{source_name} feeds required #{attr[:name]}" if source[:optional] && !attr[:optional]
+      end
+      entity[:identified_by].each do |path|
+        head = path.to_s.split(".").first
+        source_name = mapping.fetch(head, head)
+        next if command[:attributes].any? { |a| a[:name].to_s == source_name && !a[:optional] }
+
+        return "#{label}: the element's identity #{head} has no source on the door"
+      end
+      nil
+    end
+
+    # The three rendered pieces a delegating door needs: the prelude
+    # (before `dispatch`), the apply block (its whole closure body), and
+    # the events it emits — the TARGET's, exactly as `step_emit` answers
+    # `ctx.delegated_events` in place of the door's own.
+    def delegation_of(command, aggregate, value_objects_by_name)
+      delegation = delegate_of(command)
+      return nil unless delegation
+
+      entity, target = delegate_target(delegation, aggregate)
+      list_attr = aggregate[:attributes].find { |a| a[:list] && a[:type] == entity[:name] }
+      raise "#{entity[:name]}: no list attribute on #{aggregate[:name]} holds it" unless list_attr
+
+      element_record   = rust_ident(entity[:name])
+      target_args_name = "#{element_record}#{rust_ident(target[:name])}Args"
+      aliases = delegate_mapping(delegation).map { |target_key, source_key| "(#{target_key.inspect}, #{source_key.inspect})" }
+      given_specs = target[:givens].map do |given|
+        "            crate::kernel::GivenSpec { description: #{given[:description].inspect}, expr: #{ExprEmitter.emit_predicate(given[:canonical])} },"
+      end
+      ensures_specs = target[:ensures].map do |rule|
+        "            crate::kernel::EnsuresSpec { description: #{rule[:description].inspect}, expr: #{ExprEmitter.emit_predicate(rule[:canonical])} },"
+      end
+      transition = lifecycle_transition_for(target, entity)
+      mutation_lines = target[:mutations].map { |m| emit_mutation_line(m, entity, target, value_objects_by_name, optional: false) }
+      mutation_lines << "        record.#{rust_ident_field(transition[:field])} = #{transition[:to_state].inspect}.to_string();" if transition && transition[:to_state]
+      mutation_lines = ["        let _ = record;"] if mutation_lines.empty?
+
+      {
+        prelude: Exemplar.render(
+          "delegate_prelude",
+          "tmpl_aliases_placeholder()" => aliases.join(", "),
+          "TmplTargetArgs" => target_args_name,
+          "TmplElement" => element_record
+        ).lines.map { |l| "    #{l}" }.join.rstrip,
+        apply: Exemplar.render(
+          "delegate_apply",
+          "TmplRecord" => rust_ident(aggregate[:name]),
+          "tmpl_list_field" => rust_ident_field(list_attr[:name]),
+          "TmplElement" => element_record,
+          '"TmplQualifiedCommandName"' => "#{entity[:name]}.#{target[:name]}".inspect,
+          '"TmplAggregateName"' => aggregate[:name].to_s.inspect,
+          '"TmplEntityName"' => entity[:name].to_s.inspect,
+          '"TmplEntityIdentityReading"' => entity[:identified_by].join(", ").inspect,
+          "tmpl_given_spec_placeholder()," => given_specs.join("\n"),
+          "tmpl_transition_placeholder()" => transition_check_arg(transition),
+          "tmpl_entity_mutation_lines_placeholder(record);" => mutation_lines.join("\n"),
+          "tmpl_ensures_spec_placeholder()," => ensures_specs.join("\n")
+        ).lines.map { |l| "        #{l}" }.join.rstrip,
+        emits: target[:emits]
+      }
     end
 
     # `entity_command_skip_reason` — deliberately just `command_skip_reason`
@@ -502,7 +622,7 @@ module RustProjection
         transition_check_arg(transition)
 
       mutation_lines = command[:mutations].map { |m| emit_mutation_line(m, entity, command, value_objects_by_name, optional: false) }
-      mutation_lines << "        record.#{rust_ident_field(transition[:field])} = #{transition[:to_state].inspect}.to_string();" if transition
+      mutation_lines << "        record.#{rust_ident_field(transition[:field])} = #{transition[:to_state].inspect}.to_string();" if transition && transition[:to_state]
       mutation_lines = ["        let _ = record;"] if mutation_lines.empty?
 
       qualified_command_name = "#{entity[:name]}.#{command[:name]}"

--- a/rust/project/mutations.rb
+++ b/rust/project/mutations.rb
@@ -243,7 +243,18 @@ module RustProjection
       return nil unless aggregate[:lifecycle]
 
       rows = aggregate[:lifecycle][:transitions].select { |t| t[:command] == command[:name] }
-      return nil if rows.empty?
+      # `from:` WITHOUT a transition — `Admissibility#enforce_lifecycle_
+      # guard`, read directly: a command that only guards on the current
+      # state (a chess door's `from: "in_play"`) refuses with the same
+      # transition_blocked wording a transition does and moves nothing.
+      # `to_state: nil` is that "moves nothing"; every caller pushes the
+      # state-setting line only when it is present.
+      if rows.empty?
+        froms = Array(command[:from]).compact.map(&:to_s)
+        return nil if froms.empty?
+
+        return { field: aggregate[:lifecycle][:field], to_state: nil, from_states: froms.uniq, unconstrained: false }
+      end
 
       # `from: nil` — an UNCONSTRAINED transition, admitting from any
       # state (a creating command has no prior state to come from).

--- a/rust/src/exemplar/commands.rs
+++ b/rust/src/exemplar/commands.rs
@@ -36,6 +36,35 @@ impl TmplElement {
     fn identity(&self) -> String {
         String::new()
     }
+    fn extract_id(v: &crate::kernel::Json) -> Result<String, crate::kernel::Refusal> {
+        let _ = v;
+        Ok(String::new())
+    }
+    fn extract_wants(v: &crate::kernel::Json) -> String {
+        let _ = v;
+        String::new()
+    }
+}
+
+// The entity command's own args struct, as `delegate_prelude` builds it
+// from the door's facts — see that shape's own comment below.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TmplTargetArgs {
+    tmpl_field: i64,
+}
+impl crate::kernel::Fielded for TmplTargetArgs {
+    fn field(&self, name: &str) -> Option<crate::kernel::Field<'_>> {
+        None
+    }
+}
+impl TmplTargetArgs {
+    fn to_json(&self) -> crate::kernel::Json {
+        crate::kernel::Json::Null
+    }
+    fn from_json(v: &crate::kernel::Json) -> Result<Self, crate::kernel::Refusal> {
+        let _ = v;
+        Ok(TmplTargetArgs { tmpl_field: 0 })
+    }
 }
 
 // A real, minimal type satisfying `kernel::dispatch`'s own bounds
@@ -84,7 +113,7 @@ pub fn dispatch_tmpl(
 ) -> crate::kernel::DispatchResult<TmplRecord> {
 tmpl_invariant_check_placeholder()?;
     let tmpl_eval_fielded = tmpl_with_references_placeholder();
-
+tmpl_prelude_placeholder();
     crate::kernel::dispatch(
         repo,
         tmpl_hydrate_placeholder(),
@@ -114,6 +143,14 @@ tmpl_ensures_spec_placeholder(),
 fn tmpl_invariant_check_placeholder() -> Result<(), crate::kernel::Refusal> {
     Ok(())
 }
+// `tmpl_prelude_placeholder` — the line between the references binding
+// and the `dispatch` call. Every ordinary command substitutes it away
+// to nothing (so the shape keeps its one blank line there, unchanged);
+// a DELEGATING command (`delegates_to`, `commands.rb`'s own
+// `emit_delegation`) substitutes the rendered `delegate_prelude`
+// shape, below — bindings the closure and the payload both need
+// before `dispatch` is entered.
+fn tmpl_prelude_placeholder() {}
 // `tmpl_with_references_placeholder` — the real substitution is a
 // `crate::kernel::WithReferences` literal (`commands.rb`'s own
 // `with_references_binding`), the SAME cross-aggregate-dereference
@@ -137,6 +174,86 @@ fn tmpl_ensures_spec_placeholder() -> crate::kernel::EnsuresSpec {
 }
 fn tmpl_emit_placeholder() -> &'static str {
     ""
+}
+
+// A DELEGATING COMMAND — `delegates_to "Entity.Command", with: { … }`
+// (docs/implemented/guides/entities.md; `CommandInterpreter#step_
+// delegate_to_entity`, read directly). The door is an ordinary
+// aggregate command as far as `dispatch_fn` is concerned — its own
+// givens, its own `from:` guard, save, emit — and its ENTIRE mutation
+// is `kernel::apply_entity_command` run on the record inside the
+// closure: the target entity command's locate → givens → transition →
+// mutate → ensures, with `parent` read off the live record (see that
+// function's own header). Two shapes, rendered into two of
+// `dispatch_fn`'s own placeholders:
+//
+// `delegate_prelude` (into `tmpl_prelude_placeholder();`): the facts
+// the target sees are the door's own args plus the `with:` mapping
+// (`Json::with_aliases`); the target's args struct is read from them
+// the same way the routing layer reads an entity command's own; the
+// element is addressed by the entity's own `extract_id`/`extract_wants`
+// over the same facts — the identical NotFound wording a direct
+// dispatch renders.
+//
+// `delegate_apply` (into `tmpl_mutation_lines_placeholder(record);`):
+// the call itself. The inner `|record|` closure is the TARGET's own
+// mutation lines over the element and deliberately shadows the door's
+// `record` — an entity command's `sets` only ever reach the element.
+fn tmpl_aliases_placeholder() -> (&'static str, &'static str) {
+    ("", "")
+}
+
+fn tmpl_delegate_prelude_host(
+    args: TmplArgs,
+    command_deref: Vec<(&'static str, crate::kernel::DerefNode)>,
+    owner_deref: Vec<(&'static str, crate::kernel::DerefNode)>,
+) -> Result<(), crate::kernel::Refusal> {
+    // TMPL:delegate_prelude BEGIN
+    let delegate_facts = args.to_json().with_aliases(&[tmpl_aliases_placeholder()]);
+    let target_args = TmplTargetArgs::from_json(&delegate_facts)?;
+    let element_id = TmplElement::extract_id(&delegate_facts)?;
+    let element_wants = TmplElement::extract_wants(&delegate_facts);
+    let target_with_references = crate::kernel::WithReferences { command_deref: &command_deref, args: &target_args, owner_deref: &owner_deref };
+    // TMPL:delegate_prelude END
+    let _ = (element_id, element_wants, target_with_references);
+    Ok(())
+}
+
+fn tmpl_delegate_apply_host(
+    record: &mut TmplRecord,
+    id: &str,
+    element_id: String,
+    element_wants: String,
+    target_with_references: TmplArgs,
+) -> Result<(), crate::kernel::Refusal> {
+        // TMPL:delegate_apply BEGIN
+        crate::kernel::apply_entity_command(
+            record,
+            id,
+            |r: &TmplRecord| &r.tmpl_list_field,
+            |r: &mut TmplRecord| &mut r.tmpl_list_field,
+            |el: &TmplElement| el.identity() == element_id,
+            "TmplQualifiedCommandName",
+            "TmplAggregateName",
+            "TmplEntityName",
+            "TmplEntityIdentityReading",
+            &element_wants,
+            &target_with_references,
+            &[
+tmpl_given_spec_placeholder(),
+            ],
+            tmpl_transition_placeholder(),
+            |record| {
+tmpl_entity_mutation_lines_placeholder(record);
+                Ok(())
+            },
+            &[
+tmpl_ensures_spec_placeholder(),
+            ],
+            true,
+        )?;
+        // TMPL:delegate_apply END
+    Ok(())
 }
 
 // `entity_dispatch_fn` — `dispatch_fn`'s own sibling for an ENTITY

--- a/rust/src/generated/banking/account.rs
+++ b/rust/src/generated/banking/account.rs
@@ -1044,7 +1044,7 @@ pub fn dispatch_credit(
         &[
             crate::kernel::GivenSpec { description: "customer is active", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("customer.status")), right: Box::new(Expr::Str("active".to_string())) } },
         ],
-        None,
+        Some(crate::kernel::TransitionCheck { field: "status", from_states: &["open"] }),
         |record| {
         { let current = record.balance.clone().unwrap(); record.balance = Some(Money { cents: current.cents + (args.amount.cents), ..current }); }
         record.ledger.push(LedgerEntry { amount: Money { cents: args.amount.cents.clone(), currency: args.amount.currency.clone() }, narrative: args.narrative.clone(), direction: LedgerDirection::Credit, sequence: LedgerSequence { value: (record.ledger.len() as i64) + 1 }, state: "posted".to_string() });
@@ -1132,7 +1132,7 @@ pub fn dispatch_debit(
             crate::kernel::GivenSpec { description: "the balance covers it", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: true, equal: false, negated: true }, left: Box::new(Expr::Lookup("balance.cents")), right: Box::new(Expr::Lookup("amount.cents")) } },
             crate::kernel::GivenSpec { description: "the daily limit allows it", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: true, equal: false, negated: true }, left: Box::new(Expr::Lookup("daily_limit.cents")), right: Box::new(Expr::Lookup("amount.cents")) } },
         ],
-        None,
+        Some(crate::kernel::TransitionCheck { field: "status", from_states: &["open"] }),
         |record| {
         { let current = record.balance.clone().unwrap(); record.balance = Some(Money { cents: current.cents - (args.amount.cents), ..current }); }
         record.ledger.push(LedgerEntry { amount: Money { cents: args.amount.cents.clone(), currency: args.amount.currency.clone() }, narrative: args.narrative.clone(), direction: LedgerDirection::Debit, sequence: LedgerSequence { value: (record.ledger.len() as i64) + 1 }, state: "posted".to_string() });
@@ -1458,7 +1458,7 @@ pub fn dispatch_apply_fee(
             crate::kernel::GivenSpec { description: "customer is active", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("customer.status")), right: Box::new(Expr::Str("active".to_string())) } },
             crate::kernel::GivenSpec { description: "the balance covers a fee", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: true, equal: false, negated: true }, left: Box::new(Expr::Lookup("balance.cents")), right: Box::new(Expr::Lookup("amount.cents")) } },
         ],
-        None,
+        Some(crate::kernel::TransitionCheck { field: "status", from_states: &["open"] }),
         |record| {
         { let current = record.balance.clone().unwrap(); record.balance = Some(Money { cents: current.cents - (args.amount.cents), ..current }); }
         { let current = record.fees_cents.clone().unwrap(); record.fees_cents = Some(Money { cents: current.cents + (args.amount.cents), ..current }); }
@@ -1542,7 +1542,7 @@ pub fn dispatch_correct_fee(
             crate::kernel::GivenSpec { description: "customer is active", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("customer.status")), right: Box::new(Expr::Str("active".to_string())) } },
             crate::kernel::GivenSpec { description: "a correction cannot exceed collected fees", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: true, equal: false, negated: true }, left: Box::new(Expr::Lookup("fees_cents.cents")), right: Box::new(Expr::Lookup("amount.cents")) } },
         ],
-        None,
+        Some(crate::kernel::TransitionCheck { field: "status", from_states: &["open"] }),
         |record| {
         { let current = record.balance.clone().unwrap(); record.balance = Some(Money { cents: current.cents + (args.amount.cents), ..current }); }
         { let current = record.fees_cents.clone().unwrap(); record.fees_cents = Some(Money { cents: current.cents - (args.amount.cents), ..current }); }
@@ -1623,7 +1623,7 @@ pub fn dispatch_accrue_interest(
         &[
             crate::kernel::GivenSpec { description: "customer is active", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("customer.status")), right: Box::new(Expr::Str("active".to_string())) } },
         ],
-        None,
+        Some(crate::kernel::TransitionCheck { field: "status", from_states: &["open"] }),
         |record| {
         { let current = record.balance.clone().unwrap(); record.balance = Some(Money { cents: current.cents + (args.amount.cents), ..current }); }
         { let current = record.interest_cents.clone().unwrap(); record.interest_cents = Some(Money { cents: current.cents + (args.amount.cents), ..current }); }
@@ -1706,7 +1706,7 @@ pub fn dispatch_correct_interest(
             crate::kernel::GivenSpec { description: "a correction cannot exceed accrued interest", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: true, equal: false, negated: true }, left: Box::new(Expr::Lookup("interest_cents.cents")), right: Box::new(Expr::Lookup("amount.cents")) } },
             crate::kernel::GivenSpec { description: "the balance covers an interest correction", expr: Expr::Compare { op: crate::kernel::Comparison { less_than: true, equal: false, negated: true }, left: Box::new(Expr::Lookup("balance.cents")), right: Box::new(Expr::Lookup("amount.cents")) } },
         ],
-        None,
+        Some(crate::kernel::TransitionCheck { field: "status", from_states: &["open"] }),
         |record| {
         { let current = record.balance.clone().unwrap(); record.balance = Some(Money { cents: current.cents - (args.amount.cents), ..current }); }
         { let current = record.interest_cents.clone().unwrap(); record.interest_cents = Some(Money { cents: current.cents - (args.amount.cents), ..current }); }

--- a/rust/src/generated/roster/manifest.json
+++ b/rust/src/generated/roster/manifest.json
@@ -10,6 +10,12 @@
     "generated": true
   },
   {
+    "kind": "entity_command",
+    "id": "Roster::Roster.Member.Retire",
+    "generated": true,
+    "routed": true
+  },
+  {
     "kind": "command",
     "id": "Roster::Roster.Open",
     "generated": true,
@@ -30,6 +36,12 @@
   {
     "kind": "command",
     "id": "Roster::Roster.Assign",
+    "generated": true,
+    "routed": true
+  },
+  {
+    "kind": "command",
+    "id": "Roster::Roster.Retire",
     "generated": true,
     "routed": true
   },

--- a/rust/src/generated/roster/merged.rs
+++ b/rust/src/generated/roster/merged.rs
@@ -120,6 +120,29 @@ pub fn dispatch_by_name(
               let payload = crate::kernel::Json::overlay(facts_json, &args.to_json());
               crate::generated::roster::roster::dispatch_assign(&mut store.roster, &id, args, mutations, owner_deref, command_deref).map(|(_, events)| stamp_payload(events, &payload))
           }
+          "Roster::Roster.Retire" => {
+              let invocation = crate::kernel::CommandInvocation::from_json(args_json)?;
+              let route = invocation.route();
+              let facts_json = invocation.facts();
+              let id = match route { Some(route) => { route.require_depth(0)?; route.aggregate().to_string() }, None => crate::generated::roster::roster::Roster::extract_id(facts_json)?, };
+              let args = crate::generated::roster::roster::RetireArgs::from_json(facts_json)?;
+              let owner_deref = crate::kernel::owner_deref(&*store, REFERENCE_TABLE, "Roster::Roster", &id);
+              let command_deref = crate::kernel::command_deref(&*store, REFERENCE_TABLE, &[], &args);
+              let payload = crate::kernel::Json::overlay(facts_json, &args.to_json());
+              crate::generated::roster::roster::dispatch_retire(&mut store.roster, &id, args, mutations, owner_deref, command_deref).map(|(_, events)| stamp_payload(events, &payload))
+          }
+          "Roster::Roster.Member.Retire" => {
+              let invocation = crate::kernel::CommandInvocation::from_json(args_json)?;
+              let route = invocation.route();
+              let facts_json = invocation.facts();
+              let (parent_id, element_id, element_wants) = match route { Some(route) => { route.require_depth(1)?; let element_id = route.entities()[0].clone(); (route.aggregate().to_string(), element_id.clone(), element_id) }, None => { let parent_id = crate::generated::roster::roster::Roster::extract_id(facts_json)?; let element_id = crate::generated::roster::roster::Member::extract_id(facts_json)?; let element_wants = crate::generated::roster::roster::Member::extract_wants(facts_json); (parent_id, element_id, element_wants) }, };
+              let args = crate::generated::roster::roster::MemberRetireArgs::from_json(facts_json)?;
+              let owner_deref: Vec<(&'static str, crate::kernel::DerefNode)> = Vec::new();
+              let mut command_deref = crate::kernel::command_deref(&*store, REFERENCE_TABLE, &[], &args);
+              if let Some(parent_node) = crate::kernel::parent_deref(&*store, REFERENCE_TABLE, "Roster::Roster", &parent_id) { command_deref.push(("parent", parent_node)); }
+              let payload = crate::kernel::Json::overlay(facts_json, &args.to_json());
+              crate::generated::roster::roster::dispatch_entity_member_retire(&mut store.roster, &parent_id, &element_id, &element_wants, args, mutations, owner_deref, command_deref).map(|(_, events)| stamp_payload(events, &payload))
+          }
         other => Err(crate::kernel::Refusal::TypeMismatch(format!("unknown command {other:?}"))),
     }
 }
@@ -183,6 +206,8 @@ pub fn command_creates(verb: &str) -> bool {
         "Roster::Roster.AddSeat" => false,
         "Roster::Roster.Enlist" => false,
         "Roster::Roster.Assign" => false,
+        "Roster::Roster.Retire" => false,
+        "Roster::Roster.Member.Retire" => false,
         _ => false,
     }
 }

--- a/rust/src/generated/roster/registry.rs
+++ b/rust/src/generated/roster/registry.rs
@@ -120,6 +120,29 @@ pub fn dispatch_by_name(
               let payload = crate::kernel::Json::overlay(facts_json, &args.to_json());
               crate::generated::roster::roster::dispatch_assign(&mut store.roster, &id, args, mutations, owner_deref, command_deref).map(|(_, events)| stamp_payload(events, &payload))
           }
+          "Roster::Roster.Retire" => {
+              let invocation = crate::kernel::CommandInvocation::from_json(args_json)?;
+              let route = invocation.route();
+              let facts_json = invocation.facts();
+              let id = match route { Some(route) => { route.require_depth(0)?; route.aggregate().to_string() }, None => crate::generated::roster::roster::Roster::extract_id(facts_json)?, };
+              let args = crate::generated::roster::roster::RetireArgs::from_json(facts_json)?;
+              let owner_deref = crate::kernel::owner_deref(&*store, REFERENCE_TABLE, "Roster::Roster", &id);
+              let command_deref = crate::kernel::command_deref(&*store, REFERENCE_TABLE, &[], &args);
+              let payload = crate::kernel::Json::overlay(facts_json, &args.to_json());
+              crate::generated::roster::roster::dispatch_retire(&mut store.roster, &id, args, mutations, owner_deref, command_deref).map(|(_, events)| stamp_payload(events, &payload))
+          }
+          "Roster::Roster.Member.Retire" => {
+              let invocation = crate::kernel::CommandInvocation::from_json(args_json)?;
+              let route = invocation.route();
+              let facts_json = invocation.facts();
+              let (parent_id, element_id, element_wants) = match route { Some(route) => { route.require_depth(1)?; let element_id = route.entities()[0].clone(); (route.aggregate().to_string(), element_id.clone(), element_id) }, None => { let parent_id = crate::generated::roster::roster::Roster::extract_id(facts_json)?; let element_id = crate::generated::roster::roster::Member::extract_id(facts_json)?; let element_wants = crate::generated::roster::roster::Member::extract_wants(facts_json); (parent_id, element_id, element_wants) }, };
+              let args = crate::generated::roster::roster::MemberRetireArgs::from_json(facts_json)?;
+              let owner_deref: Vec<(&'static str, crate::kernel::DerefNode)> = Vec::new();
+              let mut command_deref = crate::kernel::command_deref(&*store, REFERENCE_TABLE, &[], &args);
+              if let Some(parent_node) = crate::kernel::parent_deref(&*store, REFERENCE_TABLE, "Roster::Roster", &parent_id) { command_deref.push(("parent", parent_node)); }
+              let payload = crate::kernel::Json::overlay(facts_json, &args.to_json());
+              crate::generated::roster::roster::dispatch_entity_member_retire(&mut store.roster, &parent_id, &element_id, &element_wants, args, mutations, owner_deref, command_deref).map(|(_, events)| stamp_payload(events, &payload))
+          }
         other => Err(crate::kernel::Refusal::TypeMismatch(format!("unknown command {other:?}"))),
     }
 }
@@ -183,6 +206,8 @@ pub fn command_creates(verb: &str) -> bool {
         "Roster::Roster.AddSeat" => false,
         "Roster::Roster.Enlist" => false,
         "Roster::Roster.Assign" => false,
+        "Roster::Roster.Retire" => false,
+        "Roster::Roster.Member.Retire" => false,
         _ => false,
     }
 }

--- a/rust/src/generated/roster/roster.rs
+++ b/rust/src/generated/roster/roster.rs
@@ -392,15 +392,17 @@ if !unknown.is_empty() {
 pub struct Member {
     pub id: MemberId,
     pub age: Age,
+    pub status: String,
 }
 
 impl crate::kernel::Fielded for Member {
     fn field(&self, name: &str) -> Option<crate::kernel::Field<'_>> {
         use crate::kernel::Field;
-        
+        use crate::kernel::Value;
         match name {
             "id" => Some(Field::Nested(&self.id)),
             "age" => Some(Field::Nested(&self.age)),
+            "status" => Some(Field::Value(Value::Str(self.status.clone()))),
             _ => None,
         }
     }
@@ -420,6 +422,7 @@ impl Member {
         crate::kernel::Json::Object(vec![
         ("id".to_string(), self.id.to_json()),
         ("age".to_string(), self.age.to_json()),
+        ("status".to_string(), crate::kernel::Json::Str(self.status.clone())),
         ])
     }
 }
@@ -429,6 +432,7 @@ impl Member {
         Ok(Self {
         id: MemberId::from_json(&v.require("id", "Member")?.coerce_single_field("value"))?,
         age: Age::from_json(&v.require("age", "Member")?.coerce_single_field("value"))?,
+        status: v.require("status", "Member")?.as_str().ok_or_else(|| crate::kernel::Refusal::TypeMismatch("Member.status: expected a string".to_string()))?.to_string(),
         })
     }
 }
@@ -462,6 +466,87 @@ impl Member {
     pub fn identity(&self) -> String {
         self.id.value.to_string()
     }
+}
+
+impl crate::kernel::Fielded for MemberRetireArgs {
+    fn field(&self, name: &str) -> Option<crate::kernel::Field<'_>> {
+        use crate::kernel::Field;
+        
+        match name {
+
+            _ => None,
+        }
+    }
+
+    fn items(&self, name: &str) -> Option<Vec<crate::kernel::Field<'_>>> {
+        #[allow(unused_imports)]
+        use crate::kernel::{Field, Value};
+        match name {
+
+            _ => None,
+        }
+    }
+}
+
+
+#[derive(Debug, Clone)]
+pub struct MemberRetireArgs {
+}
+
+impl MemberRetireArgs {
+    pub fn to_json(&self) -> crate::kernel::Json {
+        crate::kernel::Json::Object(vec![
+
+        ])
+    }
+}
+
+
+impl MemberRetireArgs {
+    pub fn from_json(v: &crate::kernel::Json) -> Result<Self, crate::kernel::Refusal> {
+        Ok(Self {
+
+        })
+    }
+}
+
+
+pub fn dispatch_entity_member_retire(
+    repo: &mut impl crate::kernel::Repository<Roster>, parent_id: &str, element_id: &str, element_wants: &str, args: MemberRetireArgs,
+    mutations: &mut Vec<crate::kernel::MutationRecord>, owner_deref: Vec<(&'static str, crate::kernel::DerefNode)>, command_deref: Vec<(&'static str, crate::kernel::DerefNode)>,
+) -> crate::kernel::DispatchResult<Roster> {
+
+    let with_references = crate::kernel::WithReferences { command_deref: &command_deref, args: &args, owner_deref: &owner_deref };
+
+    crate::kernel::dispatch_entity(
+        repo,
+        parent_id,
+        |r: &Roster| &r.crew,
+        |r: &mut Roster| &mut r.crew,
+        |el: &Member| el.identity() == element_id,
+        "Member.Retire",
+        "Roster::Roster",
+        "Roster",
+        "name.value",
+        "Member",
+        "id.value",
+        element_wants,
+        &with_references,
+        &[
+            crate::kernel::GivenSpec { description: "a front-row holder may not retire", expr: Expr::BlockPredicate { mode: crate::kernel::BlockMode::None, receiver: Box::new(Expr::Lookup("parent.assignments")), param: "a", predicate: Box::new(Expr::And(Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("a.member.value")), right: Box::new(Expr::Lookup("id.value")) }), Box::new(Expr::BlockPredicate { mode: crate::kernel::BlockMode::Any, receiver: Box::new(Expr::Lookup("parent.seats")), param: "s", predicate: Box::new(Expr::And(Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("s.number.value")), right: Box::new(Expr::Lookup("a.number.value")) }), Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("s.row.value")), right: Box::new(Expr::Str("front".to_string())) }))) }))) } },
+        ],
+        Some(crate::kernel::TransitionCheck { field: "status", from_states: &["active"] }),
+        |record| {
+        record.status = "retired".to_string();
+            Ok(())
+        },
+        &[
+            crate::kernel::EnsuresSpec { description: "someone still serves", expr: Expr::BlockPredicate { mode: crate::kernel::BlockMode::Any, receiver: Box::new(Expr::Lookup("parent.crew")), param: "m", predicate: Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("m.status")), right: Box::new(Expr::Str("active".to_string())) }) } },
+        ],
+        &["MemberRetired"],
+        args.to_json(),
+        mutations,
+    )
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -760,7 +845,7 @@ pub fn dispatch_enlist(
         ],
         None,
         |record| {
-        record.crew.push(Member { id: args.id.clone(), age: args.age.clone() });
+        record.crew.push(Member { id: args.id.clone(), age: args.age.clone(), status: "active".to_string() });
             Ok(())
         },
         &[
@@ -882,6 +967,114 @@ if !unknown.is_empty() {
         Ok(Self {
         member: MemberId::from_json(&v.require("member", "AssignArgs")?.coerce_single_field("value"))?,
         number: SeatNumber::from_json(&v.require("number", "AssignArgs")?.coerce_single_field("value"))?,
+        })
+    }
+}
+
+impl crate::kernel::Fielded for RetireArgs {
+    fn field(&self, name: &str) -> Option<crate::kernel::Field<'_>> {
+        use crate::kernel::Field;
+        
+        match name {
+            "id" => Some(Field::Nested(&self.id)),
+            _ => None,
+        }
+    }
+
+    fn items(&self, name: &str) -> Option<Vec<crate::kernel::Field<'_>>> {
+        #[allow(unused_imports)]
+        use crate::kernel::{Field, Value};
+        match name {
+
+            _ => None,
+        }
+    }
+}
+
+
+#[derive(Debug, Clone)]
+pub struct RetireArgs {
+    pub id: MemberId,
+}
+
+pub fn dispatch_retire(
+    repo: &mut impl crate::kernel::Repository<Roster>, id: &str, args: RetireArgs, mutations: &mut Vec<crate::kernel::MutationRecord>, owner_deref: Vec<(&'static str, crate::kernel::DerefNode)>, command_deref: Vec<(&'static str, crate::kernel::DerefNode)>,
+) -> crate::kernel::DispatchResult<Roster> {
+        args.id.check_invariants()?;
+    let with_references = crate::kernel::WithReferences { command_deref: &command_deref, args: &args, owner_deref: &owner_deref };
+    let delegate_facts = args.to_json().with_aliases(&[("id", "id")]);
+    let target_args = MemberRetireArgs::from_json(&delegate_facts)?;
+    let element_id = Member::extract_id(&delegate_facts)?;
+    let element_wants = Member::extract_wants(&delegate_facts);
+    let target_with_references = crate::kernel::WithReferences { command_deref: &command_deref, args: &target_args, owner_deref: &owner_deref };
+    crate::kernel::dispatch(
+        repo,
+        crate::kernel::Hydrate::Act { id: id.to_string() },
+        "Retire",
+        "Roster::Roster",
+        "Roster",
+        "name.value",
+        &with_references,
+        &[
+
+        ],
+        None,
+        |record| {
+                crate::kernel::apply_entity_command(
+                    record,
+                    id,
+                    |r: &Roster| &r.crew,
+                    |r: &mut Roster| &mut r.crew,
+                    |el: &Member| el.identity() == element_id,
+                    "Member.Retire",
+                    "Roster",
+                    "Member",
+                    "id.value",
+                    &element_wants,
+                    &target_with_references,
+                    &[
+                    crate::kernel::GivenSpec { description: "a front-row holder may not retire", expr: Expr::BlockPredicate { mode: crate::kernel::BlockMode::None, receiver: Box::new(Expr::Lookup("parent.assignments")), param: "a", predicate: Box::new(Expr::And(Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("a.member.value")), right: Box::new(Expr::Lookup("id.value")) }), Box::new(Expr::BlockPredicate { mode: crate::kernel::BlockMode::Any, receiver: Box::new(Expr::Lookup("parent.seats")), param: "s", predicate: Box::new(Expr::And(Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("s.number.value")), right: Box::new(Expr::Lookup("a.number.value")) }), Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("s.row.value")), right: Box::new(Expr::Str("front".to_string())) }))) }))) } },
+                    ],
+                    Some(crate::kernel::TransitionCheck { field: "status", from_states: &["active"] }),
+                    |record| {
+                record.status = "retired".to_string();
+                        Ok(())
+                    },
+                    &[
+                    crate::kernel::EnsuresSpec { description: "someone still serves", expr: Expr::BlockPredicate { mode: crate::kernel::BlockMode::Any, receiver: Box::new(Expr::Lookup("parent.crew")), param: "m", predicate: Box::new(Expr::Compare { op: crate::kernel::Comparison { less_than: false, equal: true, negated: false }, left: Box::new(Expr::Lookup("m.status")), right: Box::new(Expr::Str("active".to_string())) }) } },
+                    ],
+                    true,
+                )?;
+            Ok(())
+        },
+        &[
+
+        ],
+        &["MemberRetired"],
+        delegate_facts.clone(),
+        mutations,
+    )
+}
+
+impl RetireArgs {
+    pub fn to_json(&self) -> crate::kernel::Json {
+        crate::kernel::Json::Object(vec![
+        ("id".to_string(), self.id.to_json()),
+        ])
+    }
+}
+
+impl RetireArgs {
+    pub fn from_json(v: &crate::kernel::Json) -> Result<Self, crate::kernel::Refusal> {
+let unknown = v.unknown_keys(&["id", "roster", "name"]);
+if !unknown.is_empty() {
+    return Err(crate::kernel::Refusal::UnknownArgument(format!(
+        "Retire does not declare {} — it takes id",
+        unknown.join(", ")
+    )));
+}
+        Ok(Self {
+        id: MemberId::from_json(&v.require("id", "RetireArgs")?.coerce_single_field("value"))?,
         })
     }
 }

--- a/rust/src/kernel/dispatch.rs
+++ b/rust/src/kernel/dispatch.rs
@@ -17,7 +17,7 @@
 // `registry.rs` (`reactions.rb`'s `emit_reference_check`), the one place
 // with access to every OTHER aggregate's repo, not just this command's own.
 
-use super::expr::{interpret, EvalContext, Expr, Field, Fielded, Value, WithOld};
+use super::expr::{interpret, EvalContext, Expr, Field, Fielded, Value, WithOld, WithParent};
 use super::refusal_wording::RefusalSite;
 use super::{Event, Json, MutationRecord, Refusal, Repository, ToJson};
 
@@ -274,71 +274,49 @@ where
 /// collapsed to one string comparison because both sides already agree on
 /// the SAME dotted-path-join-by-":" convention `extract_id`/`identity()`
 /// (json_codec.rb) use everywhere else.
+/// THE ELEMENT HALF OF AN ENTITY COMMAND, on a parent record already in
+/// hand and nothing saved — `EntityInterpreter`'s locate → givens →
+/// transition → mutate → ensures, exactly the steps
+/// `CommandInterpreter#step_delegate_to_entity` runs INSIDE a
+/// delegating aggregate command (docs/implemented/guides/entities.md,
+/// `delegates_to`) and `dispatch_entity`, below, runs before its own
+/// save. One body, two callers, so a refusal reads identically whether
+/// the entity command was dispatched directly or through its door.
+///
+/// `parent_in_args`: `Admissibility#enforce_givens`/`#enforce_ensures`
+/// merge `parent:` — the OWNING record — into the args every entity
+/// given and ensures evaluates against. A direct entity dispatch gets
+/// that from the routing layer (`parent_deref`, a snapshot fetched
+/// before the command ran, pushed into `command_deref` as `"parent"`);
+/// a delegating door has no such layer, so with `parent_in_args` this
+/// reads the parent off the LIVE record instead — before the mutation
+/// for the givens, after it for the ensures, which is what Ruby's own
+/// in-place element mutation gives it: a chess king's "not left in
+/// check" ensures reads the board with the piece already moved.
 #[allow(clippy::too_many_arguments)]
-pub fn dispatch_entity<'a, T, E, R>(
-    repo: &mut R,
+pub fn apply_entity_command<'a, T, E>(
+    record: &mut T,
     parent_id: &str,
     get_list: impl Fn(&T) -> &Vec<E>,
     get_list_mut: impl FnOnce(&mut T) -> &mut Vec<E>,
     matches: impl Fn(&E) -> bool,
     command_name: &'static str,
-    aggregate_qualified_name: &'static str,
-    // `aggregate_name`/`parent_identity_reading` — the SAME split `dispatch`
-    // above makes, for the SAME reason: the parent lookup below raises the
-    // identical `record_missing` site `EntityInterpreter#parent`
-    // (entity_interpreter.rb) raises for its own failed `repository.find`,
-    // quoting the PARENT aggregate's bare name and its own declared
-    // identity reading, never the domain-qualified form.
     aggregate_name: &'static str,
-    parent_identity_reading: &'static str,
-    // `entity_name`/`entity_identity_reading` — `entity_element_missing`'s
-    // own `{entity}`/`{identity}`, codegen-time-static off the ENTITY's
-    // own `identified_by` (`element_of`, entity_interpreter.rb: `entity.
-    // hecks_name`/`Identity.reading(entity)`), distinct from the parent
-    // aggregate's above.
     entity_name: &'static str,
     entity_identity_reading: &'static str,
-    // `wants` — the one genuinely RUNTIME piece: `element_of`'s own
-    // `wants.map { |_h, path, want| Identity.scalar(path, want) }.join(",
-    // ")`, the caller-OFFERED scalar identity VALUES (not names), built by
-    // the generated registry call site alongside `element_id` and handed
-    // in already-joined — see `rust/project/registry.rb`'s entity-command
-    // arm and `json_codec.rb`'s `emit_extract_wants` for how.
     wants: &str,
     args: &'a dyn Fielded,
     givens: &[GivenSpec],
     transition: Option<TransitionCheck>,
     apply_mutations: impl FnOnce(&mut E) -> Result<(), Refusal> + 'a,
     ensures: &[EnsuresSpec],
-    emits: &[&'static str],
-    payload: Json,
-    mutations: &mut Vec<MutationRecord>,
-) -> Result<(T, Vec<Event>), Refusal>
+    parent_in_args: bool,
+) -> Result<(), Refusal>
 where
-    T: Fielded + Clone + ToJson,
+    T: Fielded + Clone,
     E: Fielded + Clone,
-    R: Repository<T>,
 {
-    // `NotFound`/`record_missing` — the parent half of `EntityInterpreter
-    // #parent`, read directly: the SAME site/wording `dispatch`'s own
-    // `Hydrate::Act` arm raises above, because Ruby raises it from the
-    // identical `RefusalWording.render("NotFound", "record_missing", ...)`
-    // call, just against the entity's OWNING aggregate instead of the
-    // aggregate acting on itself.
-    let mut record = repo.find(parent_id).ok_or_else(|| {
-        Refusal::NotFound(RefusalSite::NotFoundRecordMissing.render(&[
-            ("aggregate", aggregate_name),
-            ("identity", parent_identity_reading),
-            ("offered", &format!("{parent_id:?}")),
-        ]))
-    })?;
-
-    // `NotFound`/`entity_element_missing` — `element_of`'s own final guard
-    // (entity_interpreter.rb), read directly: `parent_id` reuses the
-    // ALREADY-quoted `{parent_id:?}` form Ruby's own `instance.id.inspect`
-    // produces (both a plain `.inspect` on a String), and `wants` arrives
-    // pre-joined by the caller exactly the way `identity`/`aggregate` do.
-    let position = get_list(&record).iter().position(|el| matches(el)).ok_or_else(|| {
+    let position = get_list(record).iter().position(|el| matches(el)).ok_or_else(|| {
         Refusal::NotFound(RefusalSite::NotFoundEntityElementMissing.render(&[
             ("entity", entity_name),
             ("identity", entity_identity_reading),
@@ -347,21 +325,17 @@ where
             ("parent_id", &format!("{parent_id:?}")),
         ]))
     })?;
+    let mut element = get_list(record)[position].clone();
 
-    // COPY-ON-WRITE, same guarantee `element_of`'s own comment names: never
-    // alias the stored element until every check has passed. `element` is
-    // what `given`/`ensures` see as `instance` (Ruby's `ctx.view`/`ctx.
-    // element`) — the WHOLE parent is never exposed to entity-command
-    // expression evaluation, only its one addressed element.
-    let mut element = get_list(&record)[position].clone();
-
-    for given in givens {
-        let ctx = EvalContext { args, instance: &element };
-        if !interpret(&given.expr, &ctx)?.truthy() {
-            // `CommandRules::Admissibility#enforce_givens`, read directly:
-            // `"#{command.hecks_name} refused — #{given.description}"` —
-            // the prefix this field-only message used to be missing.
-            return Err(Refusal::GivenNotMet(format!("{command_name} refused — {}", given.description)));
+    {
+        let parent_before = record.clone();
+        let with_parent = WithParent { args, parent: &parent_before };
+        let given_args: &dyn Fielded = if parent_in_args { &with_parent } else { args };
+        for given in givens {
+            let ctx = EvalContext { args: given_args, instance: &element };
+            if !interpret(&given.expr, &ctx)?.truthy() {
+                return Err(Refusal::GivenNotMet(format!("{command_name} refused — {}", given.description)));
+            }
         }
     }
 
@@ -369,11 +343,6 @@ where
         match element.field(check.field) {
             Some(Field::Value(Value::Str(current))) => {
                 if !check.from_states.contains(&current.as_str()) {
-                    // Same site/wording as `dispatch`'s own transition
-                    // check above — the entity's OWN lifecycle field, per
-                    // `admissible_transition(declaring, ...)` taking either
-                    // an aggregate OR an entity as `declaring` (read
-                    // directly, command_rules/admissibility.rb).
                     let allowed = check.from_states.iter().map(|s| format!("{s:?}")).collect::<Vec<_>>().join(" or ");
                     return Err(Refusal::LifecycleRefused(RefusalSite::LifecycleRefusedTransitionBlocked.render(&[
                         ("command", command_name),
@@ -393,23 +362,82 @@ where
     }
 
     let old_snapshot = if ensures.is_empty() { None } else { Some(element.clone()) };
-
     apply_mutations(&mut element)?;
+    get_list_mut(record)[position] = element;
 
     if let Some(old) = &old_snapshot {
-        let with_old = WithOld { args, old };
+        let parent_after = record.clone();
+        let with_parent = WithParent { args, parent: &parent_after };
+        let ensures_args: &dyn Fielded = if parent_in_args { &with_parent } else { args };
+        let with_old = WithOld { args: ensures_args, old };
+        let settled = &get_list(record)[position];
         for rule in ensures {
-            let ctx = EvalContext { args: &with_old, instance: &element };
+            let ctx = EvalContext { args: &with_old, instance: settled };
             if !interpret(&rule.expr, &ctx)?.truthy() {
-                // Same prefix, same source: `CommandRules::Admissibility
-                // #enforce_ensures` — `"#{command.hecks_name} refused —
-                // #{rule.description}"`.
                 return Err(Refusal::EnsuresNotMet(format!("{command_name} refused — {}", rule.description)));
             }
         }
     }
+    Ok(())
+}
 
-    get_list_mut(&mut record)[position] = element;
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_entity<'a, T, E, R>(
+    repo: &mut R,
+    parent_id: &str,
+    get_list: impl Fn(&T) -> &Vec<E>,
+    get_list_mut: impl FnOnce(&mut T) -> &mut Vec<E>,
+    matches: impl Fn(&E) -> bool,
+    command_name: &'static str,
+    aggregate_qualified_name: &'static str,
+    aggregate_name: &'static str,
+    parent_identity_reading: &'static str,
+    entity_name: &'static str,
+    entity_identity_reading: &'static str,
+    wants: &str,
+    args: &'a dyn Fielded,
+    givens: &[GivenSpec],
+    transition: Option<TransitionCheck>,
+    apply_mutations: impl FnOnce(&mut E) -> Result<(), Refusal> + 'a,
+    ensures: &[EnsuresSpec],
+    emits: &[&'static str],
+    payload: Json,
+    mutations: &mut Vec<MutationRecord>,
+) -> Result<(T, Vec<Event>), Refusal>
+where
+    T: Fielded + Clone + ToJson,
+    E: Fielded + Clone,
+    R: Repository<T>,
+{
+    // Same `record_missing` site `EntityInterpreter#parent` raises —
+    // see `dispatch` above for the aggregate-level twin.
+    let mut record = repo.find(parent_id).ok_or_else(|| {
+        Refusal::NotFound(RefusalSite::NotFoundRecordMissing.render(&[
+            ("aggregate", aggregate_name),
+            ("identity", parent_identity_reading),
+            ("offered", &format!("{parent_id:?}")),
+        ]))
+    })?;
+
+    apply_entity_command(
+        &mut record,
+        parent_id,
+        get_list,
+        get_list_mut,
+        matches,
+        command_name,
+        aggregate_name,
+        entity_name,
+        entity_identity_reading,
+        wants,
+        args,
+        givens,
+        transition,
+        apply_mutations,
+        ensures,
+        false,
+    )?;
+
     repo.save(parent_id, record.clone());
     mutations.push(MutationRecord {
         aggregate: aggregate_qualified_name.to_string(),
@@ -417,11 +445,6 @@ where
         operation: "save",
         state: record.to_json(),
     });
-
-    // SAVE AND EMIT BOTH OPERATE ON THE PARENT — docs/implemented/guides/entities.md:
-    // "announces onto the SAME event log the parent's own commands write
-    // to, because there is only ever one identity in play here, the
-    // parent's." The element's own identity never appears on the Event.
     let events = emits
         .iter()
         .map(|name| Event {
@@ -432,6 +455,5 @@ where
             correlation: None,
         })
         .collect();
-
     Ok((record, events))
 }

--- a/rust/src/kernel/expr.rs
+++ b/rust/src/kernel/expr.rs
@@ -185,6 +185,41 @@ impl<'a> Fielded for WithOld<'a> {
         }
         self.args.field(name)
     }
+
+    fn items(&self, name: &str) -> Option<Vec<Field<'_>>> {
+        if name == "old" {
+            return None;
+        }
+        self.args.items(name)
+    }
+}
+
+/// `attrs.merge(parent: parent.state …)` — `Admissibility#enforce_givens`
+/// and `#enforce_ensures`, read directly: an ENTITY command's own
+/// predicates read the owning record under one name, `parent`, on the
+/// args side. Built by `dispatch::apply_entity_command` for a
+/// delegating door (see its own header for why the routing layer's
+/// `parent_deref` snapshot is not enough there); merged AFTER `old`
+/// exactly as Ruby's own `merge` order gives `old` precedence.
+pub struct WithParent<'a> {
+    pub args: &'a dyn Fielded,
+    pub parent: &'a dyn Fielded,
+}
+
+impl<'a> Fielded for WithParent<'a> {
+    fn field(&self, name: &str) -> Option<Field<'_>> {
+        if name == "parent" {
+            return Some(Field::Nested(self.parent));
+        }
+        self.args.field(name)
+    }
+
+    fn items(&self, name: &str) -> Option<Vec<Field<'_>>> {
+        if name == "parent" {
+            return None;
+        }
+        self.args.items(name)
+    }
 }
 
 // `Comparison` used to be defined here; it now lives in

--- a/rust/src/kernel/json.rs
+++ b/rust/src/kernel/json.rs
@@ -212,6 +212,30 @@ impl Json {
         Json::Object(merged)
     }
 
+    /// `ctx.args.merge(delegation.source.to_h { |target_key, source_key|
+    /// [target_key, ctx.args[source_key]] })` —
+    /// `CommandInterpreter#step_delegate_to_entity`, read directly: the
+    /// facts a delegating door hands its entity command are the door's
+    /// OWN args plus, under each target name the `with:` mapping
+    /// declares, the door arg that mapping names. Same-named pairs are
+    /// harmless re-assignments; a pair whose source the door never
+    /// declared adds nothing, exactly as Ruby's `args[source_key]` is
+    /// nil there. Non-`Object` receivers pass through unchanged.
+    pub fn with_aliases(&self, pairs: &[(&str, &str)]) -> Json {
+        let Json::Object(fields) = self else {
+            return self.clone();
+        };
+        let mut merged = fields.clone();
+        for (target_key, source_key) in pairs {
+            let Some(value) = fields.iter().find(|(k, _)| k == source_key).map(|(_, v)| v.clone()) else { continue };
+            match merged.iter_mut().find(|(k, _)| k == target_key) {
+                Some(entry) => entry.1 = value,
+                None => merged.push((target_key.to_string(), value)),
+            }
+        }
+        Json::Object(merged)
+    }
+
     /// Stringifies a scalar leaf for identity-component joining —
     /// `extract_id`'s job (rust/project/json_codec.rb), the same "whatever
     /// it resolved to, make an id component out of it" coercion

--- a/rust/src/kernel/mod.rs
+++ b/rust/src/kernel/mod.rs
@@ -58,8 +58,8 @@ pub mod reference_lookup;
 pub mod repository;
 pub mod routing;
 
-pub use dispatch::{dispatch, dispatch_entity, EnsuresSpec, GivenSpec, Hydrate, TransitionCheck};
-pub use expr::{interpret, BlockMode, Bound, Comparison, EvalContext, Expr, Field, Fielded, NoFields, Value};
+pub use dispatch::{apply_entity_command, dispatch, dispatch_entity, EnsuresSpec, GivenSpec, Hydrate, TransitionCheck};
+pub use expr::{interpret, BlockMode, Bound, Comparison, EvalContext, Expr, Field, Fielded, NoFields, Value, WithParent};
 pub use json::Json;
 pub use named_query::{QueryCondition, QueryConditionValue, QueryDef};
 pub use orchestrate::{

--- a/rust/src/kernel/reference_lookup.rs
+++ b/rust/src/kernel/reference_lookup.rs
@@ -128,6 +128,9 @@ impl Fielded for DerefNode {
     fn as_scalar(&self) -> Option<Value> {
         Some(Value::Str(self.id.clone()))
     }
+    fn items(&self, name: &str) -> Option<Vec<Field<'_>>> {
+        self.base.items(name)
+    }
 }
 
 /// `CommandRules::References#dereference`'s own recursive body, read
@@ -243,5 +246,8 @@ impl<'a> Fielded for WithReferences<'a> {
             return Some(Field::Nested(node));
         }
         None
+    }
+    fn items(&self, name: &str) -> Option<Vec<Field<'_>>> {
+        self.args.items(name)
     }
 }

--- a/spec/corpus/roster.json
+++ b/spec/corpus/roster.json
@@ -1,9 +1,9 @@
 {
   "name": "roster-parity",
-  "note": "One roster through every command once \u2014 open, two seats, two members, one assignment \u2014 every given a block predicate, all of them accepted.",
+  "note": "One roster through every command once \u2014 open, two seats, two members, one assignment, one retirement through the delegating door \u2014 every given a block predicate, all of them accepted.",
   "domain": "examples/roster",
   "expectations": {
-    "events": 6
+    "events": 7
   },
   "steps": [
     {
@@ -81,6 +81,17 @@
         },
         "number": {
           "value": 1
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "id": {
+          "value": "bob"
         }
       }
     }

--- a/spec/corpus/rust_conformance/roster.json
+++ b/spec/corpus/rust_conformance/roster.json
@@ -1,6 +1,6 @@
 {
   "domain": "examples/roster",
-  "note": "spec/rust_conformance_spec.rb's own fixture for the enumeration operators (rust/src/kernel/expression_operators/enumeration.rs): every given in examples/roster is a block predicate \u2014 .none?/.any? over a value-object list and over an entity list, a block nested in a block reading the outer parameter, .find { } projected through a path, .all? as an implication \u2014 and this script drives each one to BOTH verdicts, so the Rust kernel's refusals, wording included, are held to Ruby's dispatch for dispatch.",
+  "note": "spec/rust_conformance_spec.rb's own fixture for the enumeration operators (rust/src/kernel/expression_operators/enumeration.rs): every given in examples/roster is a block predicate \u2014 .none?/.any? over a value-object list and over an entity list, a block nested in a block reading the outer parameter, .find { } projected through a path, .all? as an implication \u2014 and this script drives each one to BOTH verdicts, so the Rust kernel's refusals, wording included, are held to Ruby's dispatch for dispatch. The Retire steps drive `delegates_to` (Roster.Retire \u2192 Member.Retire): the entity's own given and ensures both read `parent` \u2014 the given before the element changes, the ensures after \u2014 so crew-2's lone member retiring is refused by the ensures only if the parent the ensures sees already carries the retired element.",
   "steps": [
     {
       "verb": "Roster::Roster.Open",
@@ -273,6 +273,108 @@
         },
         "age": {
           "value": 50
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "id": {
+          "value": "ada"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "id": {
+          "value": "bob"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "id": {
+          "value": "bob"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "id": {
+          "value": "nobody"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "id": {
+          "value": "dan"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Open",
+      "args": {
+        "name": {
+          "value": "crew-2"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.AddSeat",
+      "args": {
+        "name": {
+          "value": "crew-2"
+        },
+        "number": {
+          "value": 1
+        },
+        "row": {
+          "value": "back"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Enlist",
+      "args": {
+        "name": {
+          "value": "crew-2"
+        },
+        "id": {
+          "value": "zoe"
+        },
+        "age": {
+          "value": 30
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-2"
+        },
+        "id": {
+          "value": "zoe"
         }
       }
     }

--- a/spec/word_coverage_spec.rb
+++ b/spec/word_coverage_spec.rb
@@ -145,18 +145,6 @@ RSpec.describe "every live DSL word, used somewhere real" do
   # when written), not an assumption; delete an entry once the corpus
   # grows to cover it and this spec will say so on its own.
   EXEMPT = {
-    "delegates_to (Command)"               =>
-                                              "an external consumer outside this repo — `hecks_ai_training`, a downstream " \
-                                              "project building `domain/chess` — is the real motivating use: a chess move's " \
-                                              "own legality needs a synchronous, single-dispatch handoff from an aggregate-" \
-                                              "level command into one nested entity command, which neither `trigger` nor a " \
-                                              "saga's own `dispatches` can give (both commit the triggering command first " \
-                                              "and rescue the target's own refusal rather than raising it back — " \
-                                              "CommandBuilder#delegates_to_impl's own comment has the full trail). No " \
-                                              "bundled example here (banking/pizzas/compliance) has a real need for it yet; " \
-                                              "`spec/dsl_spec.rb`'s own delegates_to examples and " \
-                                              "`spec/runtime/delegates_to_spec.rb`'s own dedicated fixture and dispatch-" \
-                                              "level specs are this word's real, running coverage in the meantime.",
     "cursor (Query)"                       =>
                                               "refused unconditionally at build (QueryBuilder#seal_cursor) — no interpreter " \
                                               "implements cursor pagination, so any real declaration would refuse the bluebook " \


### PR DESCRIPTION
The one construct every chess door is made of — `delegates_to
"Knight.Move", with: { … }`, the synchronous, single-dispatch handoff
from an aggregate command into one nested entity command — was the
generator's largest remaining refusal for that domain ("sets op(s)
delegate not generated yet", every door). Generated now, in both
generators, held byte-exact, and proven through the native binary.

The kernel gains `apply_entity_command`: the element half of an entity
command — locate, givens, transition, mutate, ensures — on a parent
record already in hand and nothing saved. `dispatch_entity` is now
that plus its own find and save, so a refusal reads identically
whether the entity command was dispatched directly or through a door.
A delegating door is otherwise an ordinary `dispatch`: its own givens,
its own `from:` guard, save, emit — and its ENTIRE mutation is
`apply_entity_command` on the record inside the closure, exactly where
`CommandInterpreter#step_delegate_to_entity` sits in Ruby's own order.
The facts the target sees are the door's args plus the `with:` mapping
(`Json::with_aliases`, the port of `ctx.args.merge(delegation.source…)`);
the element is addressed by the entity's own `extract_id`/
`extract_wants` over those facts, the identical NotFound wording a
direct dispatch renders; the door emits the TARGET's events with those
facts as payload, as `step_emit` answers `ctx.delegated_events`.

`parent`, read right. Ruby merges `parent:` — the owning record — into
the args every entity given and ensures evaluates against, and because
the element is mutated in place, the ensures see the parent WITH the
element already changed: a chess king's "not left in check" reads the
board after the move. The routing layer's `parent_deref` (a snapshot
fetched before the command) cannot say that, so the delegate path
binds `parent` off the live record itself — `WithParent`, before the
mutation for the givens, after it for the ensures. The roster fixture
pins the distinction: a lone member's Retire is refused by "someone
still serves" only if the parent the ensures sees already carries the
retired element.

Found on the way, fixed in both generators: a command's `from:` guard
WITHOUT a transition (Ruby's `enforce_lifecycle_guard`; every chess
door's `from: "in_play"`, four of banking's own `from: "open"`
commands) was dropped — `lifecycle_transition_for` only answered for
transition rows. It now answers a to-state-less TransitionCheck and
every caller sets the state only when there is one.

Exemplar shapes `delegate_prelude`/`delegate_apply` carry the
generated text; `dispatch_fn` gains one placeholder line, rendered
away to nothing for every ordinary command (its output is unchanged
byte for byte). examples/roster gains `Member.Retire` (lifecycle,
a given and an ensures that both read `parent`) and the door
`Roster.Retire` that delegates to it; the rust_conformance fixture
drives the door to every verdict — the given, the lifecycle, the
missing element's wording, the ensures — equal to Ruby's. The word-
coverage exemption `delegates_to` carried ("no bundled example has a
real need for it yet") is retired: the corpus declares it now.

Chess at this commit: eleven doors generate through the delegate path;
the rest stop on the next named gap, literal-to-closed-set bridging
(`sets :moved, to: "moved"`), with Promote's optional id and the
draw_offer rewrap behind it. Suite 1804/0, cargo test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc36TdgHxuFhxs5eAjcGXr