### PR TITLE
Extend the MCP door: dry_run, batch, source, deep validate, domains, history, behaviors, follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ replace.
 | `bin/expression_projection` | The expression machinery's tables, projected from the grammar chapter's admitted set and checked in, so the evaluator and the canonical f... |
 | `bin/fuzz` | Generates random-but-valid command/query sequences from a domain's own IR (Hecks::Fuzzing::SequenceGenerator) and checks each one the way... |
 | `bin/generate` | Prints one randomly generated, valid dispatch sequence for a domain — the same generator bin/fuzz drives, exposed standalone so a sequenc... |
-| `bin/hecks_mcp_door` | THE UNIVERSAL MCP DOOR — one MCP server for EVERY booted domain, not one per command. `docs/hecks-survey-what-we-wish-we-had.md` #1 and `... |
+| `bin/hecks_mcp_door` | THE UNIVERSAL MCP DOOR — one MCP server for EVERY booted domain, not one per command. `docs/hecks-survey-what-we-wish-we-had.md` and `doc... |
 | `bin/hecks_query_ir_mcp` | AN MCP SERVER exposing Hecks::QueryIR's two queries as tools, so a coding agent calls them directly instead of shelling out to `bin/query... |
 | `bin/history` | Prints every journal entry a domain's append-only adapters hold, as JSON — the full write history, not just the current head. bin/history... |
 | `bin/ir` | Prints a booted domain's IR as JSON — the same `to_h` the golden specs pin and StorageShape hashes into an era, for reading rather than a... |

--- a/bin/hecks_mcp_door
+++ b/bin/hecks_mcp_door
@@ -1,20 +1,24 @@
 #!/usr/bin/env ruby
 
 # THE UNIVERSAL MCP DOOR — one MCP server for EVERY booted domain, not one
-# per command. `docs/hecks-survey-what-we-wish-we-had.md` #1 and
-# `docs/future-features.md`'s own "if we build three" #1 pick: `dispatch /
-# query / state / catalog / describe / validate`, six tools instead of a
-# hand-registered wrapper per verb. All the logic and the JSON shape it
-# answers with live in `Hecks::Facade::McpDoor` (lib/hecks/facade/
-# mcp_door.rb) — this file is JSON-RPC plumbing only, hand-rolled over
-# stdio exactly the way `bin/hecks_query_ir_mcp` already is (no gem
-# dependency; newline-delimited JSON, flushed after every write).
+# per command. `docs/hecks-survey-what-we-wish-we-had.md` and
+# `docs/future-features.md`'s own "if we build three" #1 pick, extended
+# past the original six tools with the rest of that same survey's ranked
+# wishlist: `dispatch` (with `dry_run`/`steps`/`source`), `query`, `state`,
+# `catalog`, `describe`, `validate` (with `deep`), `domains`, `history`,
+# `behaviors`, `follow`. All the logic and the JSON shape it answers with
+# live in `Hecks::Facade::McpDoor` (lib/hecks/facade/mcp_door.rb) — this
+# file is JSON-RPC plumbing only, hand-rolled over stdio exactly the way
+# `bin/hecks_query_ir_mcp` already is (no gem dependency; newline-delimited
+# JSON, flushed after every write).
 #
-# EVERY TOOL TAKES `domain:` — a directory containing a `.hecksagon`
-# (`examples/banking`, `examples/pizzas`, …), the same argument `bin/run`
-# takes. An MCP server's cwd is wherever the client launched it from, not
-# necessarily inside a domain, so there is no walking-up-for-.hecksagon
-# default the way `bin/run` has for a human sitting in one already.
+# EVERY DOMAIN-SCOPED TOOL TAKES `domain:` — a directory containing a
+# `.hecksagon` (`examples/banking`, `examples/pizzas`, …), the same
+# argument `bin/run` takes. An MCP server's cwd is wherever the client
+# launched it from, not necessarily inside a domain, so there is no
+# walking-up-for-.hecksagon default the way `bin/run` has for a human
+# sitting in one already — `domains` exists precisely so a caller who
+# doesn't already know a path can find one.
 #
 # ONE BOOT PER CALL — `Hecks.boot(domain, install_facade: false)` is cheap
 # (a bluebook is a few hundred lines of Ruby DSL, not a network round
@@ -37,7 +41,8 @@ SUMMARY_PROPERTY = {
 
 DOMAIN_PROPERTY = {
   type:        "string",
-  description: "The domain directory, containing a .hecksagon (e.g. \"examples/banking\")."
+  description: "The domain directory, containing a .hecksagon (e.g. \"examples/banking\"). The `domains` tool " \
+               "lists what's available."
 }.freeze
 
 ARGS_PROPERTY = {
@@ -46,21 +51,43 @@ ARGS_PROPERTY = {
                "(e.g. {\"reference\":{\"value\":\"BUG#1\"}})."
 }.freeze
 
+SOURCE_PROPERTY = {
+  type:        "string",
+  enum:        Hecks::Facade::McpDoor::SOURCE_TAGS,
+  description: "Optional: who is calling, for the audit log `follow` reads back."
+}.freeze
+
 TOOLS = [
   {
     name:        "dispatch",
-    description: "Issue a command against a booted domain. `command` is the short or qualified verb name " \
-                 "(bin/docs or the catalog/describe tools show what's available). Answers the record's id, " \
-                 "its resulting state, and the events it announced — or a structured refusal, never a crash.",
+    description: "Issue a command against a booted domain — or, with `steps`, several in one call. `command` is " \
+                 "the short or qualified verb name (the catalog/describe tools show what's available). Set " \
+                 "`dry_run: true` to check whether it WOULD succeed without committing anything. Answers the " \
+                 "record's id, its resulting state, and the events it announced — or a structured refusal, " \
+                 "never a crash.",
     inputSchema: {
       type:       "object",
       properties: {
         domain:  DOMAIN_PROPERTY,
-        command: { type: "string", description: "The command's short or qualified name, e.g. \"open_account\"." },
+        command: { type: "string", description: "The command's short or qualified name, e.g. \"open_account\". " \
+                                                "Ignored when `steps` is given." },
         args:    ARGS_PROPERTY,
-        summary: SUMMARY_PROPERTY
+        summary: SUMMARY_PROPERTY,
+        source:  SOURCE_PROPERTY,
+        dry_run: { type: "boolean", description: "Preview only — check the command would succeed, commit nothing. " \
+                                                 "Ignored when `steps` is given." },
+        steps:   {
+          type:        "array",
+          description: "Run several commands in one call, in order. Each item: {command, args}. When given, " \
+                       "`command`/`args`/`dry_run` above are ignored.",
+          items:       {
+            type:       "object",
+            properties: { command: { type: "string" }, args: ARGS_PROPERTY },
+            required:   %w[command]
+          }
+        }
       },
-      required:   %w[domain command summary]
+      required:   %w[domain summary]
     }
   },
   {
@@ -73,7 +100,8 @@ TOOLS = [
         domain:   DOMAIN_PROPERTY,
         question: { type: "string", description: "The query's short or qualified name." },
         args:     ARGS_PROPERTY,
-        summary:  SUMMARY_PROPERTY
+        summary:  SUMMARY_PROPERTY,
+        source:   SOURCE_PROPERTY
       },
       required:   %w[domain question summary]
     }
@@ -120,10 +148,57 @@ TOOLS = [
     name:        "validate",
     description: "Zoom level three: is this domain's wiring sound — every bind names a declared aggregate, " \
                  "every adapter satisfies its port, the default adapter is usable. {valid:false, error:…} " \
-                 "on a real wiring defect, never a bare crash.",
+                 "on a real wiring defect, never a bare crash. Set `deep: true` to also model-check the IR " \
+                 "for dead lifecycle transitions, unreachable saga states, and dispatches to nowhere.",
+    inputSchema: {
+      type:       "object",
+      properties: {
+        domain: DOMAIN_PROPERTY,
+        deep:   { type: "boolean", description: "Also run the static model checker (lifecycle/saga/policy IR)." }
+      },
+      required:   %w[domain]
+    }
+  },
+  {
+    name:        "domains",
+    description: "Zoom level zero: every domain directory found under a root (default \"examples\"), so a " \
+                 "caller who doesn't already know a path can find one.",
+    inputSchema: {
+      type:       "object",
+      properties: { under: { type: "string", description: "Root directory to scan. Defaults to \"examples\"." } }
+    }
+  },
+  {
+    name:        "history",
+    description: "The full write history for every aggregate in a domain — every operation an append-only " \
+                 "adapter ever recorded, not just current state. An aggregate on a non-append-only adapter " \
+                 "answers an empty history honestly.",
     inputSchema: {
       type:       "object",
       properties: { domain: DOMAIN_PROPERTY },
+      required:   %w[domain]
+    }
+  },
+  {
+    name:        "behaviors",
+    description: "Run a domain's hand-curated `.behaviors` example tests and report pass/fail/error per test. " \
+                 "`target` is a single `.behaviors` file or a directory to sweep.",
+    inputSchema: {
+      type:       "object",
+      properties: { target: { type: "string", description: "A .behaviors file, or a directory to sweep." } },
+      required:   %w[target]
+    }
+  },
+  {
+    name:        "follow",
+    description: "Tail this door's own audit log for a domain — the last `limit` dispatch/query/state/dry-run " \
+                 "calls made through it, each carrying its summary, source, and outcome.",
+    inputSchema: {
+      type:       "object",
+      properties: {
+        domain: DOMAIN_PROPERTY,
+        limit:  { type: "integer", description: "How many recent entries to return. Defaults to 20." }
+      },
       required:   %w[domain]
     }
   }
@@ -134,11 +209,17 @@ def boot(domain) = Hecks.boot(domain, install_facade: false)
 def call_tool(name, a)
   case name
   when "dispatch"
-    Hecks::Facade::McpDoor.dispatch(runtime: boot(a["domain"]), command: a["command"],
-                                    summary: a["summary"], args: a["args"] || {})
+    runtime = boot(a["domain"])
+    if a["steps"]
+      Hecks::Facade::McpDoor.dispatch_batch(runtime: runtime, steps: a["steps"], summary: a["summary"],
+                                            source: a["source"])
+    else
+      Hecks::Facade::McpDoor.dispatch(runtime: runtime, command: a["command"], summary: a["summary"],
+                                      args: a["args"] || {}, source: a["source"], dry_run: !a["dry_run"].nil?)
+    end
   when "query"
     Hecks::Facade::McpDoor.query(runtime: boot(a["domain"]), question: a["question"],
-                                 summary: a["summary"], args: a["args"] || {})
+                                 summary: a["summary"], args: a["args"] || {}, source: a["source"])
   when "state"
     Hecks::Facade::McpDoor.state(runtime: boot(a["domain"]), aggregate: a["aggregate"],
                                  summary: a["summary"], id: a["id"])
@@ -147,7 +228,15 @@ def call_tool(name, a)
   when "describe"
     Hecks::Facade::McpDoor.describe(runtime: boot(a["domain"]), aggregate: a["aggregate"])
   when "validate"
-    Hecks::Facade::McpDoor.validate(domain: a["domain"])
+    Hecks::Facade::McpDoor.validate(domain: a["domain"], deep: !!a["deep"])
+  when "domains"
+    Hecks::Facade::McpDoor.domains(under: a["under"] || "examples")
+  when "history"
+    Hecks::Facade::McpDoor.history(runtime: boot(a["domain"]))
+  when "behaviors"
+    Hecks::Facade::McpDoor.behaviors(target: a["target"])
+  when "follow"
+    Hecks::Facade::McpDoor.follow(runtime: boot(a["domain"]), limit: a["limit"] || 20)
   else
     { ok: false, error: "no such tool: #{name.inspect} — known: #{TOOLS.map { |t| t[:name] }.join(', ')}" }
   end
@@ -183,7 +272,7 @@ def handle(request)
     send_response(id, {
                     protocolVersion: PROTOCOL_VERSION,
                     capabilities:    { tools: {} },
-                    serverInfo:      { name: "hecks-mcp-door", version: "1.0.0" }
+                    serverInfo:      { name: "hecks-mcp-door", version: "1.1.0" }
                   })
   when "notifications/initialized"
     nil # a notification — no id, no response

--- a/lib/hecks/facade/mcp_door.rb
+++ b/lib/hecks/facade/mcp_door.rb
@@ -1,3 +1,6 @@
+require "json"
+require "fileutils"
+require "time"
 require_relative "command_request"
 require_relative "json_door"
 require_relative "../naming"
@@ -11,44 +14,68 @@ module Hecks
     # `docs/future-features.md` both name this the single highest-priority
     # gap against the sibling project's ten-tool Storehouse MCP: "no
     # per-command tool... the bluebook IS the contract, the MCP layer just
-    # projects it." This is that projection, at six tools instead of ten —
-    # `macrophage_check`/`behaviors`/`conceive_behaviors` are that project's
-    # own governed-door and behaviour-generation machinery, which this repo
-    # has no equivalent of yet.
+    # projects it." This is that projection, since extended past the
+    # original six with the rest of that same survey's ranked wishlist:
     #
-    # THREE ZOOM LEVELS, the survey's own framing:
     #   catalog  — what aggregates a domain declares, and what each can do
     #   describe — one aggregate's full command/query/refusal contract
-    #   validate — is this domain's wiring sound at all
-    # …and three ways to actually DRIVE it:
-    #   dispatch — issue a command
+    #   validate — is this domain's wiring sound (deep: also model-checks it)
+    #   domains  — every domain directory under a root, discovered not typed
+    #   dispatch — issue a command (dry_run: preview, steps: batch)
     #   query    — ask a question
     #   state    — read what is actually stored, no verb involved
+    #   history  — the full append-only journal, not just current state
+    #   behaviors — run a domain's hand-curated `.behaviors` examples
+    #   follow   — tail this door's own dispatch/query/state audit log
     #
-    # `dispatch`/`query`/`state` EACH REQUIRE A `summary` — the survey's
-    # "every audit row carries human intent for free". `catalog`/`describe`/
-    # `validate` do not: they change nothing and commit nothing to any log,
-    # so there is no audit row for a summary to attach to.
+    # `dispatch`/`query`/`state` EACH TAKE A `summary` — the survey's "every
+    # audit row carries human intent for free" — and `dispatch`/`query`
+    # additionally take an optional `source:` (`SOURCE_TAGS`, the survey's
+    # `SourceTag`: who is calling). Every call through those three, plus a
+    # dry run, is appended to a per-domain JSONL audit log (`record!`)
+    # `follow` tails back. `catalog`/`describe`/`validate`/`domains`/
+    # `history`/`behaviors` need neither — they change nothing and commit
+    # nothing to any log.
     #
     # A CALLER HANDS IN AN ALREADY-BOOTED `runtime`, the same division of
     # labor `Facade::CliRunner` already keeps against `bin/run`: booting a
     # domain from a path is IO the calling `bin/` script owns, this stays a
-    # pure function of a `Runtime::Dispatcher` plus plain Ruby arguments, no
-    # different from `CliRunner.call(runtime:, argv:)` itself. `validate` is
-    # the one exception — its whole job is to attempt the boot and report
-    # whether it survived, so it takes the domain PATH instead and boots it.
+    # pure function of a `Runtime::Dispatcher` plus plain Ruby arguments —
+    # no different from `CliRunner.call(runtime:, argv:)` itself.
+    # `validate` and `domains` are the two exceptions: `validate`'s whole
+    # job is to attempt the boot and report whether it survived, so it
+    # takes the domain PATH instead and boots it; `domains` has no
+    # domain to be handed one of yet, that's what it's answering.
     #
     # NO NEW VOCABULARY otherwise. Every method here composes doors that
     # already exist — `Projector.call(:cli, ...)` for verb/question alias
     # resolution (the identical table `CliRunner` itself resolves against),
     # `Projector.call(:docs, ...)` for `describe`, `JsonDoor` for the
-    # JSON↔Runtime::Value boundary, `Registry#repository` for `state`,
-    # `Registry#verify!` (run at boot by `Runtime::Loader.boot`) for
-    # `validate`. A second copy of "how do I find a command by its short
-    # name" here would be the exact duplication `JsonDoor`'s own header
-    # already warns against.
+    # JSON↔Runtime::Value boundary, `Registry#repository` for `state`/
+    # `history`, `Registry#verify!` (run by every boot) for `validate`,
+    # `Bluebook::ModelCheck` for `validate(deep: true)`, `Hecks::Behaviors`
+    # for `behaviors`, `Adapters::Folder#domain?` for `domains`,
+    # `Dispatcher#dry_run?` for `dispatch(dry_run: true)`. A second copy of
+    # any of these here would be the exact duplication `JsonDoor`'s own
+    # header already warns against.
     module McpDoor
       module_function
+
+      # THE SAME CLOSED SET `docs/hecks-survey-what-we-wish-we-had.md`'s
+      # `SourceTag` names — WHO dispatched, not WHAT. Optional: a caller
+      # that omits it gets `source: nil` recorded, honestly, rather than a
+      # guessed default.
+      SOURCE_TAGS = %w[process-manager operator hook sidequest-agent cascade daemon].freeze
+
+      # THE DOOR'S OWN AUDIT TRAIL — a JSONL file per domain, one line per
+      # `dispatch`/`query`/`state`/dry-run call, `follow` tails it back.
+      # `tmp/`, not the domain's own directory: this is the DOOR's record
+      # of what was asked of it, not part of the domain's own persisted
+      # state, and `tmp/` is already gitignored for exactly this kind of
+      # local, disposable-but-useful-while-it-lasts file.
+      LOG_ROOT = File.expand_path("../../../tmp/mcp_door", __dir__)
+
+      # ── shared resolution helpers ────────────────────────────────────
 
       # THE ONE BLUEBOOK A DOMAIN DIRECTORY BOOTS. Every `bin/*` script that
       # projects a whole-domain CLI or doc set makes this same assumption
@@ -86,34 +113,149 @@ module Hecks
               "a one-line summary: is required on dispatch/query/state — it is what makes an audit row legible later"
       end
 
+      def valid_source!(source)
+        return if source.nil? || SOURCE_TAGS.include?(source.to_s)
+
+        raise Runtime::TypeMismatch, "source: #{source.inspect} is not one of #{SOURCE_TAGS.join(', ')}"
+      end
+
+      # `dry_run?` (Runtime::Dispatcher) understands only the OLD flat
+      # legacy args shape — no to:/with: envelope, `route:` never passed
+      # (its own header explains why: built directly against
+      # CommandInterpreter/EntityInterpreter's pre-envelope contract,
+      # never updated because nothing else needed it to be — a real
+      # record of history, not a defect this door should paper over
+      # silently). `CommandRequest`/`spec[:legacy_receiver]` already know
+      # how to NAME that same flat shape for every receiver kind (a bare
+      # id under one string key for :aggregate, a {aggregate:, entity:}
+      # pair of keys for :entity) — this is the one door back INTO it.
+      def flatten_legacy(envelope, receiver, legacy_receiver)
+        facts = envelope[:with] || {}
+        return facts unless envelope.key?(:to)
+
+        route = envelope[:to]
+        case receiver
+        when :aggregate then facts.merge(legacy_receiver.to_sym => route)
+        when :entity
+          facts.merge(legacy_receiver.fetch(:aggregate).to_sym => route[:aggregate],
+                      legacy_receiver.fetch(:entity).to_sym    => route[:entity])
+        else facts
+        end
+      end
+
+      # ── the audit log `follow` reads back ───────────────────────────────
+
+      def log_path(domain_name)
+        File.join(LOG_ROOT, "#{domain_name.to_s.gsub(/[^A-Za-z0-9_-]/, '_')}.jsonl")
+      end
+
+      # NEVER FAILS A REAL CALL BECAUSE ITS OWN AUDIT LOG COULDN'T BE
+      # WRITTEN — a full disk or a permissions problem is a `follow`
+      # feature going dark, not a reason to refuse the dispatch/query/
+      # state call that was actually asked for.
+      def record!(domain_name, tool:, summary:, source:, outcome:, verb: nil)
+        return unless domain_name
+
+        entry = { time: Time.now.utc.iso8601, tool: tool, verb: verb, summary: summary, source: source,
+                  ok: outcome[:ok], id: outcome[:id], error: outcome[:error] }.compact
+        FileUtils.mkdir_p(LOG_ROOT)
+        File.open(log_path(domain_name), "a") { |f| f.puts(JSON.generate(entry)) }
+      rescue StandardError
+        nil
+      end
+
       # ── the three that drive it ────────────────────────────────────────
 
-      def dispatch(runtime:, command:, summary:, args: {})
-        require_summary!(summary)
-        cli     = Projector.call(:cli, bluebook: bluebook_for(runtime), options: { program: "mcp" })
-        spec    = resolve!(cli, command, asking: false)
-        request = CommandRequest.normalize(JsonDoor.deep_symbolize(args),
-                                           receiver:        spec[:receiver],
-                                           legacy_receiver: spec[:legacy_receiver])
-        result = runtime.dispatch(spec[:verb], **request)
+      # `dry_run: true` ANSWERS A DIFFERENT QUESTION than a real dispatch
+      # does — "would this succeed", not "here is what happened" — so a
+      # domain refusal is the legitimate, complete ANSWER (`ok: true,
+      # would_succeed: false`), not a failed call. A malformed request
+      # (unknown command, a bad args shape) is still a failed call
+      # (`ok: false`) either way — it never reached the domain to be asked.
+      def dispatch(runtime:, command:, summary:, args: {}, source: nil, dry_run: false)
+        bluebook = bluebook_for(runtime)
+        tool     = dry_run ? "dry_run" : "dispatch"
+        outcome  = perform_dispatch(runtime, bluebook, command, summary, args, source, dry_run)
 
+        record!(bluebook.name, tool: tool, verb: outcome[:verb], summary: summary, source: source, outcome: outcome)
+        outcome.except(:verb)
+      rescue *refusal_classes => e
+        outcome = refused(e, summary: summary)
+        record!(bluebook&.name, tool: tool, summary: summary, source: source, outcome: outcome)
+        outcome
+      end
+
+      def perform_dispatch(runtime, bluebook, command, summary, args, source, dry_run)
+        require_summary!(summary)
+        valid_source!(source)
+        cli      = Projector.call(:cli, bluebook: bluebook, options: { program: "mcp" })
+        spec     = resolve!(cli, command, asking: false)
+        envelope = CommandRequest.normalize(JsonDoor.deep_symbolize(args),
+                                            receiver:        spec[:receiver],
+                                            legacy_receiver: spec[:legacy_receiver])
+
+        result = dry_run ? dry_run_outcome(runtime, spec, envelope, summary: summary) : real_dispatch(runtime, spec, envelope, summary)
+        result.merge(verb: spec[:verb])
+      end
+
+      def real_dispatch(runtime, spec, envelope, summary)
+        result = runtime.dispatch(spec[:verb], **envelope)
         ok(summary: summary,
            id:      result.id,
            state:   result.state.nil? ? nil : JsonDoor.materialize(result.state),
            events:  result.events.map { |event| { name: event.name, payload: JsonDoor.materialize(event.payload) } })
+      end
+
+      def dry_run_outcome(runtime, spec, envelope, summary:)
+        flat = flatten_legacy(envelope, spec[:receiver], spec[:legacy_receiver])
+        runtime.dry_run?(spec[:verb], **flat)
+        ok(summary: summary, would_succeed: true)
+      rescue Runtime::WiringError, *Runtime::DOMAIN_REFUSALS => e
+        ok(summary: summary, would_succeed: false, error: e.message)
+      end
+
+      # ONE CALL, MANY STEPS — the survey's own `bin/run <domain> script`
+      # shape, so an agent issuing a known SEQUENCE of commands (open an
+      # account, then fund it) pays one round trip instead of N. Every step
+      # goes through `dispatch` itself — same resolution, same audit log
+      # line per step, same summary/source stamped on all of them since
+      # the batch is what the caller is declaring intent about, not each
+      # individual step. Runs every step regardless of an earlier one
+      # refusing — a later step naming a record an earlier step never
+      # created will refuse honestly on its own account, which is more
+      # informative than silently dropping the rest of the batch.
+      def dispatch_batch(runtime:, steps:, summary:, source: nil)
+        require_summary!(summary)
+        results = Array(steps).map do |raw|
+          step = JsonDoor.deep_symbolize(raw)
+          dispatch(runtime: runtime, command: step[:command], args: step[:args] || {},
+                   summary: summary, source: source)
+        end
+        { ok: results.all? { |r| r[:ok] }, summary: summary, results: results }
       rescue *refusal_classes => e
         refused(e, summary: summary)
       end
 
-      def query(runtime:, question:, summary:, args: {})
+      def query(runtime:, question:, summary:, args: {}, source: nil)
+        bluebook = bluebook_for(runtime)
+        outcome  = perform_query(bluebook, runtime, question, summary, args, source)
+
+        record!(bluebook.name, tool: "query", verb: outcome[:verb], summary: summary, source: source, outcome: outcome)
+        outcome.except(:verb)
+      rescue *refusal_classes => e
+        outcome = refused(e, summary: summary)
+        record!(bluebook&.name, tool: "query", summary: summary, source: source, outcome: outcome)
+        outcome
+      end
+
+      def perform_query(bluebook, runtime, question, summary, args, source)
         require_summary!(summary)
-        cli  = Projector.call(:cli, bluebook: bluebook_for(runtime), options: { program: "mcp" })
+        valid_source!(source)
+        cli  = Projector.call(:cli, bluebook: bluebook, options: { program: "mcp" })
         spec = resolve!(cli, question, asking: true)
         rows = runtime.query(spec[:verb], **JsonDoor.deep_symbolize(args))
 
-        ok(summary: summary, rows: rows.map { |row| JsonDoor.materialize(row) })
-      rescue *refusal_classes => e
-        refused(e, summary: summary)
+        ok(summary: summary, rows: rows.map { |row| JsonDoor.materialize(row) }).merge(verb: spec[:verb])
       end
 
       # WHAT IS ACTUALLY STORED — no verb, no interpretation, the repository
@@ -122,9 +264,20 @@ module Hecks
       # holds. This is the difference `query` can't cover: a query answers a
       # DECLARED question, and an aggregate that never declared "list
       # everything" has no query this could reuse.
-      def state(runtime:, aggregate:, summary:, id: nil)
+      def state(runtime:, aggregate:, summary:, id: nil, source: nil)
+        bluebook = bluebook_for(runtime)
+        outcome  = perform_state(runtime, bluebook, aggregate, summary, id)
+
+        record!(bluebook.name, tool: "state", summary: summary, source: source, outcome: outcome)
+        outcome
+      rescue *refusal_classes => e
+        outcome = refused(e, summary: summary)
+        record!(bluebook&.name, tool: "state", summary: summary, source: source, outcome: outcome)
+        outcome
+      end
+
+      def perform_state(runtime, bluebook, aggregate, summary, id)
         require_summary!(summary)
-        bluebook   = bluebook_for(runtime)
         ir         = aggregate_ir!(bluebook, aggregate)
         repository = runtime.registry.repository(bluebook.name, ir)
 
@@ -136,11 +289,26 @@ module Hecks
           records = repository.all.map { |instance| JsonDoor.materialize(instance.to_h) }
           ok(summary: summary, count: records.length, records: records)
         end
-      rescue *refusal_classes => e
-        refused(e, summary: summary)
       end
 
-      # ── the three zoom levels ───────────────────────────────────────────
+      # ── the four zoom levels ─────────────────────────────────────────
+
+      # ZOOM LEVEL ZERO — every domain directory a root actually holds,
+      # discovered rather than typed from memory. Every other tool takes
+      # `domain:` as a directory it assumes the caller already knows; this
+      # is how a caller who doesn't finds out. `Adapters::Folder#domain?`
+      # is the same predicate `domain_root`/`nearest_domain` already walk
+      # up directories checking — a bare `.hecksagon` or one under
+      # `bluebook/`, the two real shapes this corpus uses.
+      def domains(under: "examples")
+        root = File.expand_path(under)
+        return ok(under: under, domains: []) unless Dir.exist?(root)
+
+        folder = Adapters::Folder.new
+        found  = Dir.children(root).sort.select { |name| folder.domain?(File.join(root, name)) }
+
+        ok(under: under, domains: found.map { |name| File.join(under, name) })
+      end
 
       # ZOOM LEVEL ONE — every aggregate this domain declares, and every
       # command/query name each answers to, snake_cased exactly as
@@ -186,15 +354,102 @@ module Hecks
       # asking "is this valid" about a domain that failed to boot at all
       # has to be askable without a runtime to hand it.
       #
+      # `deep: true` GOES PAST WIRING INTO LOGIC — `Bluebook::ModelCheck`,
+      # the lightweight-formal-methods leg (dead lifecycle transitions, a
+      # saga state no handler chain reaches, a dispatch to nowhere). Opt-in
+      # and separate from the base check on purpose: a wiring defect is
+      # "this cannot run at all", a model-check finding is "this runs, but
+      # part of it can never fire" — two different questions, and the
+      # first is far cheaper to ask on every boot.
+      #
       # ANY BOOT FAILURE ANSWERS THE QUESTION, not only `WiringError` — a
       # domain path with no `.hecksagon`, a malformed bluebook, is just as
       # much "not valid" as a real wiring mismatch, and this tool exists
       # precisely so none of those ever cross the MCP boundary as a crash.
-      def validate(domain:)
-        Hecks.boot(domain, install_facade: false)
-        { ok: true, domain: domain, valid: true }
+      def validate(domain:, deep: false)
+        runtime = Hecks.boot(domain, install_facade: false)
+        result  = { ok: true, domain: domain, valid: true }
+
+        if deep
+          require_relative "../bluebook/model_check"
+          findings = runtime.registry.bluebooks.values.flat_map { |bluebook| Bluebook::ModelCheck.call(bluebook) }
+          result[:findings] = findings.map { |f| { kind: f.kind, severity: f.severity, subject: f.subject, message: f.message } }
+        end
+
+        result
       rescue StandardError => e
         { ok: false, domain: domain, valid: false, error: "#{e.class}: #{e.message}" }
+      end
+
+      # ── beyond the zoom levels ──────────────────────────────────────────
+
+      # THE FULL WRITE HISTORY, not just the current head — `bin/history`'s
+      # own logic, unchanged: an append-only-backed aggregate's `entries`,
+      # every operation that ever touched it. An aggregate bound to a
+      # non-append-only adapter (Memory, Postgres proper) answers an empty
+      # list honestly rather than pretending to a history it never kept.
+      def history(runtime:)
+        bluebook = bluebook_for(runtime)
+        entries  = bluebook.aggregates.each_with_object({}) do |aggregate, all|
+          repository = runtime.registry.repository(bluebook.name, aggregate)
+          all[aggregate.storage_name] = journal_entries(repository)
+        end
+
+        ok(domain: bluebook.name, history: entries)
+      rescue *refusal_classes => e
+        refused(e)
+      end
+
+      def journal_entries(repository)
+        return [] unless repository.is_a?(Ports::Persistence::AppendOnly)
+
+        repository.entries.map { |entry| { operation: entry.operation, id: entry.id, state: JsonDoor.materialize(entry.state) } }
+      end
+
+      # `.behaviors` FILES, RUN AND REPORTED — hand-curated examples of how
+      # to use a domain, in domain vocabulary (`docs/guides/behaviors.md`),
+      # the survey's own "honest-refusal", generated-example-suite items.
+      # `Hecks::Behaviors` boots each test fresh through `Hecks.boot_files`
+      # itself — `target:` names a `.behaviors` file OR a directory to
+      # sweep, never a `runtime:`, the one other method here besides
+      # `validate` that takes a path instead.
+      def behaviors(target:)
+        require_relative "../behaviors"
+        raise Runtime::NotFound, "no such file or directory: #{target.inspect}" unless target && File.exist?(target)
+
+        if File.directory?(target)
+          sweep = Hecks::Behaviors.run_all(target)
+          ok(target: target, files: sweep.files.map { |file| behaviors_file(file) }, counts: sweep.summary)
+        else
+          result = Hecks::Behaviors.run(target)
+          ok(target: target, files: [behaviors_file(result)], counts: Hecks::Behaviors.summarize([result]))
+        end
+      rescue *refusal_classes => e
+        refused(e)
+      end
+
+      def behaviors_file(result)
+        { path:        result.path,
+          parse_error: result.parse_error,
+          runs:        Array(result.runs).map { |run| { description: run.description, status: run.status, message: run.message } } }
+      end
+
+      # A LIVE TAIL WITHOUT A LIVE PROCESS — `bin/hecks_mcp_door` answers
+      # one request at a time over stdio, no push channel to a client that
+      # only ever asks. This is the honest version of the survey's
+      # `storehouse follow` for that shape: not a subscription, a durable
+      # JSONL log every `dispatch`/`query`/`state`/dry-run call appends to
+      # (`record!`), tailed back here. Still real, still cross-process —
+      # the log outlives any one `bin/hecks_mcp_door` invocation — just
+      # pull instead of push.
+      def follow(runtime:, limit: 20)
+        bluebook = bluebook_for(runtime)
+        path     = log_path(bluebook.name)
+        entries  = File.exist?(path) ? File.readlines(path).last([limit.to_i, 1].max).map { |line| JSON.parse(line, symbolize_names: true) } : []
+
+        ok(domain: bluebook.name, entries: entries)
+      rescue *refusal_classes => e
+        refused(e)
       end
 
       # ── shared shape ────────────────────────────────────────────────────

--- a/spec/facade/mcp_door_spec.rb
+++ b/spec/facade/mcp_door_spec.rb
@@ -5,6 +5,14 @@ require "spec_helper"
 # these specs prove composition rather than re-deriving verb resolution or
 # JSON materialization from scratch.
 RSpec.describe Hecks::Facade::McpDoor do
+  # THE DOOR'S OWN AUDIT LOG IS REAL DISK STATE, keyed only by domain name
+  # ("Pizzas") — every example in this file that dispatches/queries/reads
+  # state against `runtime` writes to the SAME file regardless of which
+  # example it is, since a fresh in-memory `runtime` per example is not a
+  # fresh log. Wiped before every example so `.follow`'s own assertions
+  # never depend on run order or on what an earlier example happened to log.
+  before { FileUtils.rm_rf(described_class::LOG_ROOT) }
+
   let(:runtime) { boot_in_memory }
   let(:pizza_args) do
     { name: { value: "Margherita" }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } } }
@@ -162,6 +170,180 @@ RSpec.describe Hecks::Facade::McpDoor do
       expect(result[:ok]).to be false
       expect(result[:valid]).to be false
       expect(result[:error]).to be_a(String)
+    end
+
+    it "runs the static model checker and reports findings when deep: true" do
+      result = described_class.validate(domain: "examples/pizzas", deep: true)
+
+      expect(result[:ok]).to be true
+      expect(result[:findings]).to be_an(Array)
+    end
+
+    it "answers no findings key at all when deep is omitted" do
+      result = described_class.validate(domain: "examples/pizzas")
+
+      expect(result).not_to have_key(:findings)
+    end
+  end
+
+  describe ".dispatch with dry_run: true" do
+    it "answers would_succeed: true and persists nothing" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                        args: pizza_args, dry_run: true)
+
+      expect(result).to eq(ok: true, summary: "spec", would_succeed: true)
+      expect(described_class.state(runtime: runtime, aggregate: "Order", summary: "spec")[:count]).to eq(0)
+    end
+
+    it "answers would_succeed: false with the domain's own refusal text, for a real domain rule" do
+      result = described_class.dispatch(runtime: runtime, command: "order.purchase", summary: "spec",
+                                        dry_run: true,
+                                        args: { to: "Margherita", amount: { cents: 1200 },
+                                                 customer_name: { value: "Alex" } })
+
+      expect(result[:ok]).to be true
+      expect(result[:would_succeed]).to be false
+      expect(result[:error]).to be_a(String)
+    end
+
+    it "still answers ok: false for a request that never reaches the domain at all" do
+      result = described_class.dispatch(runtime: runtime, command: "no_such_command", summary: "spec",
+                                        dry_run: true)
+
+      expect(result[:ok]).to be false
+      expect(result).not_to have_key(:would_succeed)
+    end
+  end
+
+  describe ".dispatch with source:" do
+    it "accepts a declared source tag" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                        args: pizza_args, source: "operator")
+
+      expect(result[:ok]).to be true
+    end
+
+    it "refuses a source tag outside the closed set" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                        args: pizza_args, source: "not-a-real-source")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("source")
+      expect(runtime.events).to be_empty
+    end
+  end
+
+  describe ".dispatch_batch" do
+    it "runs every step and reports ok: true only when all of them succeeded" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+
+      result = described_class.dispatch_batch(
+        runtime: runtime, summary: "spec",
+        steps: [{ command: "order.add_topping",
+                  args:    { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } } }]
+      )
+
+      expect(result[:ok]).to be true
+      expect(result[:results].length).to eq(1)
+      expect(result[:results].first[:ok]).to be true
+    end
+
+    it "runs every step even after an earlier one refuses, and reports ok: false overall" do
+      result = described_class.dispatch_batch(
+        runtime: runtime, summary: "spec",
+        steps: [{ command: "no_such_command", args: {} },
+                { command: "create_pizza", args: pizza_args }]
+      )
+
+      expect(result[:ok]).to be false
+      expect(result[:results].map { |r| r[:ok] }).to eq([false, true])
+    end
+  end
+
+  describe ".domains" do
+    it "lists every real example domain under the default root" do
+      result = described_class.domains
+
+      expect(result[:ok]).to be true
+      expect(result[:domains]).to include("examples/pizzas", "examples/banking")
+    end
+
+    it "answers an empty list, not an error, for a root that doesn't exist" do
+      result = described_class.domains(under: "examples/no_such_root")
+
+      expect(result).to eq(ok: true, under: "examples/no_such_root", domains: [])
+    end
+  end
+
+  describe ".history" do
+    it "answers every append-only journal entry, not just current state" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "order.add_topping", summary: "spec",
+                               args: { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } })
+
+      result = described_class.history(runtime: runtime)
+
+      expect(result[:ok]).to be true
+      expect(result[:history]["order"].length).to eq(2)
+      expect(result[:history]["order"].map { |entry| entry[:operation] }).to eq(%w[save save])
+    end
+  end
+
+  describe ".behaviors" do
+    it "runs a domain's real .behaviors suite and reports pass/fail per test" do
+      result = described_class.behaviors(target: "examples/pizzas")
+
+      expect(result[:ok]).to be true
+      expect(result[:counts][:total]).to be > 0
+      expect(result[:counts][:failed]).to eq(0)
+      expect(result[:counts][:errored]).to eq(0)
+    end
+
+    it "refuses a target that names no file or directory" do
+      result = described_class.behaviors(target: "examples/no_such_target")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("no such file or directory")
+    end
+  end
+
+  describe ".follow" do
+    it "answers no entries for a domain nothing has dispatched against yet" do
+      result = described_class.follow(runtime: runtime)
+
+      expect(result).to eq(ok: true, domain: "Pizzas", entries: [])
+    end
+
+    it "tails dispatch/query/state calls made through this door, in order" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "one", args: pizza_args,
+                               source: "operator")
+      described_class.query(runtime: runtime, question: "available", summary: "two")
+      described_class.state(runtime: runtime, aggregate: "Order", summary: "three")
+
+      result = described_class.follow(runtime: runtime)
+
+      expect(result[:ok]).to be true
+      expect(result[:entries].map { |e| e[:tool] }).to eq(%w[dispatch query state])
+      expect(result[:entries].map { |e| e[:summary] }).to eq(%w[one two three])
+      expect(result[:entries].first[:source]).to eq("operator")
+      expect(result[:entries].first[:ok]).to be true
+    end
+
+    it "respects limit, keeping the most recent entries" do
+      3.times { |n| described_class.query(runtime: runtime, question: "available", summary: "q#{n}") }
+
+      result = described_class.follow(runtime: runtime, limit: 2)
+
+      expect(result[:entries].map { |e| e[:summary] }).to eq(%w[q1 q2])
+    end
+
+    it "records a refused call too, not only a successful one" do
+      described_class.dispatch(runtime: runtime, command: "no_such_command", summary: "spec")
+
+      result = described_class.follow(runtime: runtime)
+
+      expect(result[:entries].last[:ok]).to be false
+      expect(result[:entries].last[:error]).to be_a(String)
     end
   end
 end


### PR DESCRIPTION
Follow-up to #375. Builds the remaining 8 items from the survey's ranked wishlist, each reusing an existing capability rather than inventing one:

- **`dispatch(dry_run: true)`** — `Dispatcher#dry_run?` already existed and was already tested (`spec/runtime/dry_run_spec.rb`). Wiring it in needed a real translation: `dry_run?` only understands the old flat legacy args shape (no `to:`/`with:` envelope), while every other tool here builds that envelope via `CommandRequest`. `flatten_legacy` reuses `CommandRequest`'s own `legacy_receiver` naming to go back the other direction. A domain refusal from a dry run answers `{ok: true, would_succeed: false, error: ...}` — it's the legitimate *answer* to "would this succeed", not a failed call; a malformed request (unknown command, bad args) still answers `ok: false`, since it never reached the domain to be asked.
- **`dispatch(steps: [...])`** — batch dispatch, one round trip for N commands, each step going through `dispatch` itself.
- **`dispatch`/`query(source:)`** — the survey's `SourceTag`, a closed set of who's calling, optional, recorded in the audit log.
- **`validate(deep: true)`** — folds in `Bluebook::ModelCheck` (dead lifecycle transitions, unreachable saga states, dispatches to nowhere) beside the existing wiring check.
- **`domains`** — zoom level zero: every domain directory under a root, via the same `Adapters::Folder#domain?` predicate `domain_root` already walks with.
- **`history`** — `bin/history`'s own logic (full append-only journal, not just current state), wrapped as a tool.
- **`behaviors`** — runs a domain's hand-curated `.behaviors` example suite (`Hecks::Behaviors`) and reports pass/fail/error per test.
- **`follow`** — the survey's live-tail pick, honestly scoped to what a request/response stdio server can actually do: no push channel to a client that only asks, so this is a durable per-domain JSONL log every `dispatch`/`query`/`state`/dry-run call appends to (`record!`), tailed back rather than pushed. Still real and cross-process — the log outlives any one `bin/hecks_mcp_door` invocation.

## Testing

18 new spec examples (35 total in `spec/facade/mcp_door_spec.rb`). Full suite green (1911 examples), fuzzer green, rubocop clean — all confirmed by the repo's pre-push hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)