### PR TITLE
Add the universal MCP door: dispatch/query/state/catalog/describe/validate

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,6 +2,9 @@
   "mcpServers": {
     "hecks-query-ir": {
       "command": "bin/hecks_query_ir_mcp"
+    },
+    "hecks-door": {
+      "command": "bin/hecks_mcp_door"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ replace.
 | `bin/expression_projection` | The expression machinery's tables, projected from the grammar chapter's admitted set and checked in, so the evaluator and the canonical f... |
 | `bin/fuzz` | Generates random-but-valid command/query sequences from a domain's own IR (Hecks::Fuzzing::SequenceGenerator) and checks each one the way... |
 | `bin/generate` | Prints one randomly generated, valid dispatch sequence for a domain — the same generator bin/fuzz drives, exposed standalone so a sequenc... |
+| `bin/hecks_mcp_door` | THE UNIVERSAL MCP DOOR — one MCP server for EVERY booted domain, not one per command. `docs/hecks-survey-what-we-wish-we-had.md` #1 and `... |
 | `bin/hecks_query_ir_mcp` | AN MCP SERVER exposing Hecks::QueryIR's two queries as tools, so a coding agent calls them directly instead of shelling out to `bin/query... |
 | `bin/history` | Prints every journal entry a domain's append-only adapters hold, as JSON — the full write history, not just the current head. bin/history... |
 | `bin/ir` | Prints a booted domain's IR as JSON — the same `to_h` the golden specs pin and StorageShape hashes into an era, for reading rather than a... |

--- a/bin/hecks_mcp_door
+++ b/bin/hecks_mcp_door
@@ -1,0 +1,217 @@
+#!/usr/bin/env ruby
+
+# THE UNIVERSAL MCP DOOR — one MCP server for EVERY booted domain, not one
+# per command. `docs/hecks-survey-what-we-wish-we-had.md` #1 and
+# `docs/future-features.md`'s own "if we build three" #1 pick: `dispatch /
+# query / state / catalog / describe / validate`, six tools instead of a
+# hand-registered wrapper per verb. All the logic and the JSON shape it
+# answers with live in `Hecks::Facade::McpDoor` (lib/hecks/facade/
+# mcp_door.rb) — this file is JSON-RPC plumbing only, hand-rolled over
+# stdio exactly the way `bin/hecks_query_ir_mcp` already is (no gem
+# dependency; newline-delimited JSON, flushed after every write).
+#
+# EVERY TOOL TAKES `domain:` — a directory containing a `.hecksagon`
+# (`examples/banking`, `examples/pizzas`, …), the same argument `bin/run`
+# takes. An MCP server's cwd is wherever the client launched it from, not
+# necessarily inside a domain, so there is no walking-up-for-.hecksagon
+# default the way `bin/run` has for a human sitting in one already.
+#
+# ONE BOOT PER CALL — `Hecks.boot(domain, install_facade: false)` is cheap
+# (a bluebook is a few hundred lines of Ruby DSL, not a network round
+# trip) and it means one long-lived server process can answer calls
+# against two different domains back to back with no shared, staling
+# state between them.
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "hecks"
+require "json"
+
+$stdout.sync = true
+
+PROTOCOL_VERSION = "2024-11-05"
+
+SUMMARY_PROPERTY = {
+  type:        "string",
+  description: "One line: why this call is happening. Required — it is what makes the audit trail legible later."
+}.freeze
+
+DOMAIN_PROPERTY = {
+  type:        "string",
+  description: "The domain directory, containing a .hecksagon (e.g. \"examples/banking\")."
+}.freeze
+
+ARGS_PROPERTY = {
+  type:        "object",
+  description: "The command/query's declared arguments, nested value-object literals included " \
+               "(e.g. {\"reference\":{\"value\":\"BUG#1\"}})."
+}.freeze
+
+TOOLS = [
+  {
+    name:        "dispatch",
+    description: "Issue a command against a booted domain. `command` is the short or qualified verb name " \
+                 "(bin/docs or the catalog/describe tools show what's available). Answers the record's id, " \
+                 "its resulting state, and the events it announced — or a structured refusal, never a crash.",
+    inputSchema: {
+      type:       "object",
+      properties: {
+        domain:  DOMAIN_PROPERTY,
+        command: { type: "string", description: "The command's short or qualified name, e.g. \"open_account\"." },
+        args:    ARGS_PROPERTY,
+        summary: SUMMARY_PROPERTY
+      },
+      required:   %w[domain command summary]
+    }
+  },
+  {
+    name:        "query",
+    description: "Ask a declared question of a booted domain. `question` is the short or qualified query name. " \
+                 "Answers the row array the query itself declares.",
+    inputSchema: {
+      type:       "object",
+      properties: {
+        domain:   DOMAIN_PROPERTY,
+        question: { type: "string", description: "The query's short or qualified name." },
+        args:     ARGS_PROPERTY,
+        summary:  SUMMARY_PROPERTY
+      },
+      required:   %w[domain question summary]
+    }
+  },
+  {
+    name:        "state",
+    description: "Read what an aggregate actually has stored, no verb involved. Pass `id` for one record; " \
+                 "omit it to list every record the aggregate currently holds.",
+    inputSchema: {
+      type:       "object",
+      properties: {
+        domain:    DOMAIN_PROPERTY,
+        aggregate: { type: "string", description: "The aggregate's name, e.g. \"Account\"." },
+        id:        { type: "string", description: "A specific record's id. Omit to list every record." },
+        summary:   SUMMARY_PROPERTY
+      },
+      required:   %w[domain aggregate summary]
+    }
+  },
+  {
+    name:        "catalog",
+    description: "Zoom level one: every aggregate a domain declares, and every command/query name each " \
+                 "answers to. No summary needed — this changes nothing and commits nothing to any log.",
+    inputSchema: {
+      type:       "object",
+      properties: { domain: DOMAIN_PROPERTY },
+      required:   %w[domain]
+    }
+  },
+  {
+    name:        "describe",
+    description: "Zoom level two: one aggregate's full contract — every command's arguments, the states it " \
+                 "may be issued from, and every way it can refuse. Omit `aggregate` for the whole domain.",
+    inputSchema: {
+      type:       "object",
+      properties: {
+        domain:    DOMAIN_PROPERTY,
+        aggregate: { type: "string", description: "Narrow to one aggregate. Omit for the whole domain." }
+      },
+      required:   %w[domain]
+    }
+  },
+  {
+    name:        "validate",
+    description: "Zoom level three: is this domain's wiring sound — every bind names a declared aggregate, " \
+                 "every adapter satisfies its port, the default adapter is usable. {valid:false, error:…} " \
+                 "on a real wiring defect, never a bare crash.",
+    inputSchema: {
+      type:       "object",
+      properties: { domain: DOMAIN_PROPERTY },
+      required:   %w[domain]
+    }
+  }
+].freeze
+
+def boot(domain) = Hecks.boot(domain, install_facade: false)
+
+def call_tool(name, a)
+  case name
+  when "dispatch"
+    Hecks::Facade::McpDoor.dispatch(runtime: boot(a["domain"]), command: a["command"],
+                                    summary: a["summary"], args: a["args"] || {})
+  when "query"
+    Hecks::Facade::McpDoor.query(runtime: boot(a["domain"]), question: a["question"],
+                                 summary: a["summary"], args: a["args"] || {})
+  when "state"
+    Hecks::Facade::McpDoor.state(runtime: boot(a["domain"]), aggregate: a["aggregate"],
+                                 summary: a["summary"], id: a["id"])
+  when "catalog"
+    Hecks::Facade::McpDoor.catalog(runtime: boot(a["domain"]))
+  when "describe"
+    Hecks::Facade::McpDoor.describe(runtime: boot(a["domain"]), aggregate: a["aggregate"])
+  when "validate"
+    Hecks::Facade::McpDoor.validate(domain: a["domain"])
+  else
+    { ok: false, error: "no such tool: #{name.inspect} — known: #{TOOLS.map { |t| t[:name] }.join(', ')}" }
+  end
+rescue StandardError => e
+  # A DEFECT, NOT A REFUSAL — every DOMAIN refusal is already caught inside
+  # `McpDoor` itself and answered as `{ok: false, error: "..."}`. Reaching
+  # here means something this door did not anticipate (a bad domain path,
+  # a malformed argument shape `JsonDoor` couldn't symbolize) — still
+  # answered as structured content rather than an MCP-level `isError`, so
+  # a calling agent reads one shape for every outcome.
+  { ok: false, error: "#{e.class}: #{e.message}" }
+end
+
+def tool_result(payload)
+  { content: [{ type: "text", text: JSON.pretty_generate(payload) }], isError: payload[:ok] == false }
+end
+
+def send_response(id, result)
+  puts JSON.generate({ jsonrpc: "2.0", id: id, result: result })
+end
+
+def send_error(id, code, message)
+  puts JSON.generate({ jsonrpc: "2.0", id: id, error: { code: code, message: message } })
+end
+
+def handle(request)
+  id     = request["id"]
+  method = request["method"]
+  params = request["params"] || {}
+
+  case method
+  when "initialize"
+    send_response(id, {
+                    protocolVersion: PROTOCOL_VERSION,
+                    capabilities:    { tools: {} },
+                    serverInfo:      { name: "hecks-mcp-door", version: "1.0.0" }
+                  })
+  when "notifications/initialized"
+    nil # a notification — no id, no response
+  when "tools/list"
+    send_response(id, { tools: TOOLS })
+  when "tools/call"
+    send_response(id, tool_result(call_tool(params["name"], params["arguments"] || {})))
+  when "ping"
+    send_response(id, {})
+  else
+    send_error(id, -32_601, "Method not found: #{method}") unless id.nil?
+  end
+end
+
+$stdin.each_line do |line|
+  line = line.strip
+  next if line.empty?
+
+  begin
+    request = JSON.parse(line)
+  rescue JSON::ParserError => e
+    send_error(nil, -32_700, "Parse error: #{e.message}")
+    next
+  end
+
+  begin
+    handle(request)
+  rescue StandardError => e
+    send_error(request["id"], -32_603, "Internal error: #{e.class}: #{e.message}")
+  end
+end

--- a/lib/hecks.rb
+++ b/lib/hecks.rb
@@ -31,6 +31,7 @@ require_relative "hecks/projections"
 # `Ports::Clock` (fills a staleness rule's `now` at the door) both exist.
 require_relative "hecks/facade/cli_door"
 require_relative "hecks/facade/cli_runner"
+require_relative "hecks/facade/mcp_door"
 require_relative "hecks/framework"
 require_relative "hecks/embryonaut_bluebook"
 

--- a/lib/hecks/facade/mcp_door.rb
+++ b/lib/hecks/facade/mcp_door.rb
@@ -1,0 +1,215 @@
+require_relative "command_request"
+require_relative "json_door"
+require_relative "../naming"
+require_relative "../projector"
+require_relative "../runtime/errors"
+
+module Hecks
+  module Facade
+    # THE UNIVERSAL MCP DOOR — one door onto every domain, not one tool per
+    # verb. `docs/hecks-survey-what-we-wish-we-had.md` and
+    # `docs/future-features.md` both name this the single highest-priority
+    # gap against the sibling project's ten-tool Storehouse MCP: "no
+    # per-command tool... the bluebook IS the contract, the MCP layer just
+    # projects it." This is that projection, at six tools instead of ten —
+    # `macrophage_check`/`behaviors`/`conceive_behaviors` are that project's
+    # own governed-door and behaviour-generation machinery, which this repo
+    # has no equivalent of yet.
+    #
+    # THREE ZOOM LEVELS, the survey's own framing:
+    #   catalog  — what aggregates a domain declares, and what each can do
+    #   describe — one aggregate's full command/query/refusal contract
+    #   validate — is this domain's wiring sound at all
+    # …and three ways to actually DRIVE it:
+    #   dispatch — issue a command
+    #   query    — ask a question
+    #   state    — read what is actually stored, no verb involved
+    #
+    # `dispatch`/`query`/`state` EACH REQUIRE A `summary` — the survey's
+    # "every audit row carries human intent for free". `catalog`/`describe`/
+    # `validate` do not: they change nothing and commit nothing to any log,
+    # so there is no audit row for a summary to attach to.
+    #
+    # A CALLER HANDS IN AN ALREADY-BOOTED `runtime`, the same division of
+    # labor `Facade::CliRunner` already keeps against `bin/run`: booting a
+    # domain from a path is IO the calling `bin/` script owns, this stays a
+    # pure function of a `Runtime::Dispatcher` plus plain Ruby arguments, no
+    # different from `CliRunner.call(runtime:, argv:)` itself. `validate` is
+    # the one exception — its whole job is to attempt the boot and report
+    # whether it survived, so it takes the domain PATH instead and boots it.
+    #
+    # NO NEW VOCABULARY otherwise. Every method here composes doors that
+    # already exist — `Projector.call(:cli, ...)` for verb/question alias
+    # resolution (the identical table `CliRunner` itself resolves against),
+    # `Projector.call(:docs, ...)` for `describe`, `JsonDoor` for the
+    # JSON↔Runtime::Value boundary, `Registry#repository` for `state`,
+    # `Registry#verify!` (run at boot by `Runtime::Loader.boot`) for
+    # `validate`. A second copy of "how do I find a command by its short
+    # name" here would be the exact duplication `JsonDoor`'s own header
+    # already warns against.
+    module McpDoor
+      module_function
+
+      # THE ONE BLUEBOOK A DOMAIN DIRECTORY BOOTS. Every `bin/*` script that
+      # projects a whole-domain CLI or doc set makes this same assumption
+      # (`Facade::CliRunner#call`'s own `bluebook = runtime.registry.
+      # bluebooks.values.first`) — one `.hecksagon` names one chapter.
+      def bluebook_for(runtime)
+        runtime.registry.bluebooks.values.first or
+          raise Runtime::NotFound, "this boot loaded no bluebook"
+      end
+
+      def aggregate_ir!(bluebook, name)
+        bluebook.aggregate(name) or
+          raise Runtime::NotFound, "#{bluebook.name} declares no aggregate named #{name.inspect} — " \
+                                   "known: #{bluebook.aggregates.map(&:hecks_name).sort.join(', ')}"
+      end
+
+      # THE SAME ALIAS TABLE `CliRunner` RESOLVES A TYPED WORD AGAINST — a
+      # short name when it's unambiguous, the qualified `Aggregate.Verb`
+      # form always. Shared here so `dispatch` and `query` (and their error
+      # messages) never drift from what a human typing `bin/run` sees.
+      def resolve!(cli, name, asking:)
+        pool = asking ? cli[:questions] : cli[:verbs]
+        key  = cli[:names][asking ? :question : :command][name]
+        spec = pool[key]
+        return spec if spec
+
+        known = cli[:names][asking ? :question : :command].keys.sort.join(", ")
+        raise Runtime::NotFound, "no such #{asking ? 'query' : 'command'}: #{name.inspect} — known: #{known}"
+      end
+
+      def require_summary!(summary)
+        return unless summary.nil? || summary.to_s.strip.empty?
+
+        raise Runtime::TypeMismatch,
+              "a one-line summary: is required on dispatch/query/state — it is what makes an audit row legible later"
+      end
+
+      # ── the three that drive it ────────────────────────────────────────
+
+      def dispatch(runtime:, command:, summary:, args: {})
+        require_summary!(summary)
+        cli     = Projector.call(:cli, bluebook: bluebook_for(runtime), options: { program: "mcp" })
+        spec    = resolve!(cli, command, asking: false)
+        request = CommandRequest.normalize(JsonDoor.deep_symbolize(args),
+                                           receiver:        spec[:receiver],
+                                           legacy_receiver: spec[:legacy_receiver])
+        result = runtime.dispatch(spec[:verb], **request)
+
+        ok(summary: summary,
+           id:      result.id,
+           state:   result.state.nil? ? nil : JsonDoor.materialize(result.state),
+           events:  result.events.map { |event| { name: event.name, payload: JsonDoor.materialize(event.payload) } })
+      rescue *refusal_classes => e
+        refused(e, summary: summary)
+      end
+
+      def query(runtime:, question:, summary:, args: {})
+        require_summary!(summary)
+        cli  = Projector.call(:cli, bluebook: bluebook_for(runtime), options: { program: "mcp" })
+        spec = resolve!(cli, question, asking: true)
+        rows = runtime.query(spec[:verb], **JsonDoor.deep_symbolize(args))
+
+        ok(summary: summary, rows: rows.map { |row| JsonDoor.materialize(row) })
+      rescue *refusal_classes => e
+        refused(e, summary: summary)
+      end
+
+      # WHAT IS ACTUALLY STORED — no verb, no interpretation, the repository
+      # itself. `id:` given answers one record (`NotFound` when it names
+      # nothing); omitted answers every record the aggregate currently
+      # holds. This is the difference `query` can't cover: a query answers a
+      # DECLARED question, and an aggregate that never declared "list
+      # everything" has no query this could reuse.
+      def state(runtime:, aggregate:, summary:, id: nil)
+        require_summary!(summary)
+        bluebook   = bluebook_for(runtime)
+        ir         = aggregate_ir!(bluebook, aggregate)
+        repository = runtime.registry.repository(bluebook.name, ir)
+
+        if id
+          instance = repository.find(id) or
+            raise Runtime::NotFound, "no #{ir.hecks_name} found for id #{id.inspect}"
+          ok(summary: summary, record: JsonDoor.materialize(instance.to_h))
+        else
+          records = repository.all.map { |instance| JsonDoor.materialize(instance.to_h) }
+          ok(summary: summary, count: records.length, records: records)
+        end
+      rescue *refusal_classes => e
+        refused(e, summary: summary)
+      end
+
+      # ── the three zoom levels ───────────────────────────────────────────
+
+      # ZOOM LEVEL ONE — every aggregate this domain declares, and every
+      # command/query name each answers to, snake_cased exactly as
+      # `dispatch`/`query` want it. Enough to pick a target; `describe` is
+      # the next level down for what one of them actually takes.
+      def catalog(runtime:)
+        bluebook = bluebook_for(runtime)
+
+        ok(domain:     bluebook.name,
+           aggregates: bluebook.aggregates.map do |aggregate|
+             { name:     aggregate.hecks_name,
+               commands: aggregate.commands.map { |c| "#{Naming.snake(c.hecks_name)}!" }.sort,
+               queries:  aggregate.queries.map { |q| Naming.snake(q.hecks_name) }.sort }
+           end)
+      rescue *refusal_classes => e
+        refused(e)
+      end
+
+      # ZOOM LEVEL TWO — the exact same usage document a human gets from
+      # `bin/docs <domain> [aggregate]` (`Projector::DocsProjector`, the
+      # identical projection `Surface::AggregateDoor#docs` calls one door
+      # over): every command's arguments, the states it may be issued
+      # from, and every way it can refuse. `aggregate:` omitted answers the
+      # whole chapter.
+      def describe(runtime:, aggregate: nil)
+        bluebook = bluebook_for(runtime)
+        options  = aggregate ? { aggregate: aggregate_ir!(bluebook, aggregate).hecks_name } : {}
+
+        ok(domain: bluebook.name, docs: Projector.call(:docs, bluebook: bluebook, options: options))
+      rescue *refusal_classes => e
+        refused(e)
+      end
+
+      # ZOOM LEVEL THREE — is the wiring sound at all: every bind names a
+      # declared aggregate, every adapter satisfies the port it claims, the
+      # default adapter is usable. `Registry#verify!` (`runtime/registry/
+      # verification.rb`) is the one place this repo already answers that
+      # question, and `Runtime::Loader.boot` already calls it as the last
+      # step of every boot — so THIS is the one method here that boots for
+      # itself rather than taking a `runtime:` already in hand, because a
+      # runtime that successfully reached this line already answered the
+      # question. Given a domain PATH, not a booted runtime, deliberately:
+      # asking "is this valid" about a domain that failed to boot at all
+      # has to be askable without a runtime to hand it.
+      #
+      # ANY BOOT FAILURE ANSWERS THE QUESTION, not only `WiringError` — a
+      # domain path with no `.hecksagon`, a malformed bluebook, is just as
+      # much "not valid" as a real wiring mismatch, and this tool exists
+      # precisely so none of those ever cross the MCP boundary as a crash.
+      def validate(domain:)
+        Hecks.boot(domain, install_facade: false)
+        { ok: true, domain: domain, valid: true }
+      rescue StandardError => e
+        { ok: false, domain: domain, valid: false, error: "#{e.class}: #{e.message}" }
+      end
+
+      # ── shared shape ────────────────────────────────────────────────────
+
+      def refusal_classes = [Runtime::NotFound, Runtime::TypeMismatch, *Runtime::DOMAIN_REFUSALS]
+
+      def ok(**fields) = { ok: true }.merge(fields)
+
+      # AN HONEST REFUSAL, NOT A CRASH — the survey's own item #9: "an
+      # explicit, structured refusal a caller can act on" rather than a
+      # stack trace an agent has to parse to find the one line that
+      # mattered. The domain's own refusal text travels verbatim
+      # (`RefusalWording` already renders every one of these to be read),
+      # this only wraps it consistently.
+      def refused(error, summary: nil) = { ok: false, summary: summary, error: error.message }
+    end
+  end
+end

--- a/spec/facade/mcp_door_spec.rb
+++ b/spec/facade/mcp_door_spec.rb
@@ -1,0 +1,167 @@
+require "spec_helper"
+
+# THE UNIVERSAL MCP DOOR — dispatch/query/state/catalog/describe/validate,
+# projected off the SAME machinery `CliRunner`/`JsonDoor` already use, so
+# these specs prove composition rather than re-deriving verb resolution or
+# JSON materialization from scratch.
+RSpec.describe Hecks::Facade::McpDoor do
+  let(:runtime) { boot_in_memory }
+  let(:pizza_args) do
+    { name: { value: "Margherita" }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } } }
+  end
+
+  describe ".dispatch" do
+    it "issues the command and answers the record's id, state, and events" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza",
+                                        summary: "spec", args: pizza_args)
+
+      expect(result[:ok]).to be true
+      expect(result[:id]).to eq("Margherita")
+      expect(result[:state][:status]).to eq("available")
+      expect(result[:events].map { |e| e[:name] }).to eq(["PizzaCreated"])
+    end
+
+    it "resolves the qualified form identically to the short form" do
+      short      = described_class.dispatch(runtime: runtime, command: "create_pizza",
+                                            summary: "spec", args: pizza_args)
+      qualified  = described_class.dispatch(runtime: runtime, command: "order.create_pizza", summary: "spec",
+                                            args: pizza_args.merge(name: { value: "Diavola" }))
+
+      expect(short[:ok]).to be true
+      expect(qualified[:ok]).to be true
+    end
+
+    it "refuses a summary-less call rather than dispatching" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "", args: pizza_args)
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("summary")
+      expect(runtime.events).to be_empty
+    end
+
+    it "answers a structured refusal, not a raised error, for an unknown command" do
+      result = described_class.dispatch(runtime: runtime, command: "no_such_command", summary: "spec")
+
+      expect(result[:ok]).to be false
+      expect(result[:summary]).to eq("spec")
+      expect(result[:error]).to include("no such command")
+    end
+
+    it "answers a structured refusal for a domain rule violation" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "order.add_topping", summary: "spec",
+                               args: { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } })
+      purchase_args = { to: "Margherita", amount: { cents: 1200 }, customer_name: { value: "Alex" } }
+      sold           = described_class.dispatch(runtime: runtime, command: "order.purchase", summary: "spec",
+                                                args: purchase_args)
+      purchase_again = described_class.dispatch(runtime: runtime, command: "order.purchase", summary: "spec",
+                                                args: purchase_args)
+
+      expect(sold[:ok]).to be true
+      expect(purchase_again[:ok]).to be false
+      expect(purchase_again[:error]).to be_a(String)
+    end
+  end
+
+  describe ".query" do
+    it "answers the declared question's rows" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+
+      result = described_class.query(runtime: runtime, question: "available", summary: "spec")
+
+      expect(result[:ok]).to be true
+      expect(result[:rows].map { |row| row[:id] }).to eq(["Margherita"])
+    end
+
+    it "refuses an unknown question" do
+      result = described_class.query(runtime: runtime, question: "no_such_question", summary: "spec")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("no such query")
+    end
+  end
+
+  describe ".state" do
+    before { described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args) }
+
+    it "answers every record when id is omitted" do
+      result = described_class.state(runtime: runtime, aggregate: "Order", summary: "spec")
+
+      expect(result[:ok]).to be true
+      expect(result[:count]).to eq(1)
+      expect(result[:records].first[:id]).to eq("Margherita")
+    end
+
+    it "answers one record when id is given" do
+      result = described_class.state(runtime: runtime, aggregate: "Order", id: "Margherita", summary: "spec")
+
+      expect(result[:ok]).to be true
+      expect(result[:record][:id]).to eq("Margherita")
+    end
+
+    it "refuses an id that names no record" do
+      result = described_class.state(runtime: runtime, aggregate: "Order", id: "Nope", summary: "spec")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("no Order found")
+    end
+
+    it "refuses an aggregate the domain never declared" do
+      result = described_class.state(runtime: runtime, aggregate: "Calzone", summary: "spec")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("declares no aggregate")
+    end
+  end
+
+  describe ".catalog" do
+    it "lists every aggregate and the commands/queries each answers to" do
+      result = described_class.catalog(runtime: runtime)
+
+      expect(result[:ok]).to be true
+      expect(result[:domain]).to eq("Pizzas")
+      order = result[:aggregates].find { |a| a[:name] == "Order" }
+      expect(order[:commands]).to include("create_pizza!", "purchase!")
+      expect(order[:queries]).to include("available")
+    end
+  end
+
+  describe ".describe" do
+    it "answers the whole chapter's usage document when aggregate is omitted" do
+      result = described_class.describe(runtime: runtime)
+
+      expect(result[:ok]).to be true
+      expect(result[:docs]).to include("Order")
+    end
+
+    it "narrows to one aggregate's contract" do
+      result = described_class.describe(runtime: runtime, aggregate: "Order")
+
+      expect(result[:ok]).to be true
+      expect(result[:docs]).to include("CreatePizza")
+    end
+
+    it "refuses an aggregate the domain never declared" do
+      result = described_class.describe(runtime: runtime, aggregate: "Calzone")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("declares no aggregate")
+    end
+  end
+
+  describe ".validate" do
+    it "answers valid: true for a domain whose wiring boots cleanly" do
+      result = described_class.validate(domain: "examples/pizzas")
+
+      expect(result).to eq(ok: true, domain: "examples/pizzas", valid: true)
+    end
+
+    it "answers valid: false, never a raised error, for a domain that cannot boot" do
+      result = described_class.validate(domain: "examples/no_such_domain")
+
+      expect(result[:ok]).to be false
+      expect(result[:valid]).to be false
+      expect(result[:error]).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
Builds the #1 pick from `docs/future-features.md`'s "if we build three" and item #1 in `docs/hecks-survey-what-we-wish-we-had.md`: one MCP door onto every domain instead of a hand-registered tool per command.

## Six tools, three zoom levels + three ways to drive it

- **`catalog`** — every aggregate a domain declares, and every command/query name each answers to
- **`describe`** — one aggregate's (or the whole chapter's) full contract, via the same `Projector.call(:docs, ...)` a human gets from `bin/docs`
- **`validate`** — does this domain's wiring boot cleanly at all
- **`dispatch`** — issue a command
- **`query`** — ask a declared question
- **`state`** — read what's actually stored, no verb involved (`id:` given → one record, omitted → every record)

`dispatch`/`query`/`state` each require a `summary:` — an audit row's human intent, for free. `catalog`/`describe`/`validate` don't, since they change nothing.

## Design

No new vocabulary — every tool composes doors that already exist: `Projector.call(:cli, ...)` for verb/question alias resolution (the identical table `CliRunner` resolves against), `JsonDoor` for the JSON↔`Runtime::Value` boundary, `Registry#repository` for `state`, `Registry#verify!` for `validate`. Every domain refusal answers as structured `{ok: false, error: "..."}`, never a raised error crossing the MCP boundary.

`lib/hecks/facade/mcp_door.rb` holds all the logic and takes an already-booted `runtime:` (except `validate`, whose whole job is attempting the boot) — the same division of labor `CliRunner` already keeps against `bin/run`. `bin/hecks_mcp_door` is JSON-RPC plumbing only, hand-rolled over stdio in the same shape `bin/hecks_query_ir_mcp` already uses. Registered in `.mcp.json` as `hecks-door`.

## Testing

`spec/facade/mcp_door_spec.rb` — 17 examples against `boot_in_memory`, covering every tool's success and refusal paths. Full suite green, fuzzer green, rubocop clean (pre-push hooks all passed).

## Found and left alone (pre-existing, out of scope)

`CliProjector#port_spec` calls a `module_function`-private `receiver_options` from the wrong scope, breaking `dispatch`/`query` for any domain that declares a `port` — currently only Pizzas in this corpus. Reproduces on plain `bin/run` with no `McpDoor` involved. `catalog`/`describe`/`validate` are unaffected (they never call the `:cli` projection), and every other domain (Banking) dispatches/queries cleanly through this door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)