### PR TITLE
behaviors: boot once per suite, reset between tests

### DIFF
--- a/lib/hecks/behaviors/expectations.rb
+++ b/lib/hecks/behaviors/expectations.rb
@@ -6,9 +6,10 @@ require_relative "../runtime/reaction_invocation"
 
 # Hecks::Behaviors::Expectations
 #
-# One test case, start to finish: boot a fresh runtime scoped to exactly
-# what the suite's own `loads` names, replay `setup` dispatches, dispatch
-# (or query) the command under test, check `expect`. Split out of
+# One test case, start to finish: take the suite's own runtime (booted
+# once for exactly what its `loads` names, reset to nothing between
+# tests — `runtime_for`), replay `setup` dispatches, dispatch (or query)
+# the command under test, check `expect`. Split out of
 # runner.rb the same way the file-count/sweep concern is split from a
 # single test's own execution.
 #
@@ -42,8 +43,9 @@ module Hecks
       REFUSAL_CLASSES = Hecks::Runtime::DOMAIN_REFUSALS
       SPECIAL_KEYS = %i[ok refused emits count].freeze
 
-      def run_one(test, suite)
-        runtime = Hecks::Runtime::Loader.boot_files(suite.loads, install_facade: false)
+      def run_one(test, suite, runtime: nil)
+        runtime ||= runtime_for(suite)
+        runtime.registry.reset_runtime_state!
         bluebooks = runtime.registry.bluebooks.values
 
         current_setup = nil
@@ -59,6 +61,30 @@ module Hecks
         run_tested(test, runtime, bluebooks)
       rescue StandardError => e
         error_result(test, "#{e.class}: #{e.message}")
+      end
+
+      # ONE BOOT PER SUITE, NOT PER TEST. The isolation a test needs is a
+      # runtime with nothing in it — and a boot of the same files gives
+      # exactly that back for the price of `Registry#reset_runtime_state!`
+      # instead of ~2s of loading, verifying and era-checking the same
+      # bluebook again (chess: 76 behaviours, 155s of which was booting
+      # `chess.bluebook` 76 times). Keyed by the suite's own `loads` AND
+      # their mtimes, so an edited bluebook boots fresh on the next test
+      # rather than running against a stale one — the property a watch
+      # loop or a long rspec session actually relies on. `runtime:` lets
+      # a caller that already holds a booted runtime (a spec, a REPL)
+      # hand it in; it is reset the same way.
+      RUNTIMES      = {}
+      RUNTIMES_LOCK = Mutex.new
+      private_constant :RUNTIMES, :RUNTIMES_LOCK
+
+      def runtime_for(suite)
+        files = Array(suite.loads).map { |path| File.expand_path(path) }
+        key   = files.map { |file| [file, File.exist?(file) ? File.mtime(file).to_f : nil] }
+
+        RUNTIMES_LOCK.synchronize do
+          RUNTIMES[key] ||= Hecks::Runtime::Loader.boot_files(files, install_facade: false)
+        end
       end
 
       def run_tested(test, runtime, bluebooks)

--- a/lib/hecks/runtime/registry.rb
+++ b/lib/hecks/runtime/registry.rb
@@ -116,6 +116,36 @@ module Hecks
         @repositories[[domain.to_s, aggregate.hecks_name]] ||= Ports::Persistence.repository(self, domain, aggregate)
       end
 
+      # EVERYTHING A DISPATCH WROTE, CLEARED; NOTHING A BOOT DECLARED,
+      # TOUCHED. Bluebooks, hecksagons, ports, adapters, worlds and the
+      # resolved eras are what loading the files produced and stay as
+      # they are; the logs, the saga instances and the repositories are
+      # what running commands against them produced, and go back to
+      # exactly what a fresh boot of the same files hands out. Dropping
+      # the repositories (rather than emptying each) is deliberate: a
+      # fresh boot's own repositories are new adapter instances too, so
+      # a Memory adapter starts empty and a durable one sees whatever
+      # it persisted — the same reading either way. Sagas rehydrate off
+      # that store again, the way `Loader.boot_files` does after
+      # `verify!`.
+      #
+      # What this is for: a test runner that used to boot a runtime per
+      # test to get isolation (`Behaviors::Expectations.run_one`) — ~2s a
+      # boot, 76 chess behaviours = two and a half minutes of booting the
+      # same two files — can now boot once and reset between tests.
+      def reset_runtime_state!
+        @event_log.clear
+        @reaction_log.clear
+        @saga_log.clear
+        @saga_dispatch_log.clear
+        @policy_dispatch_log.clear
+        @saga_instances.clear
+        @repositories = {}
+        @projection_repositories = {}
+        rehydrate_sagas!
+        self
+      end
+
       def capability_graph
         @capability_graph ||= CapabilityGraph.new(self)
       end

--- a/spec/behaviors/expectations_spec.rb
+++ b/spec/behaviors/expectations_spec.rb
@@ -1,3 +1,5 @@
+require "tmpdir"
+require "fileutils"
 require "hecks/behaviors/expectations"
 
 RSpec.describe Hecks::Behaviors::Expectations do
@@ -40,6 +42,49 @@ RSpec.describe Hecks::Behaviors::Expectations do
 
       expect(described_class.normalize(wrapped)).to eq(described_class.normalize({ value: "Margherita" }))
       expect(described_class.normalize({ value: "Margherita" })).to eq(described_class.normalize("Margherita"))
+    end
+  end
+
+  describe "one boot per suite" do
+    let(:suite) { Hecks::Behaviors::BehaviorsSuite.new(loads: [File.join(root, "pizzas.bluebook"), memory_hecksagon]) }
+
+    def create(name)
+      Hecks::Behaviors::TestCase.new(description: name, tests_command: "CreatePizza", on_aggregate: "Order",
+                                     kind: :command, setups: [], expect: { ok: true },
+                                     input: { name: { value: name }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } } })
+    end
+
+    it "reuses the suite's runtime across tests" do
+      first = described_class.runtime_for(suite)
+      expect(described_class.runtime_for(suite)).to be(first)
+    end
+
+    # THE ISOLATION THE PER-TEST BOOT USED TO BUY: nothing the first test
+    # dispatched is visible to the second — not its events, not its
+    # records.
+    it "resets everything a test wrote before the next one runs" do
+      expect(described_class.run_one(create("First"), suite).status).to eq(:pass)
+      runtime = described_class.runtime_for(suite)
+      expect(runtime.registry.event_log).not_to be_empty
+
+      expect(described_class.run_one(create("Second"), suite).status).to eq(:pass)
+      expect(runtime.registry.event_log.map { |e| e.payload[:name] }.map { |n| Hecks::Runtime::Value.materialize(n) })
+        .to eq([{ value: "Second" }])
+      order = runtime.registry.bluebook("Pizzas").aggregate("Order")
+      expect(runtime.registry.repository("Pizzas", order).all.map(&:id)).to eq(["Second"])
+    end
+
+    it "boots fresh when a loaded file changes" do
+      Dir.mktmpdir do |dir|
+        files = suite.loads.map { |path|
+          FileUtils.cp(path, dir)
+          File.join(dir, File.basename(path))
+        }
+        copy = Hecks::Behaviors::BehaviorsSuite.new(loads: files)
+        before = described_class.runtime_for(copy)
+        FileUtils.touch(files.first, mtime: Time.now + 5)
+        expect(described_class.runtime_for(copy)).not_to be(before)
+      end
     end
   end
 


### PR DESCRIPTION
## What

- `Registry#reset_runtime_state!` — clears everything a dispatch wrote (event/reaction/saga/dispatch logs, saga instances, repositories and projection repositories — dropped, not emptied, so a Memory adapter starts empty and a durable one sees what it persisted, the same reading a fresh boot gives) and rehydrates sagas. Nothing a boot declared is touched.
- `Behaviors::Expectations.runtime_for(suite)` — one `Loader.boot_files` per suite, memoised by the loads' paths **and mtimes** (an edited bluebook boots fresh on the next test). `run_one(test, suite, runtime: nil)` resets it before each test; a caller holding a runtime can hand it in.
- Spec: same runtime reused; the second test sees none of the first's events or records; a touched file re-boots.

## Why

`run_one` booted a fresh runtime per test — ~2s each — so a `.behaviors` file's cost was dominated by re-loading, re-verifying and era-checking the same two files. Chess (hecks_ai_training) has 76 behaviours: 155s of boot for a few seconds of dispatch. With this: `bin/behaviors domain/chess/bluebook` → 76 tests in 11.8s.

## Checks

- `rspec spec --tag ~io --tag ~fuzzing`: 1812/0
- rubocop clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc36TdgHxuFhxs5eAjcGXr