### PR TITLE
Add NarrateProjector: read a domain back to an SME in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Every domain this repository's own tests and docs draw examples from:
 | `bin/ir` | Prints a booted domain's IR as JSON — the same `to_h` the golden specs pin and StorageShape hashes into an era, for reading rather than a... |
 | `bin/merge_tail` | Tail-merge: the one deliberate command. It marks a business event — an old app retiring — never a shape change. One transaction: advance ... |
 | `bin/model_check` | STATIC ANALYSIS OVER THE IR — unreachable lifecycle states, transitions nothing can ever fire, saga states no handler chain reaches, a co... |
+| `bin/narrate` | A domain, read back in English — projected from its own bluebook. bin/narrate # list every domain in this checkout bin/narrate examples/b... |
 | `bin/pattern-cases` | THE RECORDED FIXTURE for `pattern:`, and how to regenerate it : bin/pattern-cases > spec/corpus/fixtures/patterns.json spec/pattern_subse... |
 | `bin/present` | Boots the banking example against the in-memory adapter (same rebind spec/facade/handle_spec.rb already uses — banking.hecksagon itself b... |
 | `bin/project` | Refreshes every read-model projection a domain declares, by hand — the same catch-up a boot runs lazily, forced now rather than on first ... |

--- a/bin/narrate
+++ b/bin/narrate
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+
+# A domain, read back in English — projected from its own bluebook.
+#
+#   bin/narrate                             # list every domain in this checkout
+#   bin/narrate examples/banking            # the whole chapter, to stdout
+#   bin/narrate examples/banking Account    # one aggregate
+#   bin/narrate qa > qa-for-review.md       # on disk, if you want it there
+#
+# Same idea as `bin/docs`, different reader: this one is for the subject-
+# matter expert who can say whether "Debit only goes through if the balance
+# would stay non-negative" is actually right, and has no reason to read a
+# markdown table of argument shapes to get there. See
+# `Hecks::Projector::NarrateProjector` for what it does and does not do.
+#
+# EVERY FAILURE IS A SENTENCE, NOT A BACKTRACE, and not silence — same
+# reasoning as `bin/docs`: a misspelled aggregate refuses by name instead of
+# quietly answering with nothing.
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "hecks"
+
+ROOT = File.expand_path("..", __dir__)
+
+IGNORED = %r{\A(rust|deploy|tmp|coverage)/}
+
+def domains
+  Dir.glob(File.join(ROOT, "**/*.hecksagon"))
+     .map    { |path| File.basename(File.dirname(path)) == "bluebook" ? File.dirname(path, 2) : File.dirname(path) }
+     .map    { |path| path.delete_prefix("#{ROOT}/") }
+     .grep_v(IGNORED)
+     .uniq.sort
+end
+
+here = Hecks::Adapters::Folder.new.domain_root
+
+path, aggregate =
+  if ARGV.empty?              then [here, nil]
+  elsif ARGV.length > 1       then [ARGV[0], ARGV[1]]
+  elsif File.directory?(ARGV[0]) then [ARGV[0], nil]
+  else [here, ARGV[0]]
+  end
+
+unless path
+  warn "usage: bin/narrate [domain-path] [aggregate]"
+  warn ""
+  warn "No bluebook here — #{Dir.pwd} is not inside a domain. Name one:"
+  domains.each { |candidate| warn "  #{candidate}" }
+  exit 1
+end
+
+begin
+  runtime = Hecks.boot(path, install_facade: false)
+rescue StandardError => e
+  abort "cannot read #{path}: #{e.message.lines.first.strip}"
+end
+
+bluebook = runtime.registry.bluebooks.values.first
+abort "#{path} loaded no bluebook" unless bluebook
+
+begin
+  puts Hecks::Projector.call(
+    :narrate,
+    bluebook: bluebook,
+    options:  aggregate ? { aggregate: aggregate } : {}
+  )
+rescue Hecks::Runtime::NotFound => e
+  abort e.message
+end

--- a/lib/hecks/facade/surface/aggregate_door.rb
+++ b/lib/hecks/facade/surface/aggregate_door.rb
@@ -83,6 +83,12 @@ module Hecks
             Projector.call(:docs, bluebook: dispatcher.registry.bluebook(domain),
                                   options:  options.merge(aggregate: ir.hecks_name))
           end
+          # ONE AGGREGATE, READ BACK IN ENGLISH — the same narrowing `:docs`
+          # takes, aimed at `:narrate` instead.
+          door.define_singleton_method(:narrate) do |**options|
+            Projector.call(:narrate, bluebook: dispatcher.registry.bluebook(domain),
+                                     options:  options.merge(aggregate: ir.hecks_name))
+          end
           door.define_singleton_method(:count)      { dispatcher.registry.repository(domain, ir).count }
           door.define_singleton_method(:events)     { dispatcher.events.select { |event| event.aggregate == fqn } }
 

--- a/lib/hecks/facade/surface/chapter.rb
+++ b/lib/hecks/facade/surface/chapter.rb
@@ -29,6 +29,13 @@ module Hecks
             Projector.call(:docs, bluebook: bluebook, options: options)
           end
 
+          # THE CHAPTER, READ BACK IN ENGLISH — `Projector::NarrateProjector`
+          # beside `:docs`, for the reader who needs to confirm the domain is
+          # right rather than call it: `QualityControl.narrate` in a console.
+          chapter.define_singleton_method(:narrate) do |**options|
+            Projector.call(:narrate, bluebook: bluebook, options: options)
+          end
+
           # THE DOMAIN'S OWN IR, PROJECTED. `Projector` has taken
           # `call(name, bluebook:, options:)` since §30, but nothing could
           # reach it from a booted domain — this module already closes

--- a/lib/hecks/projector.rb
+++ b/lib/hecks/projector.rb
@@ -170,10 +170,12 @@ require_relative "projector/target"
 # Neither of these requires this file back — they need `Naming` and nothing
 # else — so unlike a target they are safe to pull in from here.
 require_relative "projector/docs_projector"
+require_relative "projector/narrate_projector"
 require_relative "projector/cli_projector"
 
 Hecks::Projector.register(:ir, Hecks::Projector::IRProjector)
 Hecks::Projector.register(:docs, Hecks::Projector::DocsProjector)
+Hecks::Projector.register(:narrate, Hecks::Projector::NarrateProjector)
 Hecks::Projector.register(:cli, Hecks::Projector::CliProjector)
 
 # The TARGETS are required from lib/hecks.rb, immediately after this

--- a/lib/hecks/projector/narrate_projector.rb
+++ b/lib/hecks/projector/narrate_projector.rb
@@ -1,0 +1,243 @@
+require_relative "docs_projector"
+require_relative "../forms/field_shape"
+
+module Hecks
+  module Projector
+    # A BLUEBOOK, PROJECTED AS PROSE AN SME CAN READ BACK AND CONFIRM.
+    #
+    # WHAT THIS IS FOR. `DocsProjector` already answers "what can I call and
+    # what does it want" for the person implementing against a domain —
+    # tables of arguments, shapes, refusal reasons. That is the wrong
+    # register for the person who can actually say whether the domain is
+    # RIGHT: the subject-matter expert who knows what an account is and has
+    # never read a markdown table in their life. This projects the same IR
+    # as sentences instead — "Debit — take money out. Issued by a Teller. It
+    # only goes through if the balance covers it." — so a domain can be
+    # read back to the person who can validate it without them learning the
+    # DSL first.
+    #
+    # SAME SOURCE, SAME GUARANTEE `DocsProjector` gives: nothing here is
+    # invented. Every sentence quotes a `description`, `goal`, or `given`
+    # already declared in the chapter; where a chapter says nothing, this
+    # says nothing rather than manufacturing a sentence out of an
+    # identifier. Registered as `:narrate` beside `:docs`, same call shape
+    # (`Projector.call(:narrate, bluebook: ...)`), same aggregate-scoping
+    # via `options[:aggregate]`.
+    #
+    # WHAT IT DOES NOT DO: replace `DocsProjector`. A shape table still says
+    # "id of a Customer" more precisely than any sentence would, and an
+    # implementer still wants that. This is the other document the same IR
+    # is owed — one written for the reader who is being asked "is this
+    # right?", not "how do I call it?"
+    module NarrateProjector
+      module_function
+
+      # `options[:heading]` sets the top heading level, exactly as
+      # `DocsProjector` does — so this, too, can be spliced into a larger
+      # document rather than always starting at H1.
+      def call(bluebook:, options: {})
+        depth = (options[:heading] || 1).to_i
+        only  = options[:aggregate]
+
+        sections = []
+        sections << chapter_intro(bluebook, depth) unless only
+        Array(DocsProjector.aggregates(bluebook, only)).each do |aggregate|
+          sections << aggregate_narrative(aggregate, only ? depth : depth + 1)
+        end
+        sections << reactions_narrative(bluebook, depth + 1) unless only
+        "#{sections.compact.join("\n\n").rstrip}\n"
+      end
+
+      # ── the chapter ───────────────────────────────────────────────────
+
+      def chapter_intro(bluebook, depth)
+        parts = [DocsProjector.h(depth, bluebook.name)]
+        parts << bluebook.vision if bluebook.vision
+
+        meta = []
+        meta << "This is a #{bluebook.classification} domain." if bluebook.classification
+        meta << "It was formerly known as `#{bluebook.formerly_known_as}`." if bluebook.formerly_known_as
+        parts << meta.join(" ") unless meta.empty?
+
+        names = bluebook.aggregates.map(&:hecks_name)
+        parts << "It's told through #{to_sentence_list(names)}." unless names.empty?
+        parts.join("\n\n")
+      end
+
+      # ── one aggregate ─────────────────────────────────────────────────
+
+      def aggregate_narrative(aggregate, depth)
+        parts = [DocsProjector.h(depth, aggregate.hecks_name)]
+        parts << aggregate.description if aggregate.description
+        parts << identity_sentence(aggregate)
+
+        refs = aggregate.attributes.select(&:reference?)
+        parts << "Each one is linked to #{to_sentence_list(refs.map { |r| "#{a_or_an(r.type.target_name)} #{r.type.target_name}" })}." unless refs.empty?
+
+        parts << lifecycle_narrative(aggregate)
+        parts << verbs_narrative(aggregate, depth + 1)
+        parts << queries_narrative(aggregate.queries, aggregate.hecks_name, depth + 1)
+
+        aggregate.entities.each { |entity| parts << entity_narrative(aggregate, entity, depth + 1) }
+        parts.compact.join("\n\n")
+      end
+
+      def identity_sentence(holder)
+        return nil if holder.identity_heads.empty?
+
+        "Every #{holder.hecks_name} is identified by its #{to_sentence_list(holder.identity_heads.map { |h| "`#{h}`" })}."
+      end
+
+      def entity_narrative(aggregate, entity, depth)
+        parts = [DocsProjector.h(depth, "#{entity.hecks_name} (within #{aggregate.hecks_name})")]
+        parts << entity.description if entity.description
+        parts << "Reached through its #{aggregate.hecks_name} — you address it by the #{aggregate.hecks_name}'s " \
+                 "id together with its own `#{entity.identity_heads.join('`, `')}`."
+
+        parts << lifecycle_narrative(entity)
+        parts << verbs_narrative(entity, depth + 1)
+        parts << queries_narrative(entity.queries, entity.hecks_name, depth + 1)
+        parts.compact.join("\n\n")
+      end
+
+      # ── the machine ───────────────────────────────────────────────────
+
+      def lifecycle_narrative(holder)
+        lifecycle = holder.lifecycle or return nil
+
+        sentences = ["It carries a `#{lifecycle.field}`, starting out at `#{lifecycle.default}`."]
+        lifecycle.transitions.each do |name, transition|
+          froms = Array(transition.from).map { |f| "`#{f}`" }
+          sentences << "**#{name}** moves it from #{to_sentence_list(froms, conj: 'or')} to `#{transition.target}`."
+        end
+        sentences << "A verb not listed here can be issued from any state."
+        sentences.join(" ")
+      end
+
+      # ── the verbs ─────────────────────────────────────────────────────
+
+      def verbs_narrative(holder, depth)
+        return nil if holder.commands.empty?
+
+        header = DocsProjector.h(depth, "What can happen to #{a_or_an(holder.hecks_name)} #{holder.hecks_name}")
+        body   = holder.commands.map { |command| command_paragraph(command, holder) }.join("\n\n")
+        "#{header}\n\n#{body}"
+      end
+
+      def command_paragraph(command, holder)
+        # THE GOAL, VERBATIM — same rule `DocsProjector` holds to: quoted
+        # exactly as declared, not recased to fit mid-sentence, because the
+        # promise this whole projector makes is that a sentence here is a
+        # sentence the chapter actually wrote.
+        sentences = ["**#{command.hecks_name}**#{command.goal ? " — #{command.goal}." : '.'}"]
+        sentences << "Issued by #{a_or_an(command.role)} #{command.role}." if command.role
+        # `acts_on.nil?`, NOT `creates?` — `creates?` answers true for every
+        # verb an ENTITY declares (it never references itself; see
+        # `Command#acts_on`'s own comment), so reading it directly here would
+        # tell an SME that `LedgerEntry.Amend` brings a new ledger entry into
+        # being, which is exactly backwards.
+        sentences << "This is how a new #{holder.hecks_name} comes into being." if command.acts_on.nil?
+
+        arguments = command.attributes.reject(&:reference?)
+        sentences << "It takes #{to_sentence_list(arguments.map { |a| Forms::Humanize.label(a.name.to_s).downcase })}." unless arguments.empty?
+
+        refs = command.attributes.select(&:reference?)
+        sentences << "It's aimed at one existing #{to_sentence_list(refs.map { |r| r.type.target_name })}, by id." unless refs.empty?
+
+        conditions = conditions_of(command, holder)
+        sentences << "It only goes through if #{conditions.join('; ')}." unless conditions.empty?
+
+        guarantees = command.ensures.map(&:description)
+        sentences << "When it succeeds: #{guarantees.join('; ')}." unless guarantees.empty?
+
+        sentences << "It records `#{command.emits.join('`, `')}` as a fact." unless command.emits.empty?
+
+        sentences.join(" ")
+      end
+
+      # EVERY REQUIRED CONDITION, STATED AS SOMETHING THAT MUST BE TRUE —
+      # the same three sources `DocsProjector#refusals_of` reads (the
+      # lifecycle edge, a reference's existence, and the command's own
+      # `given`s), but kept positive rather than phrased as a refusal
+      # reason. "Refused unless not X" is a sentence a reader has to
+      # invert in their head; "only goes through if X" is not.
+      def conditions_of(command, holder)
+        conditions = []
+
+        lifecycle = holder.lifecycle
+        if lifecycle
+          froms = lifecycle.transitions.filter_map { |name, transition|
+            Array(transition.from) if name.to_s == command.hecks_name
+          }.flatten.uniq
+          conditions << "its `#{lifecycle.field}` is currently #{to_sentence_list(froms.map { |f| "`#{f}`" }, conj: 'or')}" unless froms.empty?
+        end
+
+        conditions + command.givens.map(&:description)
+      end
+
+      # ── the reads ─────────────────────────────────────────────────────
+
+      def queries_narrative(queries, holder_name, depth)
+        return nil if queries.empty?
+
+        header = DocsProjector.h(depth, "Questions you can ask about #{a_or_an(holder_name)} #{holder_name}")
+        lines = queries.map do |query|
+          shape   = query.to_h
+          takes   = Array(shape[:attributes]).map { |a| Forms::Humanize.label(a[:name].to_s).downcase }
+          # `w[:value]` ALREADY WEARS ITS OWN QUOTES OR COLON — it is a
+          # `Literal.render`ed string (see lib/hecks/literal.rb), not a raw
+          # Ruby value, so wrapping it in `.inspect` here would quote an
+          # already-quoted string a second time.
+          filters = Array(shape[:wheres]).map { |w| "`#{w[:field]}` #{op_words(w[:op])} #{w[:value]}" }
+
+          sentence = "- **#{query.hecks_name}**"
+          sentence << " (given #{to_sentence_list(takes)})" unless takes.empty?
+          sentence << " — #{query.description}" if query.description
+          sentence << "." unless sentence.end_with?(".")
+          sentence << " Only where #{to_sentence_list(filters)}." unless filters.empty?
+          sentence
+        end
+        "#{header}\n\n#{lines.join("\n")}"
+      end
+
+      def op_words(op)
+        { eq: "is", lt: "under", lte: "at most", gt: "over", gte: "at least" }[op.to_s.to_sym] || op.to_s
+      end
+
+      # ── what happens on its own ───────────────────────────────────────
+
+      def reactions_narrative(bluebook, depth)
+        return nil if bluebook.policies.empty? && bluebook.process_managers.empty?
+
+        parts = [DocsProjector.h(depth, "Reactions")]
+        bluebook.policies.each do |policy|
+          elsewhere = policy.target_domain ? " in #{policy.target_domain}" : ""
+          parts << "Whenever `#{policy.on_event}` happens, `#{policy.trigger_command}` fires on its own#{elsewhere} — nobody has to ask for it."
+        end
+
+        bluebook.process_managers.each do |saga|
+          shape = saga.to_h
+          parts << "**#{shape[:name]}** is a saga: it starts when `#{shape[:starts_on]}` happens and ends when " \
+                   "`#{shape[:ends_on]}` happens, with each run tracked by its `#{shape[:correlates_by]}`. Along the " \
+                   "way it moves through #{Array(shape[:states]).map { |s| "`#{s}`" }.join(' → ')}."
+        end
+        parts.join("\n\n")
+      end
+
+      # ── small sentence carpentry ──────────────────────────────────────
+
+      def to_sentence_list(items, conj: "and")
+        case items.size
+        when 0 then ""
+        when 1 then items[0].to_s
+        when 2 then "#{items[0]} #{conj} #{items[1]}"
+        else "#{items[0..-2].join(', ')}, #{conj} #{items[-1]}"
+        end
+      end
+
+      def a_or_an(word)
+        %w[a e i o u].include?(word.to_s[0].to_s.downcase) ? "an" : "a"
+      end
+    end
+  end
+end

--- a/spec/projector/narrate_projector_spec.rb
+++ b/spec/projector/narrate_projector_spec.rb
@@ -1,0 +1,185 @@
+require "spec_helper"
+
+# A BLUEBOOK, PROJECTED AS PROSE — the reader is the SME who can say whether
+# it's right, not the implementer calling it, so this is exercised against
+# the same two corpora `DocsProjector` is, and for the same reason: nothing
+# in the projector should know what any particular domain is.
+RSpec.describe Hecks::Projector::NarrateProjector do
+  def corpus
+    registry = Hecks::Runtime::Registry.new
+    Hecks.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      load_bluebook_files(InMemoryDomain::BANKING_BLUEBOOK_DIR)
+      Kernel.load(InMemoryDomain::PIZZAS_BLUEBOOK)
+    end
+    registry
+  end
+
+  let(:registry) { corpus }
+  let(:banking)  { described_class.call(bluebook: registry.bluebook("Banking")) }
+  let(:pizzas)   { described_class.call(bluebook: registry.bluebook("Pizzas")) }
+
+  it "is registered under :narrate, reachable the way every projector is" do
+    expect(Hecks::Projector).to be_registered(:narrate)
+    expect(Hecks::Projector.call(:narrate, bluebook: registry.bluebook("Pizzas"))).to eq(pizzas)
+  end
+
+  it "needs no runtime, no store and no boot — only the IR" do
+    expect(banking).to be_a(String)
+    expect(banking).not_to be_empty
+  end
+
+  describe "the chapter" do
+    it "opens with the vision, verbatim" do
+      expect(banking).to include(registry.bluebook("Banking").vision)
+    end
+
+    it "says whether the domain is core or supporting, as a sentence" do
+      expect(banking).to match(/This is a core domain\./i)
+    end
+
+    it "lists every aggregate it declares, and none it does not" do
+      registry.bluebook("Banking").aggregates.each { |a| expect(banking).to include("## #{a.hecks_name}") }
+    end
+  end
+
+  describe "an aggregate" do
+    it "carries its own description and how it is identified, as sentences" do
+      expect(banking).to include(registry.bluebook("Banking").aggregate("Account").description)
+      expect(banking).to include("Every Account is identified by its `number`.")
+    end
+
+    it "says what it's linked to, in words rather than a reference type" do
+      expect(banking).to match(/Each one is linked to an? Customer\./)
+    end
+  end
+
+  describe "the lifecycle" do
+    it "reads as a sentence per verb, naming where it starts and where each move goes" do
+      expect(banking).to include("starting out at `open`")
+      expect(banking).to include("**FreezeAccount** moves it from `open` to `frozen`.")
+    end
+  end
+
+  describe "a verb" do
+    it "carries its goal in the lede and names who issues it" do
+      command = registry.bluebook("Banking").aggregate("Account").commands.find { |c| c.hecks_name == "FreezeAccount" }
+      expect(banking).to include(command.goal)
+      expect(banking).to match(/Issued by an? #{Regexp.escape(command.role)}\./)
+    end
+
+    # THE PART DOCSPROJECTOR'S OWN `creates?` GETS WRONG for an entity verb —
+    # see `Command#acts_on`'s comment. `LedgerEntry.Amend` never creates a
+    # ledger entry; it corrects one that already exists.
+    it "only claims a command creates the record when it actually does" do
+      expect(banking).to match(/\*\*Open\*\*.*This is how a new Account comes into being/)
+      expect(banking).not_to match(/\*\*Amend\*\*.*This is how a new LedgerEntry comes into being/)
+    end
+
+    describe "what it requires" do
+      it "states a lifecycle constraint positively, not as a refusal to invert" do
+        expect(banking).to include("its `status` is currently `open`")
+        expect(banking).not_to include("anything other than")
+      end
+
+      it "quotes a given in the chapter's own words, without the docs projector's \"not:\" prefix" do
+        given = registry.bluebook("Banking").aggregates.flat_map(&:commands)
+                        .flat_map(&:givens).map(&:description).first
+        expect(banking).to include(given)
+        expect(banking).not_to include("not: #{given}")
+      end
+    end
+
+    it "names what it records as a fact" do
+      expect(banking).to match(/It records `[A-Za-z]+` as a fact\./)
+    end
+  end
+
+  describe "a query" do
+    it "carries its description in prose" do
+      query = registry.bluebook("Banking").aggregates.flat_map(&:queries).find(&:description)
+      expect(banking).to include(query.description)
+    end
+
+    # THE DOUBLE-QUOTING DOCSPROJECTOR ITSELF HAS — `w[:value]` already wears
+    # its own quotes or colon (`Literal.render`ed), so re-`inspect`ing it
+    # prints a literal backslash. Written for readers, this must not.
+    it "renders an already-quoted filter value without a second, escaped layer of quoting" do
+      expect(banking).to include(%(`status` is "open"))
+      expect(banking).not_to include('\\"open\\"')
+    end
+  end
+
+  describe "an entity" do
+    it "says it is reached through its holder, in words" do
+      box = registry.bluebook("Banking").aggregates.find { |a| a.entities.any? }
+      skip "banking declares no entities" unless box
+
+      entity = box.entities.first
+      expect(banking).to include("#{entity.hecks_name} (within #{box.hecks_name})")
+      expect(banking).to match(/Reached through its #{box.hecks_name}/)
+    end
+  end
+
+  describe "reactions" do
+    it "reads a policy as a sentence: what happens, and on what" do
+      expect(banking).to include("## Reactions")
+      expect(banking).to include("Whenever `Account.AccountFrozen` happens, `AccountFreezeReview.Open` fires on its own in Compliance")
+    end
+
+    it "describes a saga by where it starts, ends and correlates, in prose" do
+      skip "banking declares no saga" if registry.bluebook("Banking").process_managers.empty?
+
+      saga = registry.bluebook("Banking").process_managers.first.to_h
+      expect(banking).to include("**#{saga[:name]}** is a saga")
+      expect(banking).to include("tracked by its `#{saga[:correlates_by]}`")
+    end
+  end
+
+  it "refuses an aggregate name that names nothing, and says what is there" do
+    expect { described_class.call(bluebook: registry.bluebook("Banking"), options: { aggregate: "Acount" }) }
+      .to raise_error(Hecks::Runtime::NotFound, /no aggregate named "Acount".*it declares .*Account/m)
+  end
+
+  describe "options" do
+    it "narrows to one aggregate, dropping the chapter frame" do
+      only = described_class.call(bluebook: registry.bluebook("Banking"), options: { aggregate: "Account" })
+
+      expect(only).to start_with("# Account")
+      expect(only).not_to include("## Customer")
+      expect(only).not_to include("## Reactions")
+    end
+
+    it "pushes the headings down so it can be spliced into a larger document" do
+      nested = described_class.call(bluebook: registry.bluebook("Pizzas"), options: { heading: 2 })
+
+      expect(nested).to start_with("## Pizzas")
+      expect(nested).to include("### Order")
+    end
+  end
+
+  describe "as a method on a booted domain" do
+    it "answers on the chapter, beside docs" do
+      boot_in_memory
+
+      expect(Pizzas).to respond_to(:narrate)
+      expect(Pizzas.narrate).to eq(pizzas)
+    end
+
+    it "answers on an aggregate door, narrowed to that head" do
+      boot_in_memory
+
+      expect(Pizzas::Order.narrate).to start_with("# Order")
+      expect(Pizzas::Order.narrate).to include("**CreatePizza**")
+    end
+
+    it "takes the same options the projector does" do
+      boot_in_memory
+
+      expect(Pizzas.narrate(heading: 3)).to start_with("### Pizzas")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds `Hecks::Projector::NarrateProjector`, a new projector that renders a bluebook's IR as prose for a subject-matter expert to read and confirm, rather than as `DocsProjector`'s implementer-facing tables.

- `bin/narrate` (mirrors `bin/docs`)
- Registered as `:narrate` beside `:docs` in the projector registry
- Wired onto `Chapter#narrate` and `AggregateDoor#narrate`, beside `#docs`
- Supports `options[:aggregate]` and `options[:heading]`, same as `:docs`
- Same no-invention guarantee: every sentence quotes a declared `description`/`goal`/`given`

## Notable fixes made along the way
- Uses `Command#acts_on.nil?` rather than `#creates?` to decide whether to render "this is how a new X comes into being" — `#creates?` answers true for every entity verb (per its own doc comment), which would have told an SME that `LedgerEntry.Amend` creates a new ledger entry.
- Renders a where-clause's already-literal-rendered value directly instead of re-`.inspect`ing it, avoiding a doubled-quote artifact (`\"open\"`) present in `DocsProjector`'s own filter rendering.

## Testing
- New `spec/projector/narrate_projector_spec.rb` (24 examples), mirrored off `docs_projector_spec.rb`'s structure
- Full suite: 1839 examples, 0 failures
- `bin/reference` re-run to refresh README's generated tool index
- rubocop clean on all touched files