### PR TITLE
spec/rust_host_lineage_conformance_spec.rb: capture3, not capture2 — stop swallowing stderr

### DIFF
--- a/spec/rust_host_lineage_conformance_spec.rb
+++ b/spec/rust_host_lineage_conformance_spec.rb
@@ -79,17 +79,25 @@ RSpec.describe "Rust/Ruby lineage parity (rust/host)", io: true do
     admin.close
   end
 
+  # `capture3`, NOT `capture2`, HERE AND BELOW — a real CI failure
+  # (2026-08-26, three merges in a row) raised from `mint_via_rust_
+  # matches_ruby.rb failed` with an EMPTY message: `capture2` only ever
+  # captured stdout, and a crashing script's own reporting goes to
+  # stderr. Reproduced clean locally on the same commit (real Postgres,
+  # a correctly-versioned toolchain) — whatever failed in CI wasn't
+  # this script's own logic, but `capture2`'s own silence left no way
+  # to tell. Whoever hits this next gets the real reason.
   def seed(db_name, owner_role, app_role, script: SEED_SCRIPT)
-    stdout, status = Open3.capture2("ruby", script, db_name, owner_role, app_role)
-    raise "#{File.basename(script)} failed:\n#{stdout}" unless status.success?
+    stdout, stderr, status = Open3.capture3("ruby", script, db_name, owner_role, app_role)
+    raise "#{File.basename(script)} failed:\nstdout:\n#{stdout}\nstderr:\n#{stderr}" unless status.success?
 
     JSON.parse(stdout)
   end
 
   def run_harness(binary, db_name, app_role, domain, era, operations)
     stdin = JSON.generate({ "operations" => operations })
-    stdout, status = Open3.capture2(binary, db_name, app_role, domain, era.to_s, stdin_data: stdin)
-    expect(status).to be_success, "#{binary} exited #{status.exitstatus}:\n#{stdout}"
+    stdout, stderr, status = Open3.capture3(binary, db_name, app_role, domain, era.to_s, stdin_data: stdin)
+    expect(status).to be_success, "#{binary} exited #{status.exitstatus}:\nstdout:\n#{stdout}\nstderr:\n#{stderr}"
 
     JSON.parse(stdout).fetch("results")
   end
@@ -308,8 +316,8 @@ RSpec.describe "Rust/Ruby lineage parity (rust/host)", io: true do
     read_binary = self.class.lineage_harness_binary
     skip "cargo build --bin lineage_harness failed" unless read_binary
 
-    stdout, status = Open3.capture2("ruby", MINT_VIA_RUST_SCRIPT, mint_binary, read_binary)
-    raise "#{File.basename(MINT_VIA_RUST_SCRIPT)} failed:\n#{stdout}" unless status.success?
+    stdout, stderr, status = Open3.capture3("ruby", MINT_VIA_RUST_SCRIPT, mint_binary, read_binary)
+    raise "#{File.basename(MINT_VIA_RUST_SCRIPT)} failed:\nstdout:\n#{stdout}\nstderr:\n#{stderr}" unless status.success?
 
     result = JSON.parse(stdout)
     begin


### PR DESCRIPTION
Three merges in a row on `main` today (2026-08-26) failed "mints the same edge independently in Ruby and in Rust..." with a completely empty error message: `mint_via_rust_matches_ruby.rb failed:` and nothing after it. `Open3.capture2` only ever captures stdout — a script crashing before it prints its own JSON reports the actual reason on stderr, which this raise never saw.

## Investigation

Built `mint_harness`/`lineage_harness` with a correctly-versioned toolchain (the ambient one here was too old for an unrelated aws-sdk dependency bump — a local-only mismatch, not what CI runs), ran `mint_via_rust_matches_ruby.rb` by hand against a real Postgres. It printed clean, byte-identical `ruby_rows`/`rust_rows` on the exact commit CI failed on. Ran the whole file with `:io` enabled — all 5 examples pass.

Whatever failed in CI was not this script's own logic, and none of the three merged PRs (a diagrams feature, a surface-diagram extension, and a README section) touch Rust lineage/mint code at all — but `capture2`'s own silence made that impossible to confirm from the CI log alone.

## Fix

`capture3`, not `capture2`, in all three `Open3.capture2` call sites in this file (`seed`, `run_harness`, and the mint comparison itself) — include both stdout and stderr in the failure message. Whoever hits this next — a real regression or another environment hiccup — gets the actual reason instead of an empty string.

## Verification

No behavior change on the happy path. Full suite: 1876 examples, 0 failures, including all 5 `:io` examples in this file run directly against real Postgres. rubocop: 580 files, 0 offenses.
