### PR TITLE
Fix AppendOnly#record_event: domain events were never actually persisted

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ replace.
 | `bin/docs` | A domain's usage document, projected from its own bluebook. bin/docs # list every domain in this checkout bin/docs examples/banking # the... |
 | `bin/evolve` | The language-change convention, made executable. Adding a word to the bluebook surface has always been a many-file walk — syntax row, Rub... |
 | `bin/expression_projection` | The expression machinery's tables, projected from the grammar chapter's admitted set and checked in, so the evaluator and the canonical f... |
-| `bin/follow` | Live-tails a domain's append-only journal — the same data bin/history dumps statically, streamed as new entries land instead of read once... |
+| `bin/follow` | Live-tails a domain's own persisted event log — the declared `emits` every command reports, durably recorded (not `registry.event_log`, w... |
 | `bin/fuzz` | Generates random-but-valid command/query sequences from a domain's own IR (Hecks::Fuzzing::SequenceGenerator) and checks each one the way... |
 | `bin/generate` | Prints one randomly generated, valid dispatch sequence for a domain — the same generator bin/fuzz drives, exposed standalone so a sequenc... |
 | `bin/hecks_mcp_door` | AN MCP DOOR ONTO THE STOREHOUSE BUS — one MCP server for EVERY booted domain, not one per command. `docs/hecks-survey-what-we-wish-we-had... |

--- a/bin/follow
+++ b/bin/follow
@@ -1,15 +1,17 @@
 #!/usr/bin/env ruby
 
-# Live-tails a domain's append-only journal — the same data bin/history
-# dumps statically, streamed as new entries land instead of read once.
+# Live-tails a domain's own persisted event log — the declared `emits`
+# every command reports, durably recorded (not `registry.event_log`,
+# which is an in-process array gone at exit).
 #
-# AppendOnly (lib/hecks/ports/persistence/append_only.rb) has no
-# subscribe/notify hook — every adapter (Postgres/Sqlite/D1/Memory/heki)
-# only supports pull (`entries`, `count`). So this polls: each aggregate's
-# `entries` array is append-only and ordered, so a per-aggregate "entries
-# seen so far" count is enough to diff without re-printing anything —
-# the same mtime-diff-on-a-poll-loop shape as any file watcher, just
-# diffing an array length instead of an mtime.
+# `events`/`record_event` are ONE table per domain, not per aggregate
+# (see lib/hecks/adapters/driven/postgres.rb's own `events` table) — so
+# unlike bin/history's per-aggregate walk, this polls a single
+# repository (whichever aggregate's adapter answers `:events` first)
+# and filters client-side when `--aggregate` narrows it. AppendOnly has
+# no subscribe/notify hook, only pull, so this diffs `events.size`
+# against a last-seen count each tick — the same shape as any
+# mtime-diffing file watcher, just diffing an array length instead.
 #
 # One JSON object per line (JSONL), so this composes with jq/grep the
 # way bin/history's single blob deliberately does not.
@@ -28,45 +30,34 @@ options = { interval: 0.5, from_now: false }
 
 OptionParser.new do |parser|
   parser.banner = "usage: bin/follow <domain> [options]"
-  parser.on("-a", "--aggregate=NAME", "Only follow this aggregate (storage name)") { |v| options[:aggregate] = v }
+  parser.on("-a", "--aggregate=NAME", "Only follow events for this aggregate (e.g. Order)") { |v| options[:aggregate] = v }
   parser.on("-i", "--interval=SECONDS", Float, "Poll interval in seconds (default: 0.5)") { |v| options[:interval] = v }
-  parser.on("--from-now", "Skip existing entries; only print ones appended from now on") { options[:from_now] = true }
+  parser.on("--from-now", "Skip existing events; only print ones emitted from now on") { options[:from_now] = true }
 end.parse!(ARGV)
 
 runtime = Hecks.boot(domain_name)
 
-# storage_name => [repository, entries already printed]
-watched = runtime.registry.bluebooks.each_with_object({}) do |(bluebook_domain, bluebook), all|
-  bluebook.aggregates.each do |aggregate|
-    next if options[:aggregate] && aggregate.storage_name != options[:aggregate]
+repositories = runtime.registry.bluebooks.flat_map do |bluebook_domain, bluebook|
+  bluebook.aggregates.map { |aggregate| runtime.registry.repository(bluebook_domain, aggregate) }
+end
+repository = repositories.find { |repo| repo.respond_to?(:events) }
 
-    repository = runtime.registry.repository(bluebook_domain, aggregate)
-    next unless repository.is_a?(Hecks::Ports::Persistence::AppendOnly)
+abort "bin/follow: no adapter in #{domain_name} persists an event log" unless repository
 
-    seen = options[:from_now] ? repository.entries.size : 0
-    all[aggregate.storage_name] = [repository, seen]
-  end
+def matches?(event, filter)
+  filter.nil? || event.aggregate.to_s.split("::").last.casecmp?(filter) || event.aggregate == filter
 end
 
-abort "bin/follow: no matching append-only aggregates in #{domain_name}" if watched.empty?
+seen = options[:from_now] ? repository.events.size : 0
 
 $stdout.sync = true
 trap("INT") { exit }
 
 loop do
-  watched.each do |storage_name, (repository, seen)|
-    entries = repository.entries
-    next if entries.size <= seen
-
-    entries[seen..].each do |entry|
-      puts JSON.generate(
-        "aggregate" => storage_name,
-        "operation" => entry.operation,
-        "id"        => entry.id,
-        "state"     => entry.state
-      )
-    end
-    watched[storage_name][1] = entries.size
+  events = repository.events
+  if events.size > seen
+    events[seen..].each { |event| puts JSON.generate(event.to_h) if matches?(event, options[:aggregate]) }
+    seen = events.size
   end
 
   sleep options[:interval]

--- a/lib/hecks/ports/persistence/append_only.rb
+++ b/lib/hecks/ports/persistence/append_only.rb
@@ -90,7 +90,22 @@ module Hecks
           true
         end
 
-        def record_event(event) = @adapter.record_event(event) if @adapter.respond_to?(:record_event)
+        # NOT an endless `def record_event = ... if ...` — same gotcha as
+        # `events` above, and it bit for real here: this guard evaluated
+        # against `@adapter` at class-body time (nil, always false), so
+        # `record_event` was never defined at all. `emission.rb`'s own
+        # `repository.record_event(event) if repository.respond_to?(:record_event)`
+        # therefore never fired for any adapter, ever — every declared
+        # `emits` was computed and reported in `registry.event_log` (an
+        # in-process array, gone at exit) but never durably recorded.
+        # Caught because a live tail of a domain's own persisted events
+        # found nothing to tail. `sqlite_spec.rb`/`postgres_spec.rb`/
+        # `postgres_era_spec.rb` all call `adapter.record_event` directly,
+        # bypassing this wrapper — which is exactly why no spec noticed.
+        def record_event(event)
+          @adapter.record_event(event) if @adapter.respond_to?(:record_event)
+        end
+
         def query_read_model(domain, model, args, bluebook = nil)
           return unless @adapter.respond_to?(:query_read_model)
 

--- a/spec/ports/persistence/append_only_spec.rb
+++ b/spec/ports/persistence/append_only_spec.rb
@@ -1,0 +1,49 @@
+require "hecks"
+
+# `AppendOnly#record_event` used to be an endless method with a trailing
+# `if` modifier — `def record_event(event) = @adapter.record_event(event)
+# if @adapter.respond_to?(:record_event)`. That modifier binds to the
+# WHOLE `def`, not just its body, so it evaluated `@adapter.respond_to?`
+# against `@adapter` at class-body time (still nil, before any instance
+# exists) and silently skipped defining the method at all — the exact
+# gotcha `events` right above it in append_only.rb already carries a
+# comment warning about. Every adapter's OWN `record_event` (Memory,
+# Postgres, PostgresEra, Sqlite, D1) was, and is, written correctly;
+# `emission.rb`'s `repository.record_event(event) if
+# repository.respond_to?(:record_event)` simply never reached them,
+# because `repository` (the AppendOnly wrapper) never answered true to
+# that `respond_to?` check. Every declared `emits` was still computed and
+# reported (`registry.event_log`, an in-process array gone at exit) —
+# just never durably recorded. Caught live: a tail of a domain's own
+# persisted events found nothing to tail.
+#
+# `sqlite_spec.rb`/`postgres_spec.rb`/`postgres_era_spec.rb` all call
+# `adapter.record_event` directly, bypassing this wrapper entirely —
+# which is exactly why none of them noticed. This spec goes through the
+# wrapper, the way a real dispatch (`Runtime::CommandRules::Emission#emit`)
+# always does.
+RSpec.describe Hecks::Ports::Persistence::AppendOnly do
+  include InMemoryDomain
+
+  let(:runtime) { boot_in_memory }
+
+  it "record_event is a real, callable method — not silently undefined" do
+    expect(described_class.method_defined?(:record_event)).to be(true)
+  end
+
+  it "forwards record_event to an adapter that implements it" do
+    runtime.dispatch("Pizzas::Order.CreatePizza",
+                     name: { value: "Margherita" }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } })
+
+    repository = runtime.registry.repository("Pizzas", runtime.registry.bluebooks["Pizzas"].aggregates.first)
+
+    expect(repository.events.map(&:name)).to include("PizzaCreated")
+  end
+
+  it "record_event no-ops rather than raising for an adapter that does not implement it" do
+    adapter = double(append: nil, project: nil, entries: [])
+    repository = described_class.new(adapter)
+
+    expect { repository.record_event(:whatever) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## The bug

`AppendOnly#record_event` (`lib/hecks/ports/persistence/append_only.rb`) was:

```ruby
def record_event(event) = @adapter.record_event(event) if @adapter.respond_to?(:record_event)
```

This is an endless method definition with a trailing `if` modifier — the modifier binds to the **whole `def` statement**, not the method body. So it only defines `record_event` at all if `@adapter.respond_to?(:record_event)` is true **at class-body load time**, when `@adapter` is still `nil`. It never is, so the method was silently never defined:

```ruby
Hecks::Ports::Persistence::AppendOnly.method_defined?(:record_event) # => false
```

This is the exact same footgun the file's own comment three lines up already documents and fixes for the neighboring `events` method ("NOT an endless `def events = ... if ...`... Found live: nothing in this codebase called `AppendOnly#events` before Memory got a `reset!` test that did.") — it just wasn't caught here too.

Every adapter's own `record_event` (Memory, Postgres, PostgresEra, Sqlite, D1, heki) is written correctly. `Runtime::CommandRules::Emission#emit`'s own `repository.record_event(event) if repository.respond_to?(:record_event)` therefore never reached any of them — **every declared `emits` was computed and reported via `registry.event_log` (an in-process array, gone at process exit) but never durably recorded**, for any adapter, ever.

`spec/adapters/driven/sqlite_spec.rb`, `postgres_spec.rb`, and `postgres_era_spec.rb` all call `adapter.record_event` directly, bypassing this wrapper — exactly why no spec caught it.

## How it was found

Building a live-tail of a domain's own event log (`bin/follow`) and finding it always empty against a real Postgres-backed domain, despite `bin/run` reporting events on every dispatch.

## The fix

Rewritten as a real multi-line method, matching the sibling `events` fix's own style. Verified live against `examples/pizzas` (real Postgres): a dispatched `CreatePizza`'s `PizzaCreated` event now actually lands in the `events` table.

## Also in this PR

`bin/follow` (merged in #376) previously tailed `AppendOnly#entries` — the raw save/delete state-write record, not a domain event; that's what `bin/history` already dumps. Retargeted it to tail the real persisted event log (`name`/`aggregate`/`id`/`payload`/`occurred_at`, matching what `bin/run` already reports) now that `record_event` actually works. Also fixes a bug introduced in that retarget where the wrong domain key was passed to `registry.repository`, silently resolving to an unrelated, always-empty adapter.

## Tests

- Added `spec/ports/persistence/append_only_spec.rb` — confirmed to fail (all 3 examples) against the original code before the fix, via a temporary stash-and-revert.
- Full suite green (1935 examples), rubocop clean, fuzzer green, docs coverage clean — full pre-push gate passed.
- Verified live end-to-end against `examples/pizzas`: dispatched a command from a separate process, confirmed the event appears in Postgres and streams out through `bin/follow` within one poll cycle, in both default (replay-then-follow) and `--from-now` modes.