### PR TITLE
policy with: reads the emitting record's own identity

### DIFF
--- a/lib/hecks/bluebook/dsl/bluebook_builder.rb
+++ b/lib/hecks/bluebook/dsl/bluebook_builder.rb
@@ -398,12 +398,24 @@ module Hecks
           source_shape  = event_name && event_shape_for(event_name, aggregates)
           memory_shape  = pm && event_shape_for(pm.starts_on, aggregates)
           correlation   = pm && pm.correlates_by && pm.correlation_head
+          # A POLICY'S SOURCE ALSO CARRIES THE EMITTER'S OWN IDENTITY —
+          # `PolicyInterpreter#emitter_identity`, the runtime half of this.
+          # An entity command's event never declares its aggregate's
+          # identity (it arrives through `reference_to`, not an
+          # `attribute`), so before this a policy on `KnightCaptured` could
+          # not spell `with: { label: :label }` at all — "reads :label off
+          # KnightCaptured, which does not declare it" — and chess's
+          # AdvancePly grew optional, unread attributes just to survive a
+          # wholesale forward. Policies only: a saga leg's own source is
+          # `SagaInterpreter#dispatch_args`, which merges no such thing.
+          identity_sources = pm.nil? && event_name ? event_identity_heads_for(event_name, aggregates) : []
 
           with_spec.each do |field, source|
             raise Malformed, "#{label}'s with: names #{field.inspect}, which #{command_ref} does not declare" if target && !command_declares?(target, field, aggregates, correlation_heads)
 
             next unless source.is_a?(::Symbol)
             next if source == correlation
+            next if identity_sources.include?(source)
             next unless source_shape || memory_shape
 
             found = [source_shape, memory_shape].compact.any? { |shape| shape.any? { |name, *| name == source } }
@@ -538,6 +550,29 @@ module Hecks
 
           owner_name, command = pairs.first
           event_shape(command, owner_aggregate(owner_name, aggregates))
+        end
+
+        # The identity heads of the aggregate that emits `event_name` — an
+        # entity's event is stamped with its OWNING aggregate's identity
+        # (`Event#id` is the parent's), so an owner spelled "Game.Knight"
+        # answers Game's heads.
+        def self.event_identity_heads_for(event_name, aggregates)
+          pairs = event_emitters(aggregates).fetch(event_name.to_s, [])
+          return [] if pairs.empty?
+
+          owner_name, = pairs.first
+          aggregate = owner_aggregate(owner_name, aggregates)
+          return [] unless aggregate
+
+          heads = aggregate.identity_heads.map(&:to_sym)
+          # AN ENTITY'S EVENT ALSO CARRIES THE PIECE'S OWN IDENTITY — the
+          # args a piece was addressed by are the args its event announces
+          # (`Emission#emit`: `payload: args`), so `id`-shaped heads are
+          # genuinely there at runtime even though no `attribute` line on
+          # the entity command declares them.
+          entity_names = owner_name.to_s.split(".").drop(1)
+          entity = entity_names.reduce(aggregate) { |owner, name| owner&.entities&.find { |e| e.hecks_name == name } }
+          heads + (entity ? entity.identity_heads.map(&:to_sym) : [])
         end
 
         def self.command_lookup(aggregates)

--- a/lib/hecks/runtime/policy_interpreter.rb
+++ b/lib/hecks/runtime/policy_interpreter.rb
@@ -238,6 +238,8 @@ module Hecks
         payload = event.payload.transform_keys(&:to_sym).merge(extra)
         return payload unless ReactionInvocation.projection_declared?(policy)
 
+        payload = emitter_identity(event).merge(payload)
+
         args = ReactionInvocation.resolve_mapping(
           with_spec: policy.with_spec,
           scopes:    [["event payload and fan-out row", payload]],
@@ -255,6 +257,41 @@ module Hecks
         @registry.policy_dispatch_log << { policy: policy.name, on: event.name, payload: payload,
                                             with_spec: policy.with_spec, args: args }
         args
+      end
+
+      # THE EMITTING RECORD'S OWN IDENTITY IS A FACT A PROJECTION MAY READ
+      # — the same reasoning `for_each_query_args` gives one method up,
+      # extended from the fan-out's QUERY to the trigger's own `with:`.
+      # Routing separated from payload (`to:`/`with:`) stopped carrying
+      # the emitting aggregate's identity in the payload, which is right
+      # for the event (a KnightCaptured is a fact about a knight, not a
+      # re-statement of which game) but left a CROSS-aggregate reaction
+      # with no way to say which record to address: chess's Graveyard is
+      # one-per-game, fed by policy from every piece's own Captured
+      # event, and its burials had no way to name the game — the
+      # dispatcher fell through to the captured piece's `id` as the
+      # graveyard's identity and refused every one ("no Graveyard with
+      # label.value \"bb\""). Same-aggregate targets were already covered
+      # (`ReactionInvocation.source_receiver_for` lifts Event.id), so
+      # this is the OTHER aggregate's half of that.
+      #
+      # Offered under the emitting aggregate's own identity heads, only
+      # to an EXPLICIT projection (a legacy wholesale forward keeps its
+      # exact old payload), and never over a value the payload itself
+      # carries. `event.id` is the scalar the identity resolves to, so a
+      # projection naming it as the target's own identity head routes it
+      # as the receiver (`Identity.of` coerces a scalar against a
+      # single-field VO head), and one naming it as a declared attribute
+      # carries it as a fact. The build-time validator admits the same
+      # names (`BluebookBuilder.check_with_spec!`).
+      def emitter_identity(event)
+        return {} if event.id.nil? || event.id.to_s.empty?
+
+        domain, bare_name = event.aggregate.to_s.split("::", 2)
+        construct = bare_name && @registry.bluebook(domain)&.aggregate(bare_name)
+        return {} unless construct
+
+        construct.identity_heads.to_h { |head| [head.to_sym, event.id] }
       end
 
       # RESOLVES `target` ("Domain::Aggregate.Command", the same shape

--- a/rust/src/kernel/orchestrate.rs
+++ b/rust/src/kernel/orchestrate.rs
@@ -463,6 +463,19 @@ fn trigger_args(policy: &PolicyRule, event: &Event, extra: Option<(&str, String)
         return Json::Object(source);
     }
 
+    // THE EMITTING RECORD'S OWN IDENTITY IS A FACT A PROJECTION MAY READ
+    // — `PolicyInterpreter#emitter_identity`: offered under the emitting
+    // aggregate's own identity head, to an EXPLICIT projection only, never
+    // over a value the payload itself carries. A cross-aggregate reaction
+    // (chess's per-game Graveyard, fed from every piece's own Captured
+    // event) names its receiver this way — `with: { label: :label }` —
+    // and `split_routed_args` below routes it as `to`.
+    if let Some(head) = (tables.identity_head_fn)(&event.aggregate) {
+        if !event.id.is_empty() && !source.iter().any(|(name, _)| name == head) {
+            source.push((head.to_string(), Json::str(event.id.clone())));
+        }
+    }
+
     let projected = policy
         .with_spec
         .iter()

--- a/spec/runtime/policy_emitter_identity_spec.rb
+++ b/spec/runtime/policy_emitter_identity_spec.rb
@@ -1,0 +1,153 @@
+require "spec_helper"
+
+# A POLICY'S `with:` MAY READ THE EMITTING RECORD'S OWN IDENTITY.
+#
+# Routing separated from payload (`to:`/`with:`) stopped carrying the
+# emitting aggregate's identity in an event's payload — right for the
+# event, but it left a CROSS-aggregate reaction with no way to say which
+# record to address. The real case: chess's Graveyard is one per game,
+# fed by policy from every piece's own Captured event; an entity
+# command's event never declares its aggregate's identity (it arrives
+# through `reference_to`), so `with: { label: :label }` was refused at
+# build time and a wholesale forward fell through to the captured
+# piece's `id` as the graveyard's identity — every burial refused.
+#
+# `PolicyInterpreter#emitter_identity` offers `Event#id` under the
+# emitter's own identity heads, to an explicit projection only;
+# `BluebookBuilder.check_with_spec!` admits the same names.
+RSpec.describe "a policy projecting its emitter's identity" do
+  def boot_board(with_spec)
+    registry = Hecks::Runtime::Registry.new
+
+    Hecks.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+
+      Hecks.bluebook "Boards" do
+        aggregate "Board" do
+          attribute :label,  Label
+          attribute :pieces, list_of(Piece)
+          identified_by :label
+
+          value_object("Label")   { attribute :value, String }
+          value_object("PieceId") { attribute :value, String }
+
+          entity "Piece" do
+            attribute :id, PieceId
+            identified_by :id
+
+            lifecycle :status, default: "on_board" do
+              transition "Capture" => "captured", from: "on_board"
+            end
+
+            command "Capture", from: "on_board" do
+              emits "PieceCaptured"
+            end
+          end
+
+          command "Create" do
+            attribute :label, Label
+            sets :label
+            emits "BoardCreated"
+          end
+
+          command "Place" do
+            reference_to Board
+            attribute :id, PieceId
+            sets :pieces, append: { id: :id }
+            emits "PiecePlaced"
+          end
+
+          command "CapturePiece" do
+            reference_to Board
+            attribute :id, PieceId
+            delegates_to "Piece.Capture", with: { id: :id }
+          end
+        end
+
+        aggregate "Graveyard" do
+          attribute :label,  Label
+          attribute :fallen, list_of(Fallen)
+          identified_by :label
+
+          value_object("Label")   { attribute :value, String }
+          value_object("PieceId") { attribute :value, String }
+
+          entity "Fallen" do
+            attribute :id, PieceId
+            identified_by :id
+          end
+
+          command "Open" do
+            attribute :label, Label
+            sets :label
+            emits "GraveyardOpened"
+          end
+
+          command "Bury" do
+            reference_to Graveyard
+            attribute :id, PieceId
+            sets :fallen, append: { id: :id }
+            emits "PieceBuried"
+          end
+        end
+
+        policy "OpenWithBoard" do
+          on      "BoardCreated"
+          trigger Graveyard::Open
+        end
+
+        # THE POINT: `PieceCaptured` declares nothing — the board's own
+        # `label` only ever reaches this projection as the emitter's identity.
+        policy "BuryOnCapture" do
+          on      "PieceCaptured"
+          trigger Graveyard::Bury, with: with_spec
+        end
+      end
+
+      Hecks.hecksagon("Boards") do
+        ::Boards::Board.persisted_by("Memory")
+        ::Boards::Graveyard.persisted_by("Memory")
+      end
+    end
+
+    registry.verify!
+    Hecks::Runtime::Loader.bind_runtime(Hecks::Runtime::Dispatcher.new(registry))
+  end
+
+  it "addresses another aggregate by the identity of the record that emitted the event" do
+    runtime = boot_board({ label: :label, id: :id })
+    runtime.dispatch("Boards::Board.Create", label: { value: "g" })
+    runtime.dispatch("Boards::Board.Place", to: "g", with: { id: "p1" })
+    runtime.dispatch("Boards::Board.CapturePiece", to: "g", with: { id: "p1" })
+
+    burial = runtime.reactions.find { |row| row[:policy] == "BuryOnCapture" }
+    expect(burial).to include(delivered: true)
+    expect(runtime.registry.event_log.map(&:name).last(2)).to eq(%w[PieceCaptured PieceBuried])
+    fallen = Boards::Graveyard.find("g").fallen.map { |f| Hecks::Runtime::Value.materialize(f) }
+    expect(fallen).to eq([{ id: { value: "p1" } }])
+  end
+
+  it "never lets the identity shadow a field the payload itself carries" do
+    runtime = boot_board({ label: :label, id: :id })
+    runtime.dispatch("Boards::Board.Create", label: { value: "g" })
+    runtime.dispatch("Boards::Board.Place", to: "g", with: { id: "p1" })
+    runtime.dispatch("Boards::Board.CapturePiece", to: "g", with: { id: "p1" })
+
+    bound = runtime.registry.policy_dispatch_log.find { |row| row[:policy] == "BuryOnCapture" }
+    expect(bound[:payload]).to include(label: "g", id: Hecks::Runtime::Value)
+    # The fuzzer's independent re-derivation of the binding reads the
+    # same merged source, so the two never disagree.
+    require "hecks/fuzzing/properties"
+    expect(Hecks::Fuzzing::Properties.dispatch_binding_fidelity(
+             policy_dispatches: runtime.registry.policy_dispatch_log
+           )).to be(true)
+  end
+
+  it "still refuses a source the event neither declares nor identifies" do
+    expect { boot_board({ label: :board_name, id: :id }) }
+      .to raise_error(Hecks::Bluebook::DSL::Malformed, /reads :board_name off "PieceCaptured", which does not declare it/)
+  end
+end


### PR DESCRIPTION
## What

A policy's explicit `with:` projection can now read the emitting record's own identity (`Event#id`) under the emitting aggregate's identity heads, and the build-time validator admits those names (plus the emitting entity's own heads, which are genuinely in its payload).

- `PolicyInterpreter#emitter_identity` — merged into the projection's source scope only (never a wholesale forward, never over a payload field). The merged source is what `policy_dispatch_log` records, so `Properties.dispatch_binding_fidelity` still agrees.
- `BluebookBuilder.check_with_spec!` — `with: { label: :label }` on an entity command's event is no longer "reads :label off KnightCaptured, which does not declare it".
- Rust kernel `trigger_args` — same merge, so `split_routed_args` routes it as `to`.
- New spec `spec/runtime/policy_emitter_identity_spec.rb` (delivery, no-shadowing + fidelity, still-refused unknown source).

## Why

Once routing separated from payload (#335), an entity command's event carries exactly the command's own args. A cross-aggregate reaction then has no way to say which record to address: chess's per-game Graveyard is fed by policy from every piece's own Captured event, and every burial was refused with `no Graveyard with label.value "bb"` — the dispatcher fell through to the captured piece's `id` as the graveyard's identity — in Ruby and Rust alike. Same-aggregate targets already had `source_receiver_for`; this is the other aggregate's half.

Downstream (hecks_ai_training): the six Bury policies become `trigger Graveyard::BuryX, with: { label: :label, id: :id, side: :side }`; chess replays identical Ruby vs Rust over a 118-step greedy self-play game (25 captures → 25 PieceBuried, 0 undelivered reactions).

## Checks

- `rspec spec --tag ~io --tag ~fuzzing`: 1812/0
- `cargo test --lib`: 30/0; `cargo build`/`clippy` clean
- `rspec spec/rust_conformance_spec.rb --tag io`: 16/17 — the `roster.json` failure is pre-existing on `main` (`OnSeatAssignedHonorFront`'s literal arrives as `"\"officer\""` in Rust; unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc36TdgHxuFhxs5eAjcGXr