### PR TITLE
guard_refusals_are_declared follows a door's delegates_to

### DIFF
--- a/lib/hecks/fuzzing/properties.rb
+++ b/lib/hecks/fuzzing/properties.rb
@@ -462,10 +462,12 @@ module Hecks
 
           command = command_for_verb(bluebooks, refusal[:verb])
           next "#{refusal[:verb]} raised #{refusal[:kind]}, but no declared command resolves that verb" unless command
-          next if command.guard_descriptions.include?(match[2])
+
+          declared = effective_guard_descriptions(bluebooks, refusal[:verb], command)
+          next if declared.include?(match[2])
 
           "#{refusal[:verb]} refused — #{match[2].inspect} — but #{command.hecks_name} declares no given " \
-            "or ensures with that description (it declares #{command.guard_descriptions.inspect})"
+            "or ensures with that description (it declares #{declared.inspect})"
         end
 
         offenders.empty? || offenders.join("; ")
@@ -488,6 +490,25 @@ module Hecks
       # refusal read as "no declared command resolves that verb" purely
       # because `history[:bluebook]` was Expression, not Translation; the
       # refusal was real, this property's own domain resolution was not.
+      # A DELEGATING DOOR REFUSES WITH ITS TARGET'S OWN WORDS. `delegates_to`
+      # (CommandBuilder#delegates_to_impl) hands the whole dispatch to one
+      # entity command, and that command's given is what refuses — raised
+      # back through the door, in the door's name (chess: `Game.MoveKnight
+      # refused — "it is that color's turn"`, a given Knight.Move declares
+      # and MoveKnight, a pure passthrough, never could). Read the door's
+      # own guards first, then every delegation target's; an offence is
+      # only a description NEITHER declares. Found live mining chess's
+      # history: every refused move through a door read as undeclared.
+      def effective_guard_descriptions(bluebooks, verb, command)
+        own = command.guard_descriptions
+        delegated = command.mutations.select { |m| m.op == :delegate }.flat_map do |delegation|
+          domain, aggregate_name, = Naming.split_verb(verb)
+          target = command_for_verb(bluebooks, "#{domain}::#{aggregate_name}.#{delegation.target}")
+          target ? target.guard_descriptions : []
+        end
+        own + delegated
+      end
+
       def command_for_verb(bluebooks, verb)
         domain, aggregate_name, command_path = Naming.split_verb(verb)
         return nil unless command_path

--- a/spec/fuzzing/properties_spec.rb
+++ b/spec/fuzzing/properties_spec.rb
@@ -345,6 +345,23 @@ RSpec.describe "Hecks::Fuzzing::Properties" do
       expect(Hecks::Fuzzing::Properties.guard_refusals_are_declared(history)).to eq(true)
     end
 
+    # A `delegates_to` DOOR refuses with its TARGET's own given, in the
+    # door's name — `Roster.Retire` is a pure passthrough to
+    # `Member.Retire`, and "a front-row holder may not retire" is Retire's.
+    # Found live mining chess's history: every refused move through a
+    # door read as undeclared, and no pre-state was admitted.
+    it "guard_refusals_are_declared follows a door's delegates_to to the guards that actually refused" do
+      history = { bluebooks: bluebooks_for(File.join(ROOT_DIR, "examples/roster")),
+                  refusals:  [{ verb:  "Roster::Roster.Retire",
+                                error: "Retire refused — a front-row holder may not retire",
+                                kind:  "Hecks::Runtime::GivenNotMet" }] }
+
+      expect(Hecks::Fuzzing::Properties.guard_refusals_are_declared(history)).to eq(true)
+
+      history[:refusals].first[:error] = "Retire refused — a made up reason"
+      expect(Hecks::Fuzzing::Properties.guard_refusals_are_declared(history)).to include("a made up reason")
+    end
+
     it "guard_refusals_are_declared resolves a refusal against ITS OWN domain, not just the first-loaded one" do
       # THE REAL REGRESSION, pinned exactly as bin/fuzz found it: a
       # domain under fuzz commonly composes more than one bluebook


### PR DESCRIPTION
A `delegates_to` door refuses with its target entity command's given, in the door's name (`Chess::Game.MoveKnight refused — "it is that color's turn"`). `Properties.guard_refusals_are_declared` compared that wording against the door's own guards only, so every refused move through a door read as an undeclared guard — found mining chess's commit history downstream, where it kept every pre-state from ladder admission.

Now: the door's guards plus every delegation target's (`effective_guard_descriptions`); an offence is a description neither declares. Spec: roster's `Roster.Retire` → `Member.Retire`, both directions.

- `rspec spec/fuzzing/properties_spec.rb --tag fuzzing`: 46/0; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc36TdgHxuFhxs5eAjcGXr