### PR TITLE
dry_run reaches the binary — and a serve mode, so a chooser can hold the referee open

### DIFF
--- a/lib/hecks/fuzzing/replay.rb
+++ b/lib/hecks/fuzzing/replay.rb
@@ -67,6 +67,7 @@ module Hecks
 
           refusals        = []
           queries         = []
+          dry_runs        = []
           fan_outs        = []
           guard_checks    = []
           mutation_traces = []
@@ -126,6 +127,19 @@ module Hecks
               rescue *Runtime::DOMAIN_REFUSALS, Bluebook::Expression::EvaluationError => e
                 queries << { query: question, args: args, error: e.message }
                 refusals << { verb: question, error: e.message, kind: e.class.name }
+              end
+              next
+            end
+
+            # `{"dry_run": verb, "args": …}` — `Dispatcher#dry_run?`: the command
+            # evaluated hypothetically, nothing saved or emitted, no reaction.
+            # Recorded, never a refusal: a refused dry run is an ANSWER.
+            if (hypothetical = step["dry_run"])
+              begin
+                runtime.dry_run?(hypothetical, **args)
+                dry_runs << { verb: hypothetical, ok: true }
+              rescue *Runtime::DOMAIN_REFUSALS, Bluebook::Expression::EvaluationError => e
+                dry_runs << { verb: hypothetical, ok: false, error: e.message }
               end
               next
             end
@@ -288,7 +302,7 @@ module Hecks
           # "the" bluebook — reads this instead.
           { instances: instances, events: events, refusals: refusals,
             reactions: runtime.reactions, sagas: runtime.sagas, saga_instances: saga_instances,
-            queries: queries, fan_outs: fan_outs, guard_checks: guard_checks,
+            queries: queries, dry_runs: dry_runs, fan_outs: fan_outs, guard_checks: guard_checks,
             mutation_traces: mutation_traces,
             saga_dispatches: runtime.saga_dispatches, policy_dispatches: runtime.policy_dispatches,
             bluebook: runtime.registry.bluebooks.values.first,

--- a/rust/src/exemplar/registry.rs
+++ b/rust/src/exemplar/registry.rs
@@ -76,6 +76,10 @@ fn tmpl_dispatch_arm_placeholder() -> Result<Vec<crate::kernel::Event>, crate::k
 // header — `emit_registry` (registry.rb) keeps building it as a plain
 // Ruby constant, prepended in front of this shape's own rendered text.
 // TMPL:registry_file BEGIN
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct TmplStore2 {
     pub tmpl_field: crate::kernel::InMemoryRepository<i64>,
 }

--- a/rust/src/generated/banking/merged.rs
+++ b/rust/src/generated/banking/merged.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub customer: crate::kernel::InMemoryRepository<crate::generated::banking::customer::Customer>,
     pub account: crate::kernel::InMemoryRepository<crate::generated::banking::account::Account>,

--- a/rust/src/generated/banking/registry.rs
+++ b/rust/src/generated/banking/registry.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub customer: crate::kernel::InMemoryRepository<crate::generated::banking::customer::Customer>,
     pub account: crate::kernel::InMemoryRepository<crate::generated::banking::account::Account>,

--- a/rust/src/generated/compliance/merged.rs
+++ b/rust/src/generated/compliance/merged.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub accountfreezereview: crate::kernel::InMemoryRepository<crate::generated::compliance::accountfreezereview::AccountFreezeReview>,
     pub boxsurrenderreview: crate::kernel::InMemoryRepository<crate::generated::compliance::boxsurrenderreview::BoxSurrenderReview>,

--- a/rust/src/generated/compliance/registry.rs
+++ b/rust/src/generated/compliance/registry.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub accountfreezereview: crate::kernel::InMemoryRepository<crate::generated::compliance::accountfreezereview::AccountFreezeReview>,
     pub boxsurrenderreview: crate::kernel::InMemoryRepository<crate::generated::compliance::boxsurrenderreview::BoxSurrenderReview>,

--- a/rust/src/generated/governance/registry.rs
+++ b/rust/src/generated/governance/registry.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub roleassignment: crate::kernel::InMemoryRepository<crate::generated::governance::roleassignment::RoleAssignment>,
     pub roletransition: crate::kernel::InMemoryRepository<crate::generated::governance::roletransition::RoleTransition>,

--- a/rust/src/generated/identity/registry.rs
+++ b/rust/src/generated/identity/registry.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub identity: crate::kernel::InMemoryRepository<crate::generated::identity::identity::Identity>,
     pub externalidentifier: crate::kernel::InMemoryRepository<crate::generated::identity::externalidentifier::ExternalIdentifier>,

--- a/rust/src/generated/meta/merged.rs
+++ b/rust/src/generated/meta/merged.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub aggregate: crate::kernel::InMemoryRepository<crate::generated::meta::aggregate::Aggregate>,
     pub bluebook: crate::kernel::InMemoryRepository<crate::generated::meta::bluebook::Bluebook>,

--- a/rust/src/generated/meta/registry.rs
+++ b/rust/src/generated/meta/registry.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub aggregate: crate::kernel::InMemoryRepository<crate::generated::meta::aggregate::Aggregate>,
     pub bluebook: crate::kernel::InMemoryRepository<crate::generated::meta::bluebook::Bluebook>,

--- a/rust/src/generated/pizzas/merged.rs
+++ b/rust/src/generated/pizzas/merged.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub order: crate::kernel::InMemoryRepository<crate::generated::pizzas::order::Order>,
     pub roleassignment: crate::kernel::InMemoryRepository<crate::generated::governance::roleassignment::RoleAssignment>,

--- a/rust/src/generated/pizzas/registry.rs
+++ b/rust/src/generated/pizzas/registry.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub order: crate::kernel::InMemoryRepository<crate::generated::pizzas::order::Order>,
 }

--- a/rust/src/generated/roster/merged.rs
+++ b/rust/src/generated/roster/merged.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub roster: crate::kernel::InMemoryRepository<crate::generated::roster::roster::Roster>,
 }

--- a/rust/src/generated/roster/registry.rs
+++ b/rust/src/generated/roster/registry.rs
@@ -8,6 +8,10 @@
 // by instances()) need no import, but save() does.
 use crate::kernel::Repository;
 
+// `Clone` — a DRY RUN (`cli::run`'s `{"dry_run": …}` step, `cli::serve`'s
+// `snapshot`/`restore`) dispatches against a throwaway copy of the whole
+// store: givens, mutations, ensures all run for real, nothing is kept.
+#[derive(Clone)]
 pub struct Store {
     pub roster: crate::kernel::InMemoryRepository<crate::generated::roster::roster::Roster>,
 }

--- a/rust/src/kernel/cli.rs
+++ b/rust/src/kernel/cli.rs
@@ -108,6 +108,11 @@ pub fn run(input: &str) -> String {
     // command does, and contributes nothing here — matching Ruby, which
     // never pushes a `rows:`-bearing entry for a question that raised.
     let mut query_results: Vec<Json> = Vec::new();
+    // One entry per "dry_run" step, in step order — `Dispatcher#dry_run?`
+    // (Ruby): the command evaluated hypothetically, givens/mutations/
+    // ensures for real, nothing saved, nothing emitted, no reaction. Here:
+    // the same dispatch against a throwaway clone of the store.
+    let mut dry_runs: Vec<Json> = Vec::new();
 
     for step in steps {
         // Read once, ahead of the "query"/"verb" branch below — a query
@@ -266,9 +271,18 @@ pub fn run(input: &str) -> String {
             continue;
         }
 
+        if let Some(verb) = step.get("dry_run").and_then(Json::as_str) {
+            let caller_role = step.get("role").and_then(Json::as_str);
+            let command_input = command_input(step, args);
+            dry_runs.push(dry_run(&store, verb, command_input, caller_role));
+            mutations_per_step.push(Vec::new());
+            cross_domain_per_step.push(Vec::new());
+            continue;
+        }
+
         let verb = match step.get("verb").and_then(Json::as_str) {
             Some(v) => v,
-            None => return error_output("step missing \"verb\" or \"query\""),
+            None => return error_output("step missing \"verb\", \"dry_run\", or \"query\""),
         };
 
         // `role:` — the SAME optional per-step key `Fuzzing::Replay.call`
@@ -356,6 +370,7 @@ pub fn run(input: &str) -> String {
         ("instances".to_string(), Json::Object(store.instances())),
         ("events".to_string(), events_json),
         ("refusals".to_string(), refusals_json),
+        ("dry_runs".to_string(), Json::Array(dry_runs)),
         ("mutations".to_string(), mutations_json),
         ("queries".to_string(), Json::Array(query_results)),
         ("cross_domain_reactions".to_string(), cross_domain_json),
@@ -391,6 +406,106 @@ pub fn run(input: &str) -> String {
 /// number for a numeric comparator, a string, `null` for a genuine nil
 /// check) all the way into `repository::filter_entries`, which is the
 /// one place it's actually interpreted.
+/// `Dispatcher#dry_run?` — evaluate a command against a throwaway copy
+/// of the store. `{"verb", "ok"}` or `{"verb", "ok": false, "error"}`,
+/// the error being the very refusal a real dispatch would have raised.
+fn dry_run(store: &Store, verb: &str, command_input: &Json, caller_role: Option<&str>) -> Json {
+    let mut scratch = store.clone();
+    match dispatch_by_name(&mut scratch, verb, command_input, caller_role, &mut Vec::new()) {
+        Ok(_) => Json::obj(vec![("verb", Json::str(verb.to_string())), ("ok", Json::Bool(true))]),
+        Err(refusal) => Json::obj(vec![("verb", Json::str(verb.to_string())), ("ok", Json::Bool(false)), ("error", Json::str(refusal.to_string()))]),
+    }
+}
+
+fn tables() -> Tables<'static> {
+    Tables {
+        policies: POLICIES,
+        cross_domain_policies: CROSS_DOMAIN_POLICIES,
+        process_managers: PROCESS_MANAGERS,
+        reference_key_fn: reference_key_for_aggregate,
+        queries: QUERIES,
+        command_creates_fn: command_creates,
+        identity_head_fn: identity_head_for_aggregate,
+    }
+}
+
+/// THE STREAMING MODE — `rust --serve`: one JSON step per stdin line, one
+/// JSON answer per stdout line, the store alive across them. What a
+/// move CHOOSER needs from a referee (hecks_ai_training's bin/selfplay):
+/// propose with `{"dry_run": verb, "args": …}` as many times as it likes,
+/// commit with `{"verb": …}`, read the board with `{"instances": true}`,
+/// and try a multi-dispatch sequence (a capture is two) between
+/// `{"snapshot": true}` and `{"restore": true}` — the same throwaway-copy
+/// idea as a dry run, held open across steps. Reactions run on commits
+/// exactly as in `run`; answers carry the events each commit produced.
+pub fn serve(input: impl std::io::BufRead, mut output: impl std::io::Write) {
+    let mut store = Store::new();
+    let mut sagas: HashMap<(String, String), SagaInstance> = HashMap::new();
+    let mut reaction_log: Vec<Json> = Vec::new();
+    let mut saga_log: Vec<Json> = Vec::new();
+    let mut snapshot: Option<(Store, HashMap<(String, String), SagaInstance>)> = None;
+    let ok = || Json::obj(vec![("ok", Json::Bool(true))]);
+
+    for line in input.lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let answer = match Json::parse(&line) {
+            Err(e) => Json::obj(vec![("ok", Json::Bool(false)), ("error", Json::str(format!("invalid JSON: {e}")))]),
+            Ok(step) => {
+                let empty_args = Json::Object(vec![]);
+                let args = step.get("args").unwrap_or(&empty_args);
+                let caller_role = step.get("role").and_then(Json::as_str);
+                if step.get("snapshot").is_some() {
+                    snapshot = Some((store.clone(), sagas.clone()));
+                    ok()
+                } else if step.get("restore").is_some() {
+                    match &snapshot {
+                        Some((s, g)) => {
+                            store = s.clone();
+                            sagas = g.clone();
+                            ok()
+                        }
+                        None => Json::obj(vec![("ok", Json::Bool(false)), ("error", Json::str("no snapshot to restore"))]),
+                    }
+                } else if step.get("instances").is_some() {
+                    Json::obj(vec![("ok", Json::Bool(true)), ("instances", Json::Object(store.instances()))])
+                } else if let Some(verb) = step.get("dry_run").and_then(Json::as_str) {
+                    dry_run(&store, verb, command_input(&step, args), caller_role)
+                } else if let Some(verb) = step.get("verb").and_then(Json::as_str) {
+                    let mut events: Vec<Event> = Vec::new();
+                    let outcome = orchestrate(
+                        &mut store,
+                        dispatch_by_name,
+                        tables(),
+                        &mut sagas,
+                        verb,
+                        command_input(&step, args),
+                        caller_role,
+                        None,
+                        0,
+                        &mut events,
+                        &mut Vec::new(),
+                        &mut Vec::new(),
+                        &mut reaction_log,
+                        &mut saga_log,
+                    );
+                    match outcome {
+                        Ok(()) => Json::obj(vec![("ok", Json::Bool(true)), ("events", Json::Array(events.iter().map(event_to_json).collect()))]),
+                        Err(refusal) => Json::obj(vec![("ok", Json::Bool(false)), ("error", Json::str(refusal.to_string()))]),
+                    }
+                } else {
+                    Json::obj(vec![("ok", Json::Bool(false)), ("error", Json::str("step needs verb, dry_run, snapshot, restore, or instances"))])
+                }
+            }
+        };
+        if writeln!(output, "{}", answer.to_json_string()).is_err() || output.flush().is_err() {
+            break;
+        }
+    }
+}
+
 fn run_filter(store: &Store, filter: &Json) -> Result<Vec<Json>, Refusal> {
     let aggregate = required_str(filter, "aggregate")?;
     let field = required_str(filter, "field")?;

--- a/rust/src/kernel/orchestrate.rs
+++ b/rust/src/kernel/orchestrate.rs
@@ -200,6 +200,7 @@ pub const REFUSED: &str = "refused";
 /// by whoever owns the map (`kernel/cli.rs` — deliberately NOT a `Store`
 /// field: process managers are domain-level, not per-aggregate, and
 /// nothing about `Store`'s own generated shape needs to know they exist).
+#[derive(Clone)]
 pub struct SagaInstance {
     pub state: String,
     pub memory: Json,

--- a/rust/src/kernel/repository.rs
+++ b/rust/src/kernel/repository.rs
@@ -18,7 +18,7 @@ pub trait Repository<T: Clone> {
     fn count(&self) -> usize;
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct InMemoryRepository<T: Clone> {
     records: BTreeMap<String, T>,
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -13,6 +13,14 @@
 use std::io::Read;
 
 fn main() {
+    // `--serve`: the streaming mode (kernel/cli.rs's own `serve` header) —
+    // one step per line in, one answer per line out, store kept alive.
+    if std::env::args().any(|a| a == "--serve") {
+        let stdin = std::io::stdin();
+        let stdout = std::io::stdout();
+        rust::kernel::cli::serve(stdin.lock(), stdout.lock());
+        return;
+    }
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input).expect("failed to read stdin");
     println!("{}", rust::kernel::cli::run(&input));

--- a/spec/corpus/rust_conformance/roster.json
+++ b/spec/corpus/rust_conformance/roster.json
@@ -1,6 +1,6 @@
 {
   "domain": "examples/roster",
-  "note": "spec/rust_conformance_spec.rb's own fixture for the enumeration operators (rust/src/kernel/expression_operators/enumeration.rs): every given in examples/roster is a block predicate \u2014 .none?/.any? over a value-object list and over an entity list, a block nested in a block reading the outer parameter, .find { } projected through a path, .all? as an implication \u2014 and this script drives each one to BOTH verdicts, so the Rust kernel's refusals, wording included, are held to Ruby's dispatch for dispatch. The Retire steps drive `delegates_to` (Roster.Retire \u2192 Member.Retire): the entity's own given and ensures both read `parent` \u2014 the given before the element changes, the ensures after \u2014 so crew-2's lone member retiring is refused by the ensures only if the parent the ensures sees already carries the retired element.",
+  "note": "spec/rust_conformance_spec.rb's own fixture for the enumeration operators (rust/src/kernel/expression_operators/enumeration.rs): every given in examples/roster is a block predicate \u2014 .none?/.any? over a value-object list and over an entity list, a block nested in a block reading the outer parameter, .find { } projected through a path, .all? as an implication \u2014 and this script drives each one to BOTH verdicts, so the Rust kernel's refusals, wording included, are held to Ruby's dispatch for dispatch. The Retire steps drive `delegates_to` (Roster.Retire \u2192 Member.Retire): the entity's own given and ensures both read `parent` \u2014 the given before the element changes, the ensures after \u2014 so crew-2's lone member retiring is refused by the ensures only if the parent the ensures sees already carries the retired element. The dry_run steps are Dispatcher#dry_run? \u2014 hypothetical dispatches (a refused seat, an accepted Honor that must leave `standing` untouched, a refused delegating door) answered identically by both runtimes and persisting nothing.",
   "steps": [
     {
       "verb": "Roster::Roster.Open",
@@ -397,6 +397,53 @@
         },
         "id": {
           "value": "eve"
+        }
+      }
+    },
+    {
+      "dry_run": "Roster::Roster.AddSeat",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "number": {
+          "value": 1
+        },
+        "row": {
+          "value": "back"
+        }
+      }
+    },
+    {
+      "dry_run": "Roster::Roster.Honor",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "rank": {
+          "value": "hand"
+        }
+      }
+    },
+    {
+      "dry_run": "Roster::Roster.Retire",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "id": {
+          "value": "eve"
+        }
+      }
+    },
+    {
+      "verb": "Roster::Roster.Honor",
+      "args": {
+        "name": {
+          "value": "crew-1"
+        },
+        "rank": {
+          "value": "officer"
         }
       }
     }

--- a/spec/rust_conformance_spec.rb
+++ b/spec/rust_conformance_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe "Rust conformance (native binary)", io: true do
       expect(rust_output["queries"].reject { |q| known_refusal_gap?(q) })
         .to eq(ruby_queries.reject { |q| known_refusal_gap?(q) })
       expect(rust_output["sagas"]).to eq(ruby_sagas)
+      expect(rust_output["dry_runs"]).to eq(JSON.parse(JSON.generate(ruby_result[:dry_runs])))
 
       cross_domain = cross_domain_policy_names(rust_output)
       ruby_reactions = JSON.parse(JSON.generate(ruby_result[:reactions]))


### PR DESCRIPTION
`Dispatcher#dry_run?` — evaluate a command hypothetically: givens,
mutations in memory, ensures, nothing saved, nothing emitted, no
reaction — was the one thing the native kernel could not answer, and
the one thing a move chooser asks most (hecks_ai_training's bin/selfplay
asks it ~70 times a ply). Now it can: a `{"dry_run": verb, "args": …}`
step dispatches against a throwaway clone of the store — `Store` and
`InMemoryRepository` are `Clone` — and answers `{verb, ok}` or `{verb,
ok: false, error}`, the error being the very refusal a real dispatch
would raise. `Fuzzing::Replay` understands the same step (`dry_runs`
in its result), rust_conformance compares them, and the roster fixture
holds a refused seat, an accepted Honor that must leave `standing`
untouched, and a refused delegating door to it — identical both sides.

`rust --serve` is the shape a chooser actually needs: one JSON step per
stdin line, one answer per stdout line, the store alive across them —
`verb` (a real dispatch, reactions and all, its events in the answer),
`dry_run`, `instances` (the board), and `snapshot`/`restore` so a
multi-dispatch sequence (a capture is two) can be tried and rolled
back without replaying a history. Ruby's harness pays a full replay
per probe; this pays a clone.

Suite 1809/0, cargo test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc36TdgHxuFhxs5eAjcGXr