### PR TITLE
Add chess as a new example domain (ADR 0026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ replace.
 
 <!-- generated:begin id=corpus -->
 - **banking** — Customers hold accounts, accounts move money, and every movement is a transfer that can fail halfway. The domain that has to get it right twice — once in the rules, once in the recovery.
+- **chess** — A chess game: pieces with no life outside the board that holds them, a status that only ever moves one legal way at a time, and turn order and check enforced by declaration rather than a hand-written engine.
 - **compliance** — Something elsewhere already acted to contain a risk; this domain tracks the human review that decides what happens next.
 - **pizzas** — Put toppings on a pizza and sell it to a customer.
 - **roster** — A crew roster: seats added one at a time, members enlisted, each seated once — the smallest domain whose every rule is a question asked of a LIST.

--- a/examples/chess/bluebook/chess.bluebook
+++ b/examples/chess/bluebook/chess.bluebook
@@ -1,0 +1,377 @@
+Hecks.bluebook "Chess" do
+  vision "A chess game: pieces with no life outside the board that holds them, a status that only ever moves one legal way at a time, and turn order and check enforced by declaration rather than a hand-written engine."
+  supporting
+
+  # WHY THIS DOMAIN EXISTS (ADR 0026) — `entity`, `lifecycle`/`transition`,
+  # `policy`, and `ensures` are all declared by the language and only
+  # thinly exercised by the rest of the corpus. A chess game gives each
+  # one real, non-contrived work: a piece has no identity or lifecycle
+  # apart from the game it belongs to (entity); a game's own status moves
+  # in_progress -> check -> checkmate/stalemate/resigned/draw and refuses
+  # every illegal jump (lifecycle); turn order and check are announced by
+  # a policy reacting to a move actually having happened, not computed
+  # inline (policy); and a move has to leave the board in a state its own
+  # postcondition can still vouch for after the fact (ensures).
+  #
+  # DELIBERATELY SIMPLIFIED, on purpose, per this domain's own charter:
+  # this is not a chess engine. Move-shape legality (can a bishop
+  # actually reach that square) is trusted from the caller, the same way
+  # a real client would already have computed it before ever sending the
+  # command. What this domain enforces structurally is everything a rules
+  # engine cannot get away with skipping: whose turn it is, whether the
+  # game is still being played at all, that a square is not already
+  # occupied by a piece of the same color, and that the game's own status
+  # can only ever take one of its declared, legal transitions.
+  aggregate "Game" do
+    description "One game: its pieces, whose turn it is, and how the game currently stands."
+
+    identified_by :label
+
+    attribute :label,       GameLabel
+    attribute :turn,        Color
+    attribute :draw_offer,  DrawOffer
+    attribute :ply,         Ply
+    attribute :pieces,      list_of(Piece)
+
+    value_object "GameLabel" do
+      attribute :value, String
+      invariant("a game is labeled") { !value.to_s.empty? }
+    end
+
+    value_object "PieceId" do
+      attribute :value, String
+      invariant("a piece has an id") { !value.to_s.empty? }
+    end
+
+    # FILE/RANK, ZERO-INDEXED — file 0 is the a-file, rank 0 is white's
+    # own back rank and rank 7 is black's, the same orientation a real
+    # client's own board representation would already use.
+    value_object "Square" do
+      attribute :file, Integer
+      attribute :rank, Integer
+      invariant("a square sits on the board") { file >= 0 && file <= 7 && rank >= 0 && rank <= 7 }
+    end
+
+    value_object "Color" do
+      attribute :value, String, one_of: ["white", "black"]
+    end
+
+    value_object "PieceKind" do
+      attribute :value, String, one_of: ["pawn", "knight", "bishop", "rook", "queen", "king"]
+    end
+
+    # WHETHER A PIECE HAS EVER MOVED — a real rule (castling and a pawn's
+    # own first-move double-step both depend on it) kept as a bare fact
+    # this domain records rather than a legality check it enforces, the
+    # same simplification this file's own header names.
+    value_object "MovedFlag" do
+      attribute :value, String, one_of: ["unmoved", "moved"]
+    end
+
+    # THE FACT A MOVER DECLARES ABOUT THE OPPONENT'S OWN SIDE, immediately
+    # after the move — this domain trusts it the same way it trusts move
+    # shape, and the two policies below are what turn a true declaration
+    # into the game's own recorded status.
+    value_object "GameOutcome" do
+      attribute :value, String, one_of: ["ongoing", "check", "checkmate", "stalemate"]
+    end
+
+    # A CLOSED SET ONE MEMBER WIDER THAN Color — "none" is the state
+    # nobody has offered a draw, which Color itself has no member for.
+    # `OfferDraw`, below, bridges a Color argument straight into this
+    # field (`sets :draw_offer, to: :by`): every Color member is also a
+    # DrawOffer member, so the bridge can never refuse.
+    value_object "DrawOffer" do
+      attribute :value, String, one_of: ["none", "white", "black"]
+    end
+
+    value_object "Ply" do
+      attribute :value, Integer
+      invariant("ply never goes negative") { value >= 0 }
+    end
+
+    entity "Piece" do
+      description "One piece — no identity, no lifecycle, no query of its own outside the game that holds it. A captured piece is never a standalone record: it stays exactly where it always lived, in this same list, marked captured."
+
+      attribute :id,     PieceId
+      attribute :kind,   PieceKind
+      attribute :color,  Color
+      attribute :square, Square
+      attribute :moved,  MovedFlag
+
+      identified_by :id
+
+      # DECLARED ONCE, ON THE PIECE (the same shape banking's own
+      # LedgerEntry uses for "customer is active"/"account is open") —
+      # Move and Capture both need the identical fact about the GAME they
+      # belong to, read through `parent` rather than retyped on each.
+      given("only an active game may be played") { parent.status == "in_progress" || parent.status == "check" }
+
+      lifecycle :status, default: "on_board" do
+        transition "Capture" => "captured", from: "on_board"
+      end
+
+      command "Move", from: "on_board" do
+        goal "Move this piece to a new square, on its own color's turn"
+
+        attribute :id,          PieceId
+        attribute :destination, Square
+        attribute :by,          Color
+        attribute :outcome,     GameOutcome
+
+        given("only an active game may be played")
+        given("only the color to move may move a piece") { parent.turn.value == by.value }
+        given("a piece may only be moved by its own color") { by.value == color.value }
+        given("the destination differs from the current square") { square.file != destination.file || square.rank != destination.rank }
+        given("no piece of the same color already stands on the destination") do
+          parent.pieces.none? { |p| p.status == "on_board" && p.color.value == color.value && p.square.file == destination.file && p.square.rank == destination.rank }
+        end
+
+        sets :square, to: :destination
+        sets :moved,  to: "moved"
+
+        ensures("the piece is exactly where it was told to move") { square.file == destination.file && square.rank == destination.rank }
+
+        emits "PieceMoved"
+      end
+
+      command "Capture", from: "on_board" do
+        goal "Remove this piece from play, taken by the opposing side"
+
+        attribute :id, PieceId
+        attribute :by, Color
+
+        given("only an active game may be played")
+        given("only the color to move may capture") { parent.turn.value == by.value }
+        given("a side may only capture the opposing color's piece") { by.value != color.value }
+
+        emits "PieceCaptured"
+      end
+
+      query "OnBoard" do
+        description "Every piece still on the board, whichever game it belongs to."
+        where(status: "on_board")
+      end
+    end
+
+    # A draw offer only ever came from one side or nobody — declared once
+    # so AcceptDraw and DeclineDraw read the identical fact rather than
+    # retyping it.
+    given("a draw was actually offered, by the other side") { draw_offer.value != "none" && draw_offer.value != by.value }
+
+    lifecycle :status, default: "in_progress" do
+      # ORDER MATTERS HERE — every policy below reacting to "PieceMoved"
+      # fires in the order its own `policy` block is declared (Runtime::
+      # PolicyInterpreter#policies_for reads a bluebook's own array in
+      # declaration order), and `AdvanceTurn` is declared, and therefore
+      # runs, BEFORE the three Declare* policies further down. AdvanceTurn
+      # unconditionally clears a stale "check" back to "in_progress" every
+      # time a piece moves; only after that does a genuine new check,
+      # checkmate, or stalemate get declared on top of it. Reverse that
+      # declaration order and a freshly-declared check would be wiped the
+      # instant the turn advances.
+      transition "AdvanceTurn"      => "in_progress", from: ["in_progress", "check"]
+      transition "DeclareCheck"     => "check",       from: "in_progress"
+      transition "DeclareCheckmate" => "checkmate",   from: ["in_progress", "check"]
+      transition "DeclareStalemate" => "stalemate",   from: "in_progress"
+      transition "Resign"           => "resigned",    from: ["in_progress", "check"]
+      transition "AcceptDraw"       => "draw",        from: ["in_progress", "check"]
+    end
+
+    command "Start" do
+      goal "Begin a new, empty game"
+
+      attribute :label, GameLabel
+
+      sets :turn,       to: "white"
+      sets :draw_offer, to: "none"
+      sets :ply,        to: 0
+
+      emits "GameStarted"
+    end
+
+    command "PlacePiece" do
+      goal "Set a piece down on the board — used to build the starting position, or any position a test needs"
+
+      reference_to Game
+      attribute :id,     PieceId
+      attribute :kind,   PieceKind
+      attribute :color,  Color
+      attribute :square, Square
+
+      given("only an active game accepts new pieces") { status == "in_progress" || status == "check" }
+      given("a piece id is not reused") { pieces.none? { |p| p.id.value == id.value } }
+      given("no two pieces already share a square") do
+        pieces.none? { |p| p.status == "on_board" && p.square.file == square.file && p.square.rank == square.rank }
+      end
+
+      sets :pieces, append: { id: :id, kind: :kind, color: :color, square: :square, moved: "unmoved" }
+
+      emits "PiecePlaced"
+    end
+
+    # THE ONLY DOOR A CALLER USES TO MOVE A PIECE — Piece.Move itself is
+    # never dispatched directly here. `delegates_to` makes the entity's
+    # own refusal this command's refusal, synchronously, in the same
+    # dispatch, rather than a reaction a caller would have to poll a log
+    # to see the result of.
+    command "MovePiece" do
+      goal "Move one of your own pieces, on your turn, on the caller's behalf"
+
+      reference_to Game
+      attribute :id,          PieceId
+      attribute :destination, Square
+      attribute :by,          Color
+      attribute :outcome,     GameOutcome
+
+      ensures("the mover's own king remains on the board after the move") do
+        pieces.any? { |p| p.kind.value == "king" && p.color.value == by.value && p.status == "on_board" }
+      end
+
+      delegates_to "Piece.Move", with: { id: :id, destination: :destination, by: :by, outcome: :outcome }
+    end
+
+    command "CapturePiece" do
+      goal "Capture an opposing piece, on the caller's behalf — dispatched before the capturing piece's own MovePiece onto the vacated square"
+
+      reference_to Game
+      attribute :id, PieceId
+      attribute :by, Color
+
+      delegates_to "Piece.Capture", with: { id: :id, by: :by }
+    end
+
+    command "AdvanceTurn" do
+      goal "Pass the move to the other color and clear any prior check, after a piece has moved"
+
+      reference_to Game
+      attribute :turn, Color
+
+      given("only an active game continues") { status == "in_progress" || status == "check" }
+
+      sets :turn
+      sets :ply, increment: 1
+
+      emits "TurnAdvanced"
+    end
+
+    command "DeclareCheck" do
+      goal "Record that the side now to move stands in check"
+
+      reference_to Game
+      attribute :by, Color
+
+      emits "CheckDeclared"
+    end
+
+    command "DeclareCheckmate" do
+      goal "End the game — the side to move has no way out of check"
+
+      reference_to Game
+      attribute :by, Color
+
+      emits "GameEnded"
+    end
+
+    command "DeclareStalemate" do
+      goal "End the game — the side to move has no legal move and is not in check"
+
+      reference_to Game
+      attribute :by, Color
+
+      emits "GameEnded"
+    end
+
+    command "Resign" do
+      goal "Give up the game, ending it immediately"
+
+      reference_to Game
+      attribute :by, Color
+
+      emits "GameResigned"
+    end
+
+    command "OfferDraw" do
+      goal "Offer a draw to the other side"
+
+      reference_to Game
+      attribute :by, Color
+
+      given("only an active game accepts a draw offer") { status == "in_progress" || status == "check" }
+      given("a side does not re-offer a draw already on the table") { draw_offer.value == "none" }
+
+      sets :draw_offer, to: :by
+
+      emits "DrawOffered"
+    end
+
+    command "AcceptDraw" do
+      goal "Accept the other side's outstanding draw offer"
+
+      reference_to Game
+      attribute :by, Color
+
+      given("a draw was actually offered, by the other side")
+
+      sets :draw_offer, to: "none"
+
+      emits "DrawAgreed"
+    end
+
+    command "DeclineDraw" do
+      goal "Turn down the other side's draw offer"
+
+      reference_to Game
+      attribute :by, Color
+
+      given("a draw was actually offered, by the other side")
+
+      sets :draw_offer, to: "none"
+
+      emits "DrawDeclined"
+    end
+
+    query "InProgress" do
+      description "Every game still being played, check included."
+      where(status: "in_progress")
+    end
+  end
+
+  # TURN ALTERNATION — declared FIRST, see the lifecycle's own comment on
+  # why declaration order matters here. Exactly one of these two ever
+  # matches a given "PieceMoved" event, since `by` is always exactly one
+  # Color.
+  policy "OnWhiteMovedAdvanceTurn" do
+    on "PieceMoved"
+    where { by.value == "white" }
+    trigger Game::AdvanceTurn, with: { turn: "black" }
+  end
+
+  policy "OnBlackMovedAdvanceTurn" do
+    on "PieceMoved"
+    where { by.value == "black" }
+    trigger Game::AdvanceTurn, with: { turn: "white" }
+  end
+
+  # CHECK DETECTION — reacting to a move having actually happened, not
+  # computed inline inside `Piece.Move` itself. Each `where` reads the
+  # `outcome` the mover declared on the very event `AdvanceTurn`, above,
+  # already reacted to.
+  policy "OnCheckDeclaredAfterMove" do
+    on "PieceMoved"
+    where { outcome.value == "check" }
+    trigger Game::DeclareCheck, with: { by: :by }
+  end
+
+  policy "OnCheckmateDeclaredAfterMove" do
+    on "PieceMoved"
+    where { outcome.value == "checkmate" }
+    trigger Game::DeclareCheckmate, with: { by: :by }
+  end
+
+  policy "OnStalemateDeclaredAfterMove" do
+    on "PieceMoved"
+    where { outcome.value == "stalemate" }
+    trigger Game::DeclareStalemate, with: { by: :by }
+  end
+end

--- a/examples/chess/bluebook/chess.hecksagon
+++ b/examples/chess/bluebook/chess.hecksagon
@@ -1,0 +1,3 @@
+Hecks.hecksagon "Chess" do
+  Chess::Game.persisted_by("PostgresEra")
+end

--- a/examples/chess/bluebook/chess.world
+++ b/examples/chess/bluebook/chess.world
@@ -1,0 +1,7 @@
+Hecks.world "Chess" do
+  realm "Examples"
+
+  persisted_by("PostgresEra") do
+    database "postgres://localhost/hecks_chess"
+  end
+end

--- a/spec/corpus/chess.json
+++ b/spec/corpus/chess.json
@@ -1,0 +1,82 @@
+{
+  "name": "chess-parity",
+  "note": "One game through most of the domain — start, four pieces placed, a move each side, a draw offered and accepted — exercising the entity's own lifecycle, the turn-alternation policy, and the aggregate's own lifecycle all in one pass.",
+  "domain": "examples/chess",
+  "expectations": {
+    "events": 11
+  },
+  "steps": [
+    {
+      "verb": "Chess::Game.Start",
+      "args": { "label": { "value": "g1" } }
+    },
+    {
+      "verb": "Chess::Game.PlacePiece",
+      "args": {
+        "label": { "value": "g1" },
+        "id": { "value": "wk" },
+        "kind": { "value": "king" },
+        "color": { "value": "white" },
+        "square": { "file": 4, "rank": 0 }
+      }
+    },
+    {
+      "verb": "Chess::Game.PlacePiece",
+      "args": {
+        "label": { "value": "g1" },
+        "id": { "value": "wr1" },
+        "kind": { "value": "rook" },
+        "color": { "value": "white" },
+        "square": { "file": 0, "rank": 0 }
+      }
+    },
+    {
+      "verb": "Chess::Game.PlacePiece",
+      "args": {
+        "label": { "value": "g1" },
+        "id": { "value": "bk" },
+        "kind": { "value": "king" },
+        "color": { "value": "black" },
+        "square": { "file": 4, "rank": 7 }
+      }
+    },
+    {
+      "verb": "Chess::Game.PlacePiece",
+      "args": {
+        "label": { "value": "g1" },
+        "id": { "value": "bn1" },
+        "kind": { "value": "knight" },
+        "color": { "value": "black" },
+        "square": { "file": 1, "rank": 7 }
+      }
+    },
+    {
+      "verb": "Chess::Game.MovePiece",
+      "args": {
+        "label": { "value": "g1" },
+        "id": { "value": "wr1" },
+        "destination": { "file": 0, "rank": 3 },
+        "by": { "value": "white" },
+        "outcome": { "value": "ongoing" }
+      }
+    },
+    {
+      "verb": "Chess::Game.MovePiece",
+      "args": {
+        "label": { "value": "g1" },
+        "id": { "value": "bn1" },
+        "destination": { "file": 2, "rank": 5 },
+        "by": { "value": "black" },
+        "outcome": { "value": "ongoing" }
+      }
+    },
+    {
+      "verb": "Chess::Game.OfferDraw",
+      "args": { "label": { "value": "g1" }, "by": { "value": "white" } }
+    },
+    {
+      "verb": "Chess::Game.AcceptDraw",
+      "args": { "label": { "value": "g1" }, "by": { "value": "black" } }
+    }
+  ]
+}

--- a/spec/parser_parity_spec.rb
+++ b/spec/parser_parity_spec.rb
@@ -198,8 +198,22 @@ RSpec.describe "Rust parser parity (hecks-parse)", io: true do
   # against Ruby's own `ir.json` before moving out of PENDING_MEMBERS,
   # not left stale — the safety net doing exactly its job, catching a
   # PENDING member that stopped failing the way its own reason claimed.
+  #
+  # "chess" — a new real corpus member (`examples/chess/`, ADR 0026's
+  # own named gap: `entity`, `lifecycle`/`transition`, `policy`, and
+  # `ensures` given real, non-contrived work — a piece with no life
+  # outside the game that holds it, a status that refuses every illegal
+  # jump, turn order and check announced by a policy reacting to a move
+  # having happened, and a move whose own postcondition is checked after
+  # the fact). Built entirely out of constructs `delegates_to`/`entity`/
+  # `lifecycle`/`policy`/`ensures`'s own existing byte-matched users
+  # (roster, banking) already exercise, so it round-trips the same way
+  # they do — confirmed byte-exact against Ruby's own `ir.json` before
+  # being added here rather than left in PENDING_MEMBERS to claim a
+  # parser gap this domain does not actually have.
   PENDING_MEMBERS = (PARITY_CORPUS_MEMBERS.map(&:first) -
-                     %w[pizzas identity governance console_settings expression translation banking compliance roster bluebook_language] -
+                     %w[pizzas identity governance console_settings expression translation banking compliance roster
+                        chess bluebook_language] -
                      PARITY_FIXTURE_MEMBERS.map { |member| fixture_stem(member) })
                     .to_h { |stem| [stem, "Stage 1: parser not implemented yet — see rust/parser/src/parse/mod.rs"] }.freeze
 
@@ -224,7 +238,7 @@ RSpec.describe "Rust parser parity (hecks-parse)", io: true do
   # Derived the SAME way PARITY_CORPUS_MEMBERS itself is (`bluebook_in`/
   # `hecksagon_in`/`chapter_name_of`), not hand-listed, so this stays
   # honest if pizzas.bluebook's own file ever moves.
-  REAL_PARITY_MEMBERS = %w[pizzas banking compliance roster].to_h { |stem|
+  REAL_PARITY_MEMBERS = %w[pizzas banking compliance roster chess].to_h { |stem|
     domain = PARITY_EXAMPLE_ROOTS.find { |path| File.basename(path) == stem } or raise "no examples/#{stem} directory"
     bluebooks = bluebooks_in(domain)
     raise "#{domain} has no .bluebook" if bluebooks.empty?


### PR DESCRIPTION
## Summary

Lands `examples/chess/` as a new corpus member, chosen deliberately because it exercises the constructs ADR 0026 found under-used across the corpus: `entity`, `lifecycle`/`transition`, `policy`, and `ensures`. Registers `chess` in `REAL_PARITY_MEMBERS` (`spec/parser_parity_spec.rb`).

## Design

- **Aggregate `Game`** (label-identified): `turn`, `draw_offer`, `ply`, `pieces`.
- **Entity `Piece`** (owned by `Game`, no life or identity outside it): `id`, `kind`, `color`, `square`, `moved`. Own lifecycle `on_board → captured` (terminal). Its `Move`/`Capture` commands are reached only via `Game`'s delegating doors (`MovePiece`/`CapturePiece`, via `delegates_to`).
- **`Game`'s lifecycle**: `in_progress → check/checkmate/stalemate/resigned/draw`, with real illegal-transition refusals (no exit from any terminal state — checkmate can't go back to in_progress, etc.).
- **Policies**: two alternate turn after every `PieceMoved` (`OnWhiteMovedAdvanceTurn`/`OnBlackMovedAdvanceTurn`), declared before three that announce check/checkmate/stalemate from the mover's self-declared `outcome` — declaration order is load-bearing (documented inline), since turn-advance must clear a stale "check" before a fresh one is declared.
- **`ensures`**: `Piece.Move`'s own (destination reached) and `Game.MovePiece`'s whole-board postcondition (the mover's own king remains on the board after the move).
- **`OfferDraw`/`AcceptDraw`/`DeclineDraw`**: a small two-party flow.

## Deliberate simplifications

Move-shape legality (e.g. "can a bishop actually reach that square") is trusted from the caller — this is a DSL example domain, not a chess engine. What's structurally enforced: turn order, whether the game is still being played, that a destination isn't already held by the mover's own side, and the lifecycle's legal transitions. Check/checkmate/stalemate are self-declared facts from the mover; policies react to the declaration (the genuinely load-bearing part ADR 0026 cares about). Pawn promotion was left out as unnecessary scope for what the ADR requires.

One naming note: the move-destination argument is `destination`, not `to`, because `to:` is a reserved routing keyword on `Runtime::Dispatcher#dispatch` — `to:` there would silently break raw/JSON-script dispatch.

## Verification

- `bundle exec rspec` — 1913 examples, all green
- `bundle exec rspec --tag io` — 238 examples, including `parser_parity_spec.rb`'s byte-exact chess check
- `bin/model_check` — 0 errors; 5 expected `stuck_state` warnings on genuinely terminal states (same shape as banking's `CardPayment`); `ALLOWED_FINDINGS` untouched since nothing here is gated
- `bin/doc_coverage`, `rubocop` (one touched Ruby file), plus targeted runs of `word_coverage_spec`, `vocabulary_conformance_spec`, `plurality/optionality_coverage_spec`, `ir_golden_spec`, `guides_spec`, `reference_golden_spec`, `reference_doctest_spec`, `behaviors_examples_spec`, `spec/fuzzing/meta_domain_coverage_spec.rb`

No `lib/hecks/language/bluebook/*` file touched, no new DSL keyword invented — every construct used already has a real, byte-matched precedent elsewhere in the corpus (`delegates_to` from roster; `entity`/`lifecycle`/`policy`/`ensures` and the entity-level named-`given` pattern from banking's `LedgerEntry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)