### PR TITLE
ADR 0026 was already implemented — close the one real gap it missed, fix the stale status line

### DIFF
--- a/docs/decisions/0026-the-language-uses-everything-it-declares-and-what-it-does-not-use-is-a-sub-language.md
+++ b/docs/decisions/0026-the-language-uses-everything-it-declares-and-what-it-does-not-use-is-a-sub-language.md
@@ -1,6 +1,6 @@
 # The language uses everything it declares, and what it does not use is a sub-language
 
-**Status:** Accepted — not yet implemented. Depends on ADR 0025's principle 4 (a word earns its place by being used) and on `MetaValidator.defer`, which landed in `97dfdf9` and made the language bootable as an ordinary domain in the first place.
+**Status:** Accepted — implemented. The self-use gate landed as `spec/self_use_spec.rb` (S16), modelled on `spec/fuzzing/meta_domain_coverage_spec.rb` as this decision specifies. All three commissioned remodels landed too: `Paging` was extracted as its own attached sub-language (`lib/hecks/language/bluebook/attaches/paging.bluebook`); `Keyword`/`Argument` carry a real `lifecycle :status` with declared transitions in place of the old plain-attribute `Status`; `Member`, `Dispatch`, and `Handler` are genuine entities of `ValueObject`, `Handler`, and `ProcessManager` respectively (S14, S17). Verified directly against the live grammar: `entity` (5 real declarations), `lifecycle`/`transition` (2), and `ensures` (1) are now genuinely used by the language's own definition. `policy`, `process_manager`, `provenance`, `group_by`, `authorize`, and `generic` remain honest, itemized `SELF_USE_KNOWN_GAPS` entries in the gate, each carrying a one-line reason rather than a silent exemption — per this decision's own Consequences section, that is the intended steady state, not a shortfall. Depends on ADR 0025's principle 4 (a word earns its place by being used) and on `MetaValidator.defer`, which landed in `97dfdf9` and made the language bootable as an ordinary domain in the first place.
 
 ## Context
 
@@ -80,12 +80,6 @@ A related consequence, accepted: the set of legal words in a body becomes a func
 
 - Whether `expression` and `translation` are retrofitted to the same seam mechanism. They attach differently today, and unifying them is not required for paging to move.
 - Whether the self-use gate applies to each sub-language against its own corpus, or only to the core. A `Paging` sub-language used by banking and not by the language is fine; the question is what the rule *says* rather than what happens to be true.
-
-## Implementation note
-
-The self-use gate has landed as `spec/self_use_spec.rb`, modelled on `spec/fuzzing/meta_domain_coverage_spec.rb` as this decision specifies, and is green. Verified directly against the live grammar rather than trusting the numbers above: `entity` (5 real declarations), `lifecycle`/`transition` (2), and `ensures` (1) are now genuinely used by the language's own definition; `policy`, `process_manager`, `provenance`, `group_by`, `authorize`, and `generic` remain honest, itemized `SELF_USE_KNOWN_GAPS` entries, each carrying a one-line reason rather than a silent exemption.
-
-Separately from the gate itself, this repository's history also already carries all three remodels this decision commissions: `Paging` was extracted as its own attached sub-language (`lib/hecks/language/bluebook/attaches/paging.bluebook`), `Keyword`/`Argument` carry a real `lifecycle :status` with declared transitions in place of the old plain-attribute `Status`, and `Member`/`Dispatch`/`Handler` are genuine entities of `ValueObject`/`Handler`/`ProcessManager` respectively. The `Status:` line above is left as-is pending an explicit decision on this point — this note only records what a fresh read of the working tree found already true.
 
 ## Rejected alternatives
 

--- a/docs/decisions/0026-the-language-uses-everything-it-declares-and-what-it-does-not-use-is-a-sub-language.md
+++ b/docs/decisions/0026-the-language-uses-everything-it-declares-and-what-it-does-not-use-is-a-sub-language.md
@@ -81,6 +81,12 @@ A related consequence, accepted: the set of legal words in a body becomes a func
 - Whether `expression` and `translation` are retrofitted to the same seam mechanism. They attach differently today, and unifying them is not required for paging to move.
 - Whether the self-use gate applies to each sub-language against its own corpus, or only to the core. A `Paging` sub-language used by banking and not by the language is fine; the question is what the rule *says* rather than what happens to be true.
 
+## Implementation note
+
+The self-use gate has landed as `spec/self_use_spec.rb`, modelled on `spec/fuzzing/meta_domain_coverage_spec.rb` as this decision specifies, and is green. Verified directly against the live grammar rather than trusting the numbers above: `entity` (5 real declarations), `lifecycle`/`transition` (2), and `ensures` (1) are now genuinely used by the language's own definition; `policy`, `process_manager`, `provenance`, `group_by`, `authorize`, and `generic` remain honest, itemized `SELF_USE_KNOWN_GAPS` entries, each carrying a one-line reason rather than a silent exemption.
+
+Separately from the gate itself, this repository's history also already carries all three remodels this decision commissions: `Paging` was extracted as its own attached sub-language (`lib/hecks/language/bluebook/attaches/paging.bluebook`), `Keyword`/`Argument` carry a real `lifecycle :status` with declared transitions in place of the old plain-attribute `Status`, and `Member`/`Dispatch`/`Handler` are genuine entities of `ValueObject`/`Handler`/`ProcessManager` respectively. The `Status:` line above is left as-is pending an explicit decision on this point — this note only records what a fresh read of the working tree found already true.
+
 ## Rejected alternatives
 
 - **The core declaring its own seams** (`Query` admits `Paging`). Rejected because it puts a list of possible extensions into the core grammar — a core that names `Paging` knows about paging, which is the very thing being removed. Its advantage, that reading `Query` tells you what a query body admits, is answered instead by `bin/reference` rendering the loaded sub-languages onto the context page they attach to.

--- a/spec/self_use_spec.rb
+++ b/spec/self_use_spec.rb
@@ -16,11 +16,16 @@ require "spec_helper"
 # names as already closed by the two remodels it commissions (S17, S14)
 # — this spec is what makes "closed" a checked fact rather than a claim
 # in a commit message. The rest — `policy`/`process_manager`/`ensures`/
-# `provenance`/`group_by`/`authorize` — are the ADR's own remaining
-# list, ADOPTED where a real, non-decorative use exists (S16 added one:
-# `ensures` on `Bluebook.Attach`) and NAMED where it does not — the ADR
-# itself warns against the alternative ("Forcing every construct into
-# the language... is decoration... modelling to satisfy a tool").
+# `provenance`/`group_by`/`authorize`/`generic` — are the ADR's own
+# remaining list, ADOPTED where a real, non-decorative use exists (S16
+# added one: `ensures` on `Bluebook.Attach`) and NAMED where it does
+# not — the ADR itself warns against the alternative ("Forcing every
+# construct into the language... is decoration... modelling to satisfy
+# a tool"). `generic` is the ADR's own Consequences section, named
+# explicitly there ("a candidate for demotion rather than adoption")
+# rather than in its main table, which is why it was missing here until
+# this session verified it against the live grammar and found the same
+# zero the ADR predicted.
 #
 # SCOPED TO THE CORE, NOT EVERY ATTACHED SUB-LANGUAGE — the ADR leaves
 # this open ("Whether the self-use gate applies to each sub-language
@@ -89,7 +94,14 @@ RSpec.describe "the language uses everything the core grammar declares" do
     "ensures"                => -> { every_command.sum { |c| c.ensures.to_a.size } },
     "provenance"             => -> { every_command.count { |c| c.provenance } },
     "group_by"               => -> { SELF_USE_LANGUAGE.read_models.count { |r| !r.group_by.to_a.empty? } },
-    "authorize"              => -> { every_query.count(&:authorization) }
+    "authorize"              => -> { every_query.count(&:authorization) },
+    # ADR 0026's own Consequences section, verbatim: "`generic` is a
+    # candidate for demotion rather than adoption... a subdomain
+    # classification the language itself never applies." The language
+    # declares itself `core` (`SELF_USE_LANGUAGE.classification`), the
+    # sibling word in the same closed set — never `generic` — so this
+    # counts real self-classification, not a grammar row.
+    "generic"                => -> { SELF_USE_LANGUAGE.classification == "generic" ? 1 : 0 }
   }.freeze
 
   # NAMED, REASONED — never a silent exclusion. Each entry is the ADR's
@@ -132,7 +144,16 @@ RSpec.describe "the language uses everything the core grammar declares" do
                          "authorize gates a query behind a tenant/policy boundary — the " \
                          "language has no multi-tenant concept of its own; a grammar row is " \
                          "not scoped to a caller, and inventing a tenant for the language's " \
-                         "own records to be walled off by would be pure decoration."
+                         "own records to be walled off by would be pure decoration.",
+    "generic"         =>
+                         "generic marks a bluebook as NOT a real business domain, so that " \
+                         "Expression/Translation/Paging can classify themselves that way — " \
+                         "the language's own chapter IS the canonical grammar, declared " \
+                         "`core`, and applying `generic` reflexively to the definition that " \
+                         "does the classifying would be the sub-language demotion test " \
+                         "turned on itself. ADR 0025 already names it as zero-corpus-use " \
+                         "everywhere, not just here; ADR 0026's own Consequences section " \
+                         "names this exact gap by hand."
   }.freeze
 
   it "uses every construct it declares, or names why not" do


### PR DESCRIPTION
## Summary

Started this to build ADR 0026's self-use gate from scratch. Turned out both halves — the gate (`spec/self_use_spec.rb`, commit `0f300543` "S16") and the full remodel it commissions (`Paging` extraction, `Status`→`lifecycle`, `Member`/`Dispatch`/`Handler`→entities) — were already on `main`. The ADR's `Status:` line just never got updated to say so.

## What this PR actually does

1. **Closes one real, verified gap the existing gate missed**: `generic` (named explicitly in ADR 0026's own Consequences section as "a candidate for demotion rather than adoption," zero corpus use per ADR 0025) had no tracking in `spec/self_use_spec.rb`'s `SELF_USE_KNOWN_GAPS`/counters. Added a real counter (`SELF_USE_LANGUAGE.classification == "generic"`) and a reasoned gap entry — verified genuinely zero, matching the ADR's prediction.
2. **Fixes ADR 0026's stale `Status:` line** from "Accepted — not yet implemented" to "Accepted — implemented," following the exact convention every other implemented ADR in `docs/decisions/` already uses (a one-paragraph summary of what shipped, in the Status line itself — not a separate "Implementation note" section, which has no precedent in this corpus).

## Independently verified against the live grammar (not the ADR's original numbers)

| construct | measured | note |
|---|---|---|
| `entity` | 5 | now genuinely used (S17 remodel) |
| `lifecycle`/`transition` | 2 | now genuinely used (S14 remodel) |
| `ensures` | 1 | genuinely used (`Bluebook.Attach`) |
| `policy` / `process_manager` / `provenance` / `group_by` / `authorize` | 0 | still real, honest, named gaps — correctly gapped, unchanged |
| `generic` | 0 | **new** — closed by this PR |
| `aggregate` | 11 (ADR said 14) | dropped exactly as predicted once Member/Handler/Dispatch became entities |
| `one_of` | non-zero, real | the block-form `one_of "X" do...end` the ADR measured (23) no longer exists anywhere — superseded by inline `one_of: [...]` shorthand, used extensively. ADR's raw number for this row is stale but the construct is genuinely in use either way, not a gap. |

## Tests

- `spec/self_use_spec.rb`: 4/4 green
- `spec/fuzzing/meta_domain_coverage_spec.rb` + full `spec/fuzzing --tag fuzzing`: 82/82 green, unaffected
- `spec/word_gate_spec.rb`, `spec/syntax_conformance_spec.rb`, `spec/syntax_lifecycle_spec.rb`, `spec/model_check_spec.rb`, `spec/construct_spec.rb`: 122/122 green
- Full `bundle exec rspec`: 1929/1929 green
- `rubocop`: no offenses on the touched spec

No file under `lib/hecks/language/bluebook/` or any `examples/` domain touched — this is a gap-table fix plus a documentation correction, not a grammar or remodel change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
