### PR TITLE
Add bin/follow: live tail of a domain's append-only journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ replace.
 | `bin/docs` | A domain's usage document, projected from its own bluebook. bin/docs # list every domain in this checkout bin/docs examples/banking # the... |
 | `bin/evolve` | The language-change convention, made executable. Adding a word to the bluebook surface has always been a many-file walk — syntax row, Rub... |
 | `bin/expression_projection` | The expression machinery's tables, projected from the grammar chapter's admitted set and checked in, so the evaluator and the canonical f... |
+| `bin/follow` | Live-tails a domain's append-only journal — the same data bin/history dumps statically, streamed as new entries land instead of read once... |
 | `bin/fuzz` | Generates random-but-valid command/query sequences from a domain's own IR (Hecks::Fuzzing::SequenceGenerator) and checks each one the way... |
 | `bin/generate` | Prints one randomly generated, valid dispatch sequence for a domain — the same generator bin/fuzz drives, exposed standalone so a sequenc... |
 | `bin/hecks_query_ir_mcp` | AN MCP SERVER exposing Hecks::QueryIR's two queries as tools, so a coding agent calls them directly instead of shelling out to `bin/query... |

--- a/bin/follow
+++ b/bin/follow
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+
+# Live-tails a domain's append-only journal — the same data bin/history
+# dumps statically, streamed as new entries land instead of read once.
+#
+# AppendOnly (lib/hecks/ports/persistence/append_only.rb) has no
+# subscribe/notify hook — every adapter (Postgres/Sqlite/D1/Memory/heki)
+# only supports pull (`entries`, `count`). So this polls: each aggregate's
+# `entries` array is append-only and ordered, so a per-aggregate "entries
+# seen so far" count is enough to diff without re-printing anything —
+# the same mtime-diff-on-a-poll-loop shape as any file watcher, just
+# diffing an array length instead of an mtime.
+#
+# One JSON object per line (JSONL), so this composes with jq/grep the
+# way bin/history's single blob deliberately does not.
+#
+#   bin/follow <domain> [--aggregate NAME] [--interval SECONDS] [--from-now]
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "hecks"
+require "json"
+require "optparse"
+
+domain_name = ARGV.shift or abort "usage: bin/follow <domain> [options]"
+
+options = { interval: 0.5, from_now: false }
+
+OptionParser.new do |parser|
+  parser.banner = "usage: bin/follow <domain> [options]"
+  parser.on("-a", "--aggregate=NAME", "Only follow this aggregate (storage name)") { |v| options[:aggregate] = v }
+  parser.on("-i", "--interval=SECONDS", Float, "Poll interval in seconds (default: 0.5)") { |v| options[:interval] = v }
+  parser.on("--from-now", "Skip existing entries; only print ones appended from now on") { options[:from_now] = true }
+end.parse!(ARGV)
+
+runtime = Hecks.boot(domain_name)
+
+# storage_name => [repository, entries already printed]
+watched = runtime.registry.bluebooks.each_with_object({}) do |(bluebook_domain, bluebook), all|
+  bluebook.aggregates.each do |aggregate|
+    next if options[:aggregate] && aggregate.storage_name != options[:aggregate]
+
+    repository = runtime.registry.repository(bluebook_domain, aggregate)
+    next unless repository.is_a?(Hecks::Ports::Persistence::AppendOnly)
+
+    seen = options[:from_now] ? repository.entries.size : 0
+    all[aggregate.storage_name] = [repository, seen]
+  end
+end
+
+abort "bin/follow: no matching append-only aggregates in #{domain_name}" if watched.empty?
+
+$stdout.sync = true
+trap("INT") { exit }
+
+loop do
+  watched.each do |storage_name, (repository, seen)|
+    entries = repository.entries
+    next if entries.size <= seen
+
+    entries[seen..].each do |entry|
+      puts JSON.generate(
+        "aggregate" => storage_name,
+        "operation" => entry.operation,
+        "id" => entry.id,
+        "state" => entry.state
+      )
+    end
+    watched[storage_name][1] = entries.size
+  end
+
+  sleep options[:interval]
+end

--- a/bin/follow
+++ b/bin/follow
@@ -62,8 +62,8 @@ loop do
       puts JSON.generate(
         "aggregate" => storage_name,
         "operation" => entry.operation,
-        "id" => entry.id,
-        "state" => entry.state
+        "id"        => entry.id,
+        "state"     => entry.state
       )
     end
     watched[storage_name][1] = entries.size


### PR DESCRIPTION
Adds `bin/follow` — a live tail of a domain's append-only event journal, the same data `bin/history` dumps statically but streamed as new entries land.

## Why
Implements item 2 of `docs/hecks-survey-what-we-wish-we-had.md`'s "if we build three": *"`follow` + `SourceTag` — persist the dispatch stream we already emit... add a JSONL tail and a `bin/follow`."*

## How
`AppendOnly` (`lib/hecks/ports/persistence/append_only.rb`) has no subscribe/notify hook — every adapter only supports pull (`entries`, `count`). So this polls each watched aggregate's `entries` and diffs against a last-seen count, printing only what's new — the same mtime-diff-on-a-poll-loop shape as a file watcher, just diffing an array length instead of an mtime.

```
bin/follow <domain> [--aggregate NAME] [--interval SECONDS] [--from-now]
```

- Default: replays existing entries first, then follows (like `tail -f`)
- `--from-now`: skip existing entries, only print what's appended after start (`tail -n0 -f`)
- `--aggregate`: narrow to one aggregate's journal by storage name
- Output is JSONL (one line per entry), so it composes with `jq`/`grep`, unlike `bin/history`'s single JSON blob

Verified live end-to-end against `examples/pizzas` (real Postgres-backed domain): started `bin/follow --from-now`, dispatched `Pizzas::Order.CreatePizza` via `bin/run` from a separate process, confirmed the new entry streamed out within one poll cycle. Also confirmed default mode replays existing history first.

README's generated bin/ tools index was regenerated via `bin/reference` to include the new script (caught by `spec/reference_golden_spec.rb`).