### PR TITLE
Add caller identity (role:/actor_id:) to dispatch/query, and an events tool

### DIFF
--- a/bin/hecks_mcp_door
+++ b/bin/hecks_mcp_door
@@ -12,6 +12,11 @@
 # `bin/hecks_query_ir_mcp` already is (no gem dependency; newline-delimited
 # JSON, flushed after every write).
 #
+# `dispatch`/`query` ALSO TAKE `role:`/`actor_id:` — a real caller
+# identity, bound for the call's duration via `Hecks.as_caller`, so a
+# role-gated command's authorization is actually CHECKED through this
+# door rather than merely documented by `describe`.
+#
 # EVERY DOMAIN-SCOPED TOOL TAKES `domain:` — a directory containing a
 # `.hecksagon` (`examples/banking`, `examples/pizzas`, …), the same
 # argument `bin/run` takes. An MCP server's cwd is wherever the client
@@ -57,6 +62,18 @@ SOURCE_PROPERTY = {
   description: "Optional: who is calling, for the audit log `follow` reads back."
 }.freeze
 
+ROLE_PROPERTY = {
+  type:        "string",
+  description: "Optional: bind a real caller identity for the call's duration, so a role-gated command's " \
+               "authorization is actually checked rather than merely documented. Required if `actor_id` is given."
+}.freeze
+
+ACTOR_ID_PROPERTY = {
+  type:        "string",
+  description: "Optional, alongside `role`: WHO holds that role — once the domain attaches Governance, checked " \
+               "against a real Governance::RoleAssignment instead of a bare string match. Requires `role`."
+}.freeze
+
 TOOLS = [
   {
     name:        "dispatch",
@@ -68,15 +85,17 @@ TOOLS = [
     inputSchema: {
       type:       "object",
       properties: {
-        domain:  DOMAIN_PROPERTY,
-        command: { type: "string", description: "The command's short or qualified name, e.g. \"open_account\". " \
-                                                "Ignored when `steps` is given." },
-        args:    ARGS_PROPERTY,
-        summary: SUMMARY_PROPERTY,
-        source:  SOURCE_PROPERTY,
-        dry_run: { type: "boolean", description: "Preview only — check the command would succeed, commit nothing. " \
+        domain:   DOMAIN_PROPERTY,
+        command:  { type: "string", description: "The command's short or qualified name, e.g. \"open_account\". " \
                                                  "Ignored when `steps` is given." },
-        steps:   {
+        args:     ARGS_PROPERTY,
+        summary:  SUMMARY_PROPERTY,
+        source:   SOURCE_PROPERTY,
+        role:     ROLE_PROPERTY,
+        actor_id: ACTOR_ID_PROPERTY,
+        dry_run:  { type: "boolean", description: "Preview only — check the command would succeed, commit nothing. " \
+                                                  "Ignored when `steps` is given." },
+        steps:    {
           type:        "array",
           description: "Run several commands in one call, in order. Each item: {command, args}. When given, " \
                        "`command`/`args`/`dry_run` above are ignored.",
@@ -101,9 +120,29 @@ TOOLS = [
         question: { type: "string", description: "The query's short or qualified name." },
         args:     ARGS_PROPERTY,
         summary:  SUMMARY_PROPERTY,
-        source:   SOURCE_PROPERTY
+        source:   SOURCE_PROPERTY,
+        role:     ROLE_PROPERTY,
+        actor_id: ACTOR_ID_PROPERTY
       },
       required:   %w[domain question summary]
+    }
+  },
+  {
+    name:        "events",
+    description: "What actually HAPPENED, with payloads, to one aggregate/record — events THIS DOOR witnessed " \
+                 "(every real dispatch ever routed through it, sourced from its own audit log — not a full " \
+                 "domain-wide event-sourcing replay). Distinct from `state` (what's stored now) and `history` " \
+                 "(append-only operation snapshots, no payload). Narrow with `aggregate` and (requires " \
+                 "`aggregate`) `id`; `limit` keeps only the most recent.",
+    inputSchema: {
+      type:       "object",
+      properties: {
+        domain:    DOMAIN_PROPERTY,
+        aggregate: { type: "string", description: "Narrow to one aggregate, e.g. \"Account\"." },
+        id:        { type: "string", description: "Narrow to one record's own events. Requires `aggregate`." },
+        limit:     { type: "integer", description: "Keep only the most recent N events. Omit for all of them." }
+      },
+      required:   %w[domain]
     }
   },
   {
@@ -212,14 +251,19 @@ def call_tool(name, a)
     runtime = boot(a["domain"])
     if a["steps"]
       Hecks::Facade::McpDoor.dispatch_batch(runtime: runtime, steps: a["steps"], summary: a["summary"],
-                                            source: a["source"])
+                                            source: a["source"], role: a["role"], actor_id: a["actor_id"])
     else
       Hecks::Facade::McpDoor.dispatch(runtime: runtime, command: a["command"], summary: a["summary"],
-                                      args: a["args"] || {}, source: a["source"], dry_run: !a["dry_run"].nil?)
+                                      args: a["args"] || {}, source: a["source"],
+                                      dry_run: a["dry_run"] == true, role: a["role"], actor_id: a["actor_id"])
     end
   when "query"
     Hecks::Facade::McpDoor.query(runtime: boot(a["domain"]), question: a["question"],
-                                 summary: a["summary"], args: a["args"] || {}, source: a["source"])
+                                 summary: a["summary"], args: a["args"] || {}, source: a["source"],
+                                 role: a["role"], actor_id: a["actor_id"])
+  when "events"
+    Hecks::Facade::McpDoor.events(runtime: boot(a["domain"]), aggregate: a["aggregate"], id: a["id"],
+                                  limit: a["limit"])
   when "state"
     Hecks::Facade::McpDoor.state(runtime: boot(a["domain"]), aggregate: a["aggregate"],
                                  summary: a["summary"], id: a["id"])
@@ -228,7 +272,7 @@ def call_tool(name, a)
   when "describe"
     Hecks::Facade::McpDoor.describe(runtime: boot(a["domain"]), aggregate: a["aggregate"])
   when "validate"
-    Hecks::Facade::McpDoor.validate(domain: a["domain"], deep: !!a["deep"])
+    Hecks::Facade::McpDoor.validate(domain: a["domain"], deep: a["deep"] == true)
   when "domains"
     Hecks::Facade::McpDoor.domains(under: a["under"] || "examples")
   when "history"

--- a/lib/hecks/facade/mcp_door.rb
+++ b/lib/hecks/facade/mcp_door.rb
@@ -24,6 +24,9 @@ module Hecks
     #   dispatch — issue a command (dry_run: preview, steps: batch)
     #   query    — ask a question
     #   state    — read what is actually stored, no verb involved
+    #   events   — what HAPPENED, with payloads, to one record — not just its
+    #              current state; events THIS DOOR witnessed, sourced from
+    #              its own audit log, not a full event-sourcing replay
     #   history  — the full append-only journal, not just current state
     #   behaviors — run a domain's hand-curated `.behaviors` examples
     #   follow   — tail this door's own dispatch/query/state audit log
@@ -31,10 +34,14 @@ module Hecks
     # `dispatch`/`query`/`state` EACH TAKE A `summary` — the survey's "every
     # audit row carries human intent for free" — and `dispatch`/`query`
     # additionally take an optional `source:` (`SOURCE_TAGS`, the survey's
-    # `SourceTag`: who is calling). Every call through those three, plus a
-    # dry run, is appended to a per-domain JSONL audit log (`record!`)
-    # `follow` tails back. `catalog`/`describe`/`validate`/`domains`/
-    # `history`/`behaviors` need neither — they change nothing and commit
+    # `SourceTag`: who is calling) AND an optional `role:`/`actor_id:` —
+    # a real caller identity, bound for the call's duration via `Hecks.
+    # as_caller`, the one thing that makes a `role`-gated command's
+    # authorization actually checkable through this door rather than merely
+    # documented by `describe`. Every call through those three, plus a dry
+    # run, is appended to a per-domain JSONL audit log (`record!`) `follow`
+    # tails back. `catalog`/`describe`/`validate`/`domains`/`history`/
+    # `behaviors`/`events` need neither — they change nothing and commit
     # nothing to any log.
     #
     # A CALLER HANDS IN AN ALREADY-BOOTED `runtime`, the same division of
@@ -119,6 +126,36 @@ module Hecks
         raise Runtime::TypeMismatch, "source: #{source.inspect} is not one of #{SOURCE_TAGS.join(', ')}"
       end
 
+      # `actor_id` NAMES WHO, `role` NAMES WHAT THEY HOLD — `Hecks.
+      # as_caller` requires the latter always, the former is additive
+      # (`Runtime::Caller::Current`'s own shape). An `actor_id` with no
+      # `role` would silently do nothing rather than bind a real caller,
+      # which is worse than refusing: a caller who thinks they've
+      # identified themselves and haven't deserves to be told.
+      def valid_caller!(role, actor_id)
+        return unless actor_id && role.nil?
+
+        raise Runtime::TypeMismatch, "actor_id: requires role: too — a caller names WHO through WHICH role they hold"
+      end
+
+      # BOUND FOR THE DURATION OF ONE CALL, THEN GONE — `Hecks.as_caller`
+      # is itself a `Thread.current`-scoped `ensure`-guarded block, so
+      # nothing here needs its own cleanup. `role: nil` (the default,
+      # every caller before this) yields unbound, exactly as before:
+      # `CommandRules::Authorization#refuse_role_mismatch` is OPT-IN on
+      # both sides — no caller bound, no role declared, both unchecked.
+      # Query authorization runs on a wholly separate mechanism
+      # (`authorize policy, tenant: :field`, checked against an explicit
+      # `tenant:` argument — see `Runtime::TenantScope`), so binding a
+      # caller around a query has no effect on it TODAY; it is still
+      # accepted here, for symmetry and for the audit log, against the
+      # day a read model does check `Caller.current`.
+      def with_caller(role, actor_id, &block)
+        return block.call if role.nil?
+
+        Hecks.as_caller(role: role, actor_id: actor_id, &block)
+      end
+
       # `dry_run?` (Runtime::Dispatcher) understands only the OLD flat
       # legacy args shape — no to:/with: envelope, `route:` never passed
       # (its own header explains why: built directly against
@@ -153,11 +190,12 @@ module Hecks
       # WRITTEN — a full disk or a permissions problem is a `follow`
       # feature going dark, not a reason to refuse the dispatch/query/
       # state call that was actually asked for.
-      def record!(domain_name, tool:, summary:, source:, outcome:, verb: nil)
+      def record!(domain_name, tool:, summary:, source:, outcome:, verb: nil, role: nil, actor_id: nil)
         return unless domain_name
 
         entry = { time: Time.now.utc.iso8601, tool: tool, verb: verb, summary: summary, source: source,
-                  ok: outcome[:ok], id: outcome[:id], error: outcome[:error] }.compact
+                  role: role, actor_id: actor_id,
+                  ok: outcome[:ok], id: outcome[:id], error: outcome[:error], events: outcome[:events] }.compact
         FileUtils.mkdir_p(LOG_ROOT)
         File.open(log_path(domain_name), "a") { |f| f.puts(JSON.generate(entry)) }
       rescue StandardError
@@ -172,29 +210,34 @@ module Hecks
       # would_succeed: false`), not a failed call. A malformed request
       # (unknown command, a bad args shape) is still a failed call
       # (`ok: false`) either way — it never reached the domain to be asked.
-      def dispatch(runtime:, command:, summary:, args: {}, source: nil, dry_run: false)
+      def dispatch(runtime:, command:, summary:, args: {}, source: nil, dry_run: false, role: nil, actor_id: nil)
         bluebook = bluebook_for(runtime)
         tool     = dry_run ? "dry_run" : "dispatch"
-        outcome  = perform_dispatch(runtime, bluebook, command, summary, args, source, dry_run)
+        outcome  = perform_dispatch(runtime, bluebook, command, summary, args, source, dry_run, role, actor_id)
 
-        record!(bluebook.name, tool: tool, verb: outcome[:verb], summary: summary, source: source, outcome: outcome)
+        record!(bluebook.name, tool: tool, verb: outcome[:verb], summary: summary, source: source,
+                outcome: outcome, role: role, actor_id: actor_id)
         outcome.except(:verb)
       rescue *refusal_classes => e
         outcome = refused(e, summary: summary)
-        record!(bluebook&.name, tool: tool, summary: summary, source: source, outcome: outcome)
+        record!(bluebook&.name, tool: tool, summary: summary, source: source, outcome: outcome,
+                role: role, actor_id: actor_id)
         outcome
       end
 
-      def perform_dispatch(runtime, bluebook, command, summary, args, source, dry_run)
+      def perform_dispatch(runtime, bluebook, command, summary, args, source, dry_run, role, actor_id)
         require_summary!(summary)
         valid_source!(source)
+        valid_caller!(role, actor_id)
         cli      = Projector.call(:cli, bluebook: bluebook, options: { program: "mcp" })
         spec     = resolve!(cli, command, asking: false)
         envelope = CommandRequest.normalize(JsonDoor.deep_symbolize(args),
                                             receiver:        spec[:receiver],
                                             legacy_receiver: spec[:legacy_receiver])
 
-        result = dry_run ? dry_run_outcome(runtime, spec, envelope, summary: summary) : real_dispatch(runtime, spec, envelope, summary)
+        result = with_caller(role, actor_id) do
+          dry_run ? dry_run_outcome(runtime, spec, envelope, summary: summary) : real_dispatch(runtime, spec, envelope, summary)
+        end
         result.merge(verb: spec[:verb])
       end
 
@@ -224,36 +267,39 @@ module Hecks
       # refusing — a later step naming a record an earlier step never
       # created will refuse honestly on its own account, which is more
       # informative than silently dropping the rest of the batch.
-      def dispatch_batch(runtime:, steps:, summary:, source: nil)
+      def dispatch_batch(runtime:, steps:, summary:, source: nil, role: nil, actor_id: nil)
         require_summary!(summary)
         results = Array(steps).map do |raw|
           step = JsonDoor.deep_symbolize(raw)
           dispatch(runtime: runtime, command: step[:command], args: step[:args] || {},
-                   summary: summary, source: source)
+                   summary: summary, source: source, role: role, actor_id: actor_id)
         end
         { ok: results.all? { |r| r[:ok] }, summary: summary, results: results }
       rescue *refusal_classes => e
         refused(e, summary: summary)
       end
 
-      def query(runtime:, question:, summary:, args: {}, source: nil)
+      def query(runtime:, question:, summary:, args: {}, source: nil, role: nil, actor_id: nil)
         bluebook = bluebook_for(runtime)
-        outcome  = perform_query(bluebook, runtime, question, summary, args, source)
+        outcome  = perform_query(bluebook, runtime, question, summary, args, source, role, actor_id)
 
-        record!(bluebook.name, tool: "query", verb: outcome[:verb], summary: summary, source: source, outcome: outcome)
+        record!(bluebook.name, tool: "query", verb: outcome[:verb], summary: summary, source: source,
+                outcome: outcome, role: role, actor_id: actor_id)
         outcome.except(:verb)
       rescue *refusal_classes => e
         outcome = refused(e, summary: summary)
-        record!(bluebook&.name, tool: "query", summary: summary, source: source, outcome: outcome)
+        record!(bluebook&.name, tool: "query", summary: summary, source: source, outcome: outcome,
+                role: role, actor_id: actor_id)
         outcome
       end
 
-      def perform_query(bluebook, runtime, question, summary, args, source)
+      def perform_query(bluebook, runtime, question, summary, args, source, role, actor_id)
         require_summary!(summary)
         valid_source!(source)
+        valid_caller!(role, actor_id)
         cli  = Projector.call(:cli, bluebook: bluebook, options: { program: "mcp" })
         spec = resolve!(cli, question, asking: true)
-        rows = runtime.query(spec[:verb], **JsonDoor.deep_symbolize(args))
+        rows = with_caller(role, actor_id) { runtime.query(spec[:verb], **JsonDoor.deep_symbolize(args)) }
 
         ok(summary: summary, rows: rows.map { |row| JsonDoor.materialize(row) }).merge(verb: spec[:verb])
       end
@@ -444,17 +490,67 @@ module Hecks
       # pull instead of push.
       def follow(runtime:, limit: 20)
         bluebook = bluebook_for(runtime)
-        path     = log_path(bluebook.name)
-        entries  = File.exist?(path) ? File.readlines(path).last([limit.to_i, 1].max).map { |line| JSON.parse(line, symbolize_names: true) } : []
+        entries  = log_lines(bluebook.name).last([limit.to_i, 1].max)
 
         ok(domain: bluebook.name, entries: entries)
       rescue *refusal_classes => e
         refused(e)
       end
 
+      def log_lines(domain_name)
+        path = log_path(domain_name)
+        return [] unless File.exist?(path)
+
+        File.readlines(path).map { |line| JSON.parse(line, symbolize_names: true) }
+      end
+
+      # WHAT ACTUALLY HAPPENED, with payloads — distinct from `state`
+      # (what's stored NOW) and `history` (append-only operation
+      # SNAPSHOTS, no payload). NOT a domain-wide event-sourcing replay:
+      # "one boot per call" means `runtime.events` is always empty except
+      # during the very call that populated it, discarded the moment that
+      # call returns — there is no cross-call in-memory log to read here.
+      # So this reads the SAME durable audit log `follow` already tails
+      # (`record!` now stamps a successful dispatch's own announced
+      # events onto its log line), reshaped: `follow` answers "what was
+      # CALLED, in order, across every tool"; this answers "what HAPPENED
+      # to one aggregate/record" — events THIS DOOR witnessed, which is
+      # every real dispatch ever routed through it, but no more than that.
+      # `aggregate:` narrows to one aggregate; `id:` (requires
+      # `aggregate:` — an id alone is not unique across aggregates)
+      # narrows to one record's own events.
+      def events(runtime:, aggregate: nil, id: nil, limit: nil)
+        raise Runtime::TypeMismatch, "id: requires aggregate: too — an id alone is not unique across aggregates" if id && !aggregate
+
+        bluebook = bluebook_for(runtime)
+        fqn      = aggregate ? "#{bluebook.name}::#{aggregate_ir!(bluebook, aggregate).hecks_name}" : nil
+
+        found = log_lines(bluebook.name).filter_map do |entry|
+          next unless entry[:tool] == "dispatch" && entry[:ok] && entry[:events]
+          next if fqn && !entry[:verb].to_s.start_with?("#{fqn}.")
+          next if id && entry[:id] != id
+
+          entry[:events].map { |event| event.merge(time: entry[:time], verb: entry[:verb], id: entry[:id]) }
+        end.flatten(1)
+
+        found = found.last(limit.to_i) if limit
+
+        ok(domain: bluebook.name, events: found)
+      rescue *refusal_classes => e
+        refused(e)
+      end
+
       # ── shared shape ────────────────────────────────────────────────────
 
-      def refusal_classes = [Runtime::NotFound, Runtime::TypeMismatch, *Runtime::DOMAIN_REFUSALS]
+      # `Runtime::WiringError` BELONGS HERE TOO, alongside the true domain
+      # refusals — not because it IS one (it's a structural defect, not a
+      # rule the caller broke), but because "this domain isn't wired to
+      # answer what you're asking" (a `role:`+`actor_id:` caller reaching
+      # an authorization port nothing implements, a dry run against a
+      # port verb) is exactly the shape this door promises never crashes
+      # through it. `dry_run_outcome` already treats it this way locally;
+      # this makes every OTHER caller of `refusal_classes` do the same.
+      def refusal_classes = [Runtime::NotFound, Runtime::TypeMismatch, Runtime::WiringError, *Runtime::DOMAIN_REFUSALS]
 
       def ok(**fields) = { ok: true }.merge(fields)
 

--- a/spec/facade/mcp_door_spec.rb
+++ b/spec/facade/mcp_door_spec.rb
@@ -346,4 +346,110 @@ RSpec.describe Hecks::Facade::McpDoor do
       expect(result[:entries].last[:error]).to be_a(String)
     end
   end
+
+  describe ".dispatch with role:/actor_id:" do
+    it "checks a role-gated command against the bound caller, by string equality" do
+      wrong = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                       args: pizza_args, role: "Visitor")
+      right = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                       args: pizza_args, role: "Chef")
+
+      expect(wrong[:ok]).to be false
+      expect(wrong[:error]).to match(/role/i)
+      expect(right[:ok]).to be true
+    end
+
+    it "leaves a command that declares no role unaffected by an unrelated role binding" do
+      result = described_class.query(runtime: runtime, question: "available", summary: "spec", role: "Chef")
+
+      expect(result[:ok]).to be true
+    end
+
+    it "refuses actor_id given without role" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                        args: pizza_args, actor_id: "u1")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("actor_id")
+      expect(runtime.events).to be_empty
+    end
+
+    it "records role/actor_id on the audit log line, win or refuse" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                               args: pizza_args, role: "Chef")
+
+      entry = described_class.follow(runtime: runtime)[:entries].first
+      expect(entry[:role]).to eq("Chef")
+    end
+
+    # `boot_in_memory`'s fixture attaches Governance but binds no real
+    # authorization ADAPTER — an `actor_id` alongside `role` reaches for
+    # a live `Governance::RoleAssignment` lookup through one
+    # (`CommandRules::Authorization`'s own header), which is genuinely
+    # unanswerable here. `Runtime::WiringError` is the honest result;
+    # this proves it comes back as a structured refusal — role/actor_id
+    # STILL recorded on the log line — never a raised error crossing
+    # this door, the same promise every other refusal here keeps.
+    it "answers a structured refusal, not a raised error, when no authorization adapter can answer actor_id" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                        args: pizza_args, role: "Chef", actor_id: "u1")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to be_a(String)
+
+      entry = described_class.follow(runtime: runtime)[:entries].first
+      expect(entry[:role]).to eq("Chef")
+      expect(entry[:actor_id]).to eq("u1")
+      expect(entry[:ok]).to be false
+    end
+  end
+
+  describe ".events" do
+    it "answers no events for a domain nothing has dispatched against yet" do
+      result = described_class.events(runtime: runtime)
+
+      expect(result).to eq(ok: true, domain: "Pizzas", events: [])
+    end
+
+    it "answers the events a real dispatch announced, sourced from this door's own audit log" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+
+      result = described_class.events(runtime: runtime, aggregate: "Order", id: "Margherita")
+
+      expect(result[:ok]).to be true
+      expect(result[:events].map { |e| e[:name] }).to eq(["PizzaCreated"])
+      expect(result[:events].first[:id]).to eq("Margherita")
+    end
+
+    it "answers nothing for a dry run — nothing was actually announced" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               dry_run: true)
+
+      result = described_class.events(runtime: runtime, aggregate: "Order")
+
+      expect(result[:events]).to eq([])
+    end
+
+    it "answers nothing for an id that named no dispatch" do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+
+      result = described_class.events(runtime: runtime, aggregate: "Order", id: "Nope")
+
+      expect(result[:events]).to eq([])
+    end
+
+    it "refuses id: without aggregate:" do
+      result = described_class.events(runtime: runtime, id: "Margherita")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("aggregate")
+    end
+
+    it "refuses an aggregate the domain never declared" do
+      result = described_class.events(runtime: runtime, aggregate: "Calzone")
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to include("declares no aggregate")
+    end
+  end
 end


### PR DESCRIPTION
Builds the two follow-up picks from the survey wishlist discussion: real caller identity on `dispatch`/`query`, and an `events` tool.

## `role:`/`actor_id:`

Bind a real caller for the call's duration via `Hecks.as_caller`, so a role-gated command's authorization is actually *checked* through this door rather than merely documented by `describe`. `actor_id` without `role` refuses (a caller names WHO through WHICH role they hold, never WHO alone). Both are recorded on the audit log line alongside `source`, so `follow` shows who dispatched, not just what.

## `events`

What actually *happened* to one aggregate/record, with payloads — distinct from `state` (current) and `history` (append-only snapshots, no payload). Sourced from this door's own durable audit log, not `runtime.events`: "one boot per call" means the in-memory event log is always empty except during the very call that populated it, so `record!` now stamps a successful dispatch's own announced events onto its log line, and `events` reads them back from there, filtered by aggregate/id. Honestly scoped in its own docs as events *this door witnessed*, not a full domain-wide event-sourcing replay — verified end to end against the real (Heki-backed) `examples/banking` domain, not just the in-memory spec fixture.

## Also fixed while in here

- `refusal_classes` now includes `Runtime::WiringError` — an unbound authorization port (`actor_id:` reaching a domain with no live Governance adapter) used to raise straight through `dispatch`/`query` uncaught, the one place this door could still crash instead of answering a structured refusal.
- A real bug in `bin/hecks_mcp_door`, found while re-reading it: rubocop's own `Style/DoubleNegation` autocorrect from the previous PR silently changed `dry_run: !!a["dry_run"]` to `dry_run: !a["dry_run"].nil?`, which treats an explicit `"dry_run": false` the same as `true` (`.nil?` is `false` either way). Fixed to `a["dry_run"] == true`, and the same-shaped `deep: !!a["deep"]` rewritten the same way pre-emptively.

## Testing

11 new spec examples (46 total in `spec/facade/mcp_door_spec.rb`). Full suite green (1922 examples), fuzzer green, rubocop clean — confirmed by the repo's pre-push hooks. Role/actor_id and `events` also verified end-to-end through the real `bin/hecks_mcp_door` process against live `examples/banking` (a genuine role-mismatch refusal, a genuine authorized dispatch, `events` correctly reflecting it) — any incidental fixture-data mutation from that testing was reverted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)