### PR TITLE
A scalar literal bridges into a single-field value object; a literal spelling its field's name is a value, not the sets shorthand

### DIFF
--- a/examples/roster/bluebook/roster.bluebook
+++ b/examples/roster/bluebook/roster.bluebook
@@ -18,6 +18,8 @@ Hecks.bluebook "Roster" do
     description "One roster: its seats, its crew, and who sits where."
 
     attribute :name,        RosterName
+    attribute :motto,       Motto
+    attribute :mood,        Mood
     attribute :seats,       list_of(Seat)
     attribute :crew,        list_of(Member)
     attribute :assignments, list_of(Assignment)
@@ -25,6 +27,21 @@ Hecks.bluebook "Roster" do
     identified_by :name
 
     value_object("RosterName") { attribute :value, String }
+    # SCALAR LITERALS INTO SINGLE-FIELD VALUE OBJECTS — `sets :motto, to:
+    # "all hands"` (a plain one-field VO), `sets :mood, to: "open"` and
+    # `to: "busy"` (a closed set), and Enlist's `rank: "hand"` appended
+    # into an entity's own closed-set field: the runtime's own rewrap of
+    # a bare literal into the sole field, which every projection has to
+    # bridge the same way (a chess rook's `sets :moved, to: "moved"`).
+    value_object("Motto") { attribute :value, String }
+
+    value_object "Mood" do
+      attribute :value, String, one_of: ["open", "busy"]
+    end
+
+    value_object "Rank" do
+      attribute :value, String, one_of: ["hand", "officer"]
+    end
     value_object("MemberId")   { attribute :value, String }
     value_object("SeatNumber") { attribute :value, Integer }
     value_object("Age")        { attribute :value, Integer }
@@ -46,8 +63,9 @@ Hecks.bluebook "Roster" do
     entity "Member" do
       description "One enlisted member — an entity, so the crew list's elements are entity records, not value objects."
 
-      attribute :id,  MemberId
-      attribute :age, Age
+      attribute :id,   MemberId
+      attribute :age,  Age
+      attribute :rank, Rank
 
       identified_by :id
 
@@ -79,6 +97,9 @@ Hecks.bluebook "Roster" do
 
       attribute :name, RosterName
 
+      sets :motto, to: "all hands"
+      sets :mood,  to: "open"
+
       emits "RosterOpened"
     end
 
@@ -108,7 +129,7 @@ Hecks.bluebook "Roster" do
       # parameter — "some seat has no assignment naming its number".
       given("an open seat remains") { seats.any? { |s| assignments.none? { |a| a.number.value == s.number.value } } }
 
-      sets :crew, append: { id: :id, age: :age }
+      sets :crew, append: { id: :id, age: :age, rank: "hand" }
 
       emits "MemberEnlisted"
     end
@@ -132,6 +153,7 @@ Hecks.bluebook "Roster" do
       end
 
       sets :assignments, append: { member: :member, number: :number }
+      sets :mood, to: "busy"
 
       emits "SeatAssigned"
     end

--- a/lib/hecks/bluebook/dsl/command_builder.rb
+++ b/lib/hecks/bluebook/dsl/command_builder.rb
@@ -481,7 +481,16 @@ module Hecks
         end
 
         def resolve_bare_set!(mutation)
-          return unless mutation.source.to_s == mutation.target.to_s
+          # A SYMBOL naming its own target — never a literal that merely
+          # spells the same word. `sets :moved, to: "moved"` (a chess rook
+          # recording that it has moved, into a closed set whose member is
+          # literally "moved") used to read as the shorthand and import
+          # the owner's `moved` attribute onto the command — a phantom
+          # argument nothing ever passes, harmless at runtime only
+          # because the owner's default filled it, and a real, silent
+          # divergence for every projection that reads the command's
+          # declared arguments.
+          return unless mutation.source.is_a?(Symbol) && mutation.source.to_s == mutation.target.to_s
           return if attributes.any? { |attr| attr.name == mutation.target }
 
           owner_attr = @owner_attributes.find { |attr| attr.name == mutation.target }

--- a/rust/codegen/src/bridging.rs
+++ b/rust/codegen/src/bridging.rs
@@ -142,13 +142,41 @@ pub fn value_rhs(source_expr: &str, source_type: &str, target_type: &str, value_
 
 pub fn literal_set_bridgeable(value: &Literal, target_type: Option<&str>, value_objects_by_name: &HashMap<String, &Json>) -> bool {
     match value {
-        Literal::Str(_) | Literal::Int(_) | Literal::Float(_) | Literal::Bool(_) => true,
         Literal::Hash(_) => match target_type {
             Some(target_type) => literal_hash_bridgeable(value, target_type, value_objects_by_name),
             None => false,
         },
+        Literal::Str(_) | Literal::Int(_) | Literal::Float(_) | Literal::Bool(_) => {
+            let Some(target_type) = target_type else { return true };
+            if !value_objects_by_name.contains_key(target_type) {
+                return true;
+            }
+            // A SCALAR literal into a SINGLE-FIELD value object — see
+            // bridging.rb's own `literal_set_bridgeable?`: the literal is
+            // the sole field's value and bridges as the hash it stands for.
+            match crate::json_codec::sole_field_of(target_type, value_objects_by_name) {
+                Some(sole) => literal_hash_bridgeable(&Literal::Hash(vec![(sole, value.clone())]), target_type, value_objects_by_name),
+                None => false,
+            }
+        }
         _ => false,
     }
+}
+
+/// Port of bridging.rb's `literal_rhs_for` — the rendered right-hand
+/// side of ANY literal into a target type.
+pub fn literal_rhs_for(value: &Literal, target_type: Option<&str>, value_objects_by_name: &HashMap<String, &Json>) -> String {
+    if let Literal::Hash(_) = value {
+        return literal_hash_rhs(value, target_type.unwrap_or(""), value_objects_by_name);
+    }
+    if let Some(target_type) = target_type {
+        if value_objects_by_name.contains_key(target_type) {
+            if let Some(sole) = crate::json_codec::sole_field_of(target_type, value_objects_by_name) {
+                return literal_hash_rhs(&Literal::Hash(vec![(sole, value.clone())]), target_type, value_objects_by_name);
+            }
+        }
+    }
+    crate::literal::literal_rhs(value)
 }
 
 /// A literal Hash's own bridgeability into a target type — either an

--- a/rust/codegen/src/mutations.rs
+++ b/rust/codegen/src/mutations.rs
@@ -77,10 +77,8 @@ pub fn append_field_source(source: &str) -> Literal {
 }
 
 pub fn literal_problem(mutation: &Json, field_name: &str, lit: &Literal, field_attr: &Json, value_objects_by_name: &HashMap<String, &Json>) -> Option<String> {
-    if let Literal::Hash(_) = lit {
-        if crate::bridging::literal_hash_bridgeable(lit, crate::attr::type_name(field_attr), value_objects_by_name) {
-            return None;
-        }
+    if crate::bridging::literal_set_bridgeable(lit, Some(crate::attr::type_name(field_attr)), value_objects_by_name) {
+        return None;
     }
     let target = mutation.get("target").map(Json::to_s).unwrap_or_default();
     Some(format!("{target}.{field_name}: literal doesn't bridge to {}", crate::attr::type_name(field_attr)))
@@ -207,10 +205,7 @@ pub fn lifecycle_transition_for(command: &Json, aggregate: &Json) -> Option<Tran
 pub fn mutation_set_rhs(source: &Json, target_type: &str, command: &Json, value_objects_by_name: &HashMap<String, &Json>) -> String {
     if source.get("kind").map(Json::to_s).unwrap_or_default() == "literal" {
         let value = source.get("value").unwrap_or(&Json::Null);
-        if let Json::Object(_) = value {
-            return crate::bridging::literal_hash_rhs(&Literal::from_json(value), target_type, value_objects_by_name);
-        }
-        return naming::literal_rhs(value);
+        return crate::bridging::literal_rhs_for(&Literal::from_json(value), Some(target_type), value_objects_by_name);
     }
 
     let source_name = source.get("name").map(Json::to_s).unwrap_or_default();
@@ -294,7 +289,7 @@ pub fn build_identity_expr(components: &[IdentityComponent]) -> String {
 pub fn append_field_rhs(source: &str, field_attr: &Json, command: &Json, value_objects_by_name: &HashMap<String, &Json>) -> String {
     let parsed = append_field_source(source);
     let Literal::Symbol(arg_name) = &parsed else {
-        return crate::bridging::literal_hash_rhs(&parsed, crate::attr::type_name(field_attr), value_objects_by_name);
+        return crate::bridging::literal_rhs_for(&parsed, Some(crate::attr::type_name(field_attr)), value_objects_by_name);
     };
 
     let cmd_attrs = command.get("attributes").map(Json::each).unwrap_or(&[]);

--- a/rust/project/bridging.rb
+++ b/rust/project/bridging.rb
@@ -135,10 +135,33 @@ module RustProjection
     end
 
     def literal_set_bridgeable?(value, target_type, value_objects_by_name)
-      return true if value.is_a?(String) || value.is_a?(Numeric) || value == true || value == false
-      return false unless value.is_a?(Hash) && target_type
+      return literal_hash_bridgeable?(value, target_type, value_objects_by_name) if value.is_a?(Hash) && target_type
+      return false if value.is_a?(Hash)
+      return false unless value.is_a?(String) || value.is_a?(Numeric) || value == true || value == false
+      return true unless target_type && value_objects_by_name[target_type]
 
-      literal_hash_bridgeable?(value, target_type, value_objects_by_name)
+      # A SCALAR literal into a SINGLE-FIELD value object — `Value.
+      # for_attribute`'s own rewrap, the coercion every `sets :x, to:
+      # "literal"` onto a closed set (a chess rook's `moved: "moved"`)
+      # or a plain one-field VO relies on at runtime: the literal is the
+      # sole field's value, and bridges exactly as the hash it stands for.
+      sole = sole_field_of(target_type, value_objects_by_name)
+      return false unless sole
+
+      literal_hash_bridgeable?({ sole => value }, target_type, value_objects_by_name)
+    end
+
+    # The rendered right-hand side of ANY literal into a target type —
+    # a Hash through `literal_hash_rhs`, a scalar into a single-field
+    # value object through the same after the rewrap above, a scalar
+    # into a scalar as itself.
+    def literal_rhs_for(value, target_type, value_objects_by_name)
+      return literal_hash_rhs(value, target_type, value_objects_by_name) if value.is_a?(Hash)
+
+      sole = target_type && value_objects_by_name[target_type] && sole_field_of(target_type, value_objects_by_name)
+      return literal_hash_rhs({ sole => value }, target_type, value_objects_by_name) if sole
+
+      literal_rhs(value)
     end
 
     # A literal Hash's own bridgeability into a target type — either an

--- a/rust/project/mutations.rb
+++ b/rust/project/mutations.rb
@@ -229,7 +229,7 @@ module RustProjection
     def append_field_source(source) = Hecks::Bluebook::Assembly::Marks.read(source)
 
     def literal_problem(mutation, field_name, literal, field_attr, value_objects_by_name)
-      return nil if literal.is_a?(Hash) && literal_hash_bridgeable?(literal, field_attr[:type], value_objects_by_name)
+      return nil if literal_set_bridgeable?(literal, field_attr[:type], value_objects_by_name)
 
       "#{mutation[:target]}.#{field_name}: literal doesn't bridge to #{field_attr[:type]}"
     end
@@ -288,10 +288,7 @@ module RustProjection
     # `bridgeable_value_types?`/`value_rhs`'s shared job.
     def mutation_set_rhs(source, target_type, command, value_objects_by_name)
       if source[:kind] == "literal"
-        value = source[:value]
-        return literal_hash_rhs(value, target_type, value_objects_by_name) if value.is_a?(Hash)
-
-        return literal_rhs(value)
+        return literal_rhs_for(source[:value], target_type, value_objects_by_name)
       end
 
       source_attr = command[:attributes].find { |a| a[:name].to_s == source[:name] }
@@ -437,7 +434,7 @@ module RustProjection
     # unwraps instead.
     def append_field_rhs(source, field_attr, command, value_objects_by_name)
       parsed = append_field_source(source)
-      return literal_hash_rhs(parsed, field_attr[:type], value_objects_by_name) unless parsed.is_a?(Symbol)
+      return literal_rhs_for(parsed, field_attr[:type], value_objects_by_name) unless parsed.is_a?(Symbol)
 
       arg_attr = command[:attributes].find { |a| a[:name].to_s == parsed.to_s }
       arg_expr = "args.#{rust_ident_field(arg_attr[:name])}"

--- a/rust/src/generated/roster/roster.rs
+++ b/rust/src/generated/roster/roster.rs
@@ -60,6 +60,142 @@ if !unknown.is_empty() {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct Motto {
+    pub value: String,
+}
+
+impl crate::kernel::Fielded for Motto {
+    fn field(&self, name: &str) -> Option<crate::kernel::Field<'_>> {
+        use crate::kernel::Field;
+        use crate::kernel::Value;
+        match name {
+            "value" => Some(Field::Value(Value::Str(self.value.clone()))),
+            _ => None,
+        }
+    }
+
+    fn items(&self, name: &str) -> Option<Vec<crate::kernel::Field<'_>>> {
+        #[allow(unused_imports)]
+        use crate::kernel::{Field, Value};
+        match name {
+
+            _ => None,
+        }
+    }
+}
+
+
+impl Motto {
+    pub fn check_invariants(&self) -> Result<(), crate::kernel::Refusal> {
+
+        Ok(())
+    }
+}
+
+impl Motto {
+    pub fn to_json(&self) -> crate::kernel::Json {
+        crate::kernel::Json::Object(vec![
+        ("value".to_string(), crate::kernel::Json::Str(self.value.clone())),
+        ])
+    }
+}
+
+impl Motto {
+    pub fn from_json(v: &crate::kernel::Json) -> Result<Self, crate::kernel::Refusal> {
+let unknown = v.unknown_keys(&["value"]);
+if !unknown.is_empty() {
+    return Err(crate::kernel::Refusal::UnknownArgument(format!(
+        "Motto does not declare {} — it takes value",
+        unknown.join(", ")
+    )));
+}
+        Ok(Self {
+        value: { let x = v.require("value", "Motto")?; x.as_str().map(|s| s.to_string()).ok_or_else(|| crate::kernel::Refusal::TypeMismatch("Motto.value: expected String".to_string()))? },
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mood {
+    Open,
+    Busy,
+}
+
+impl crate::kernel::Fielded for Mood {
+    fn field(&self, name: &str) -> Option<crate::kernel::Field<'_>> {
+        use crate::kernel::{Field, Value};
+        match name {
+            "value" => Some(Field::Value(Value::Str(match self { Mood::Open => "open".to_string(), Mood::Busy => "busy".to_string(), }))),
+            _ => None,
+        }
+    }
+}
+
+impl Mood {
+    pub fn to_json(&self) -> crate::kernel::Json {
+        let member = match self {
+            Mood::Open => "open",
+            Mood::Busy => "busy",
+        };
+        crate::kernel::Json::obj(vec![("value", crate::kernel::Json::str(member))])
+    }
+
+    pub fn from_json(v: &crate::kernel::Json) -> Result<Self, crate::kernel::Refusal> {
+        let raw = v.require("value", "Mood")?.as_str()
+            .ok_or_else(|| crate::kernel::Refusal::TypeMismatch("Mood.value: expected string".to_string()))?;
+        match raw {
+            "open" => Ok(Mood::Open),
+            "busy" => Ok(Mood::Busy),
+            other => Err(crate::kernel::Refusal::InvariantViolation(crate::kernel::RefusalSite::InvariantViolationClosedSetMember.render(&[
+                ("type", "Mood"),
+                ("admitted", "\"open\", \"busy\""),
+                ("offered", &format!("{:?}", other)),
+            ]))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Rank {
+    Hand,
+    Officer,
+}
+
+impl crate::kernel::Fielded for Rank {
+    fn field(&self, name: &str) -> Option<crate::kernel::Field<'_>> {
+        use crate::kernel::{Field, Value};
+        match name {
+            "value" => Some(Field::Value(Value::Str(match self { Rank::Hand => "hand".to_string(), Rank::Officer => "officer".to_string(), }))),
+            _ => None,
+        }
+    }
+}
+
+impl Rank {
+    pub fn to_json(&self) -> crate::kernel::Json {
+        let member = match self {
+            Rank::Hand => "hand",
+            Rank::Officer => "officer",
+        };
+        crate::kernel::Json::obj(vec![("value", crate::kernel::Json::str(member))])
+    }
+
+    pub fn from_json(v: &crate::kernel::Json) -> Result<Self, crate::kernel::Refusal> {
+        let raw = v.require("value", "Rank")?.as_str()
+            .ok_or_else(|| crate::kernel::Refusal::TypeMismatch("Rank.value: expected string".to_string()))?;
+        match raw {
+            "hand" => Ok(Rank::Hand),
+            "officer" => Ok(Rank::Officer),
+            other => Err(crate::kernel::Refusal::InvariantViolation(crate::kernel::RefusalSite::InvariantViolationClosedSetMember.render(&[
+                ("type", "Rank"),
+                ("admitted", "\"hand\", \"officer\""),
+                ("offered", &format!("{:?}", other)),
+            ]))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct MemberId {
     pub value: String,
 }
@@ -392,6 +528,7 @@ if !unknown.is_empty() {
 pub struct Member {
     pub id: MemberId,
     pub age: Age,
+    pub rank: Rank,
     pub status: String,
 }
 
@@ -402,6 +539,7 @@ impl crate::kernel::Fielded for Member {
         match name {
             "id" => Some(Field::Nested(&self.id)),
             "age" => Some(Field::Nested(&self.age)),
+            "rank" => Some(Field::Nested(&self.rank)),
             "status" => Some(Field::Value(Value::Str(self.status.clone()))),
             _ => None,
         }
@@ -422,6 +560,7 @@ impl Member {
         crate::kernel::Json::Object(vec![
         ("id".to_string(), self.id.to_json()),
         ("age".to_string(), self.age.to_json()),
+        ("rank".to_string(), self.rank.to_json()),
         ("status".to_string(), crate::kernel::Json::Str(self.status.clone())),
         ])
     }
@@ -432,6 +571,7 @@ impl Member {
         Ok(Self {
         id: MemberId::from_json(&v.require("id", "Member")?.coerce_single_field("value"))?,
         age: Age::from_json(&v.require("age", "Member")?.coerce_single_field("value"))?,
+        rank: Rank::from_json(&v.require("rank", "Member")?.coerce_single_field("value"))?,
         status: v.require("status", "Member")?.as_str().ok_or_else(|| crate::kernel::Refusal::TypeMismatch("Member.status: expected a string".to_string()))?.to_string(),
         })
     }
@@ -552,6 +692,8 @@ pub fn dispatch_entity_member_retire(
 #[derive(Debug, Clone, PartialEq)]
 pub struct Roster {
     pub name: Option<RosterName>,
+    pub motto: Option<Motto>,
+    pub mood: Option<Mood>,
     pub seats: Vec<Seat>,
     pub crew: Vec<Member>,
     pub assignments: Vec<Assignment>,
@@ -562,6 +704,8 @@ impl crate::kernel::Fielded for Roster {
         use crate::kernel::{Field, Value};
         match name {
             "name" => self.name.as_ref().map(|v| Field::Nested(v)).or(Some(Field::Value(Value::Nil))),
+            "motto" => self.motto.as_ref().map(|v| Field::Nested(v)).or(Some(Field::Value(Value::Nil))),
+            "mood" => self.mood.as_ref().map(|v| Field::Nested(v)).or(Some(Field::Value(Value::Nil))),
             "seats" => Some(Field::Value(Value::List(self.seats.len()))),
             "crew" => Some(Field::Value(Value::List(self.crew.len()))),
             "assignments" => Some(Field::Value(Value::List(self.assignments.len()))),
@@ -585,6 +729,8 @@ impl Roster {
     pub fn to_json(&self) -> crate::kernel::Json {
         crate::kernel::Json::Object(vec![
         ("name".to_string(), self.name.as_ref().map(|v| v.to_json()).unwrap_or(crate::kernel::Json::Null)),
+        ("motto".to_string(), self.motto.as_ref().map(|v| v.to_json()).unwrap_or(crate::kernel::Json::Null)),
+        ("mood".to_string(), self.mood.as_ref().map(|v| v.to_json()).unwrap_or(crate::kernel::Json::Null)),
         ("seats".to_string(), crate::kernel::Json::Array(self.seats.iter().map(|x| x.to_json()).collect())),
         ("crew".to_string(), crate::kernel::Json::Array(self.crew.iter().map(|x| x.to_json()).collect())),
         ("assignments".to_string(), crate::kernel::Json::Array(self.assignments.iter().map(|x| x.to_json()).collect())),
@@ -596,6 +742,8 @@ impl Roster {
     pub fn from_json(v: &crate::kernel::Json) -> Result<Self, crate::kernel::Refusal> {
         Ok(Self {
         name: match v.get("name") { Some(&crate::kernel::Json::Null) | None => None, Some(x) => Some(RosterName::from_json(&x.coerce_single_field("value"))?), },
+        motto: match v.get("motto") { Some(&crate::kernel::Json::Null) | None => None, Some(x) => Some(Motto::from_json(&x.coerce_single_field("value"))?), },
+        mood: match v.get("mood") { Some(&crate::kernel::Json::Null) | None => None, Some(x) => Some(Mood::from_json(&x.coerce_single_field("value"))?), },
         seats: match v.get("seats").and_then(crate::kernel::Json::as_array) { Some(items) => items.iter().map(Seat::from_json).collect::<Result<Vec<_>, crate::kernel::Refusal>>()?, None => Vec::new(), },
         crew: match v.get("crew").and_then(crate::kernel::Json::as_array) { Some(items) => items.iter().map(Member::from_json).collect::<Result<Vec<_>, crate::kernel::Refusal>>()?, None => Vec::new(), },
         assignments: match v.get("assignments").and_then(crate::kernel::Json::as_array) { Some(items) => items.iter().map(Assignment::from_json).collect::<Result<Vec<_>, crate::kernel::Refusal>>()?, None => Vec::new(), },
@@ -662,6 +810,8 @@ pub fn dispatch_open(
         id: args.name.value.to_string(),
         build: Box::new(|| Roster {
             name: Some(args.name.clone()),
+            motto: None,
+            mood: None,
             seats: vec![],
             crew: vec![],
             assignments: vec![],
@@ -677,7 +827,8 @@ pub fn dispatch_open(
         ],
         None,
         |record| {
-        let _ = record;
+        record.motto = Some(Motto { value: "all hands".to_string() });
+        record.mood = Some(Mood::Open);
             Ok(())
         },
         &[
@@ -845,7 +996,7 @@ pub fn dispatch_enlist(
         ],
         None,
         |record| {
-        record.crew.push(Member { id: args.id.clone(), age: args.age.clone(), status: "active".to_string() });
+        record.crew.push(Member { id: args.id.clone(), age: args.age.clone(), rank: Rank::Hand, status: "active".to_string() });
             Ok(())
         },
         &[
@@ -935,6 +1086,7 @@ pub fn dispatch_assign(
         None,
         |record| {
         record.assignments.push(Assignment { member: args.member.clone(), number: args.number.clone() });
+        record.mood = Some(Mood::Busy);
             Ok(())
         },
         &[

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -2509,6 +2509,19 @@ RSpec.describe "the DSL surface" do
       expect(command.attribute(:balance).type).to eq("Tag")
     end
 
+    # A LITERAL THAT SPELLS THE FIELD'S OWN NAME IS NOT THE SHORTHAND —
+    # `sets :moved, to: "moved"` (a chess rook recording that it has
+    # moved, into a closed set whose member is literally "moved") used
+    # to read as `sets :moved` and import the owner's attribute as a
+    # phantom argument. Only a bare SYMBOL naming its own target is the
+    # sugar; a String is a value.
+    it "sets :field, to: \"field\" — a literal spelling the field's name — imports nothing" do
+      command = build_command("CmdLiteralSpellsName") { sets :balance, to: "balance" }
+
+      expect(command.attribute(:balance)).to be_nil
+      expect(command.mutations.first.to_h[:source]).to eq(kind: "literal", value: "balance")
+    end
+
     # THE NEGATIVE CASE — neither the command nor the owner declares the
     # field a bare `sets` names. `resolve_implicit_attributes!` finds no
     # owner attribute and adds nothing, so the command's own `attributes`


### PR DESCRIPTION
Two things stood between chess's remaining doors and Rust, and both
wore the same message. `sets :moved, to: "moved"` — a rook recording
that it has moved, into a closed set whose member is literally "moved"
— was refused by the generator as "target argument moved has no source
on the door", and the `Place*`/`Crown*` appends of `moved: "never_moved"`
as "literal doesn't bridge to Moved".

The first is a DSL bug, fixed at the source. `CommandBuilder#resolve_
bare_set!` — the sugar by which a bare `sets :field` imports the
owner's own attribute onto the command — compared the mutation's
source and target AS TEXT, so a String literal that happened to spell
the field's own name read as the shorthand and grew the command a
phantom `moved` argument nothing ever passed. Harmless at runtime
(the owner's default filled it), a silent divergence for every
projection reading the command's declared arguments. Its own comment
already said only a bare symbol qualifies; the code now does too, and
spec/dsl_spec.rb pins the literal case. (The append twin,
`resolve_append_fields!`, already required a Symbol.)

The second is the bridge itself, in both generators: a SCALAR literal
into a SINGLE-FIELD value object — closed set or plain — is
`Value.for_attribute`'s own rewrap, the literal standing for the sole
field's value, and now bridges exactly as the hash it stands for
(`literal_set_bridgeable?`/`literal_rhs_for` in bridging.rb, the same
in rust/codegen's bridging.rs), for `sets :x, to: "…"` and for append
fields alike; a scalar into a scalar field stays itself. examples/
roster gains `motto` (a plain one-field VO set from a literal), `mood`
(a closed set set from a literal at creation and again later) and
`rank` (a closed set appended as a literal into an entity element),
and the conformance fixture's instances hold the native binary to
Ruby's coerced values. Suite 1806/0, cargo test green.

Chess at this commit: seventeen doors generate; two skips remain and
they are different questions — `draw_offer` (a `Color` argument set
into a `DrawOffer` field, a type bridge) and Promote's optional `id`
feeding the element's identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc36TdgHxuFhxs5eAjcGXr