### PR TITLE
Fix flaky mint_via_rust_matches_ruby: Tempfile unlinked by GC before mint_harness reads it

### DIFF
--- a/rust/host/tests/fixtures/mint_via_rust_matches_ruby.rb
+++ b/rust/host/tests/fixtures/mint_via_rust_matches_ruby.rb
@@ -150,8 +150,24 @@ def export_ir(source, translation_source:)
   )
 end
 
-v1_ir_path = Tempfile.new(["mvr-v1-", ".json"]).tap { |f| f.write(JSON.generate(export_ir(V1, translation_source: nil))); f.flush }.path
-v2_ir_path = Tempfile.new(["mvr-v2-", ".json"]).tap { |f| f.write(JSON.generate(export_ir(V2, translation_source: edge_src))); f.flush }.path
+# Kept as `Tempfile` objects, not just their `.path` strings: a Tempfile
+# with no live reference is eligible for GC at any point, and its
+# finalizer unlinks the underlying file — exactly the flake this fixture
+# hit in CI ("reading /tmp/mvr-v1-*.json: No such file or directory"),
+# nondeterministically on either file depending on GC timing, because
+# `.tap { |f| ... }.path` discards the only reference to `f` on this
+# same line. `v1_ir_file`/`v2_ir_file` stay reachable as top-level
+# locals for the rest of this script, so the file can't be unlinked out
+# from under `run!(mint_harness_binary, ..., v1_ir_path)` below.
+v1_ir_file = Tempfile.new(["mvr-v1-", ".json"])
+v1_ir_file.write(JSON.generate(export_ir(V1, translation_source: nil)))
+v1_ir_file.flush
+v1_ir_path = v1_ir_file.path
+
+v2_ir_file = Tempfile.new(["mvr-v2-", ".json"])
+v2_ir_file.write(JSON.generate(export_ir(V2, translation_source: edge_src)))
+v2_ir_file.flush
+v2_ir_path = v2_ir_file.path
 
 def run!(*cmd, stdin_data: nil)
   stdout, status = Open3.capture2(*cmd, stdin_data: stdin_data)


### PR DESCRIPTION
## Summary

`main`'s CI is currently flaky-red on `spec/rust_host_lineage_conformance_spec.rb`'s Rust/Ruby lineage-parity example, failing with:

```
Error: reading /tmp/mvr-v1-*.json: No such file or directory (os error 2)
mint_harness ... failed (exit 1)
```

— sometimes naming `mvr-v1-*.json`, sometimes `mvr-v2-*.json` in different runs. That inconsistency was the tell.

## Root cause

`rust/host/tests/fixtures/mint_via_rust_matches_ruby.rb` built its IR fixture paths like this:

```ruby
v1_ir_path = Tempfile.new(["mvr-v1-", ".json"]).tap { |f| f.write(...); f.flush }.path
```

The `Tempfile` object itself is never assigned anywhere — only its `.path` string survives. With no live reference, the object is eligible for GC immediately, and `Tempfile`'s finalizer unlinks the underlying file when it's collected. A GC pass anywhere in the substantial amount of work between building the path and `mint_harness` reading it (lineage checks, PG connections, era-2 JSON round-trips) can unlink either file first — which is exactly the observed flake: it isn't deterministically v1 or v2, it's whichever `Tempfile` GC happens to reap first.

Isolated and confirmed with a minimal repro (not part of the suite, just verification):

```ruby
# reproduces the bug
Tempfile.new(["repro-", ".json"]).tap { |f| f.write("hello"); f.flush }.path
10.times { GC.start }
File.exist?(path) # => false

# survives
file = Tempfile.new(["repro-", ".json"]); file.write("hello"); file.flush; path = file.path
10.times { GC.start }
File.exist?(path) # => true
```

Checked every other `Tempfile.new` call in `rust/host/tests/` and `spec/` — all of them assign to a `file` local and consume it immediately in the same scope, so this was the only occurrence of the pattern.

## Fix

Keep `v1_ir_file`/`v2_ir_file` as top-level locals for the rest of the script, so they stay reachable (and un-finalized) until after both `mint_harness` invocations complete.

## Verification

Could not run this fixture end-to-end locally — this machine's `rustc` (1.94.0) is below what `rust/host`'s `Cargo.lock` requires (1.94.1), so `cargo build --bin mint_harness` fails before the fixture ever runs, independent of this bug (the conformance spec already degrades this to a clean `pending` on build failure). CI's `rustc` already satisfies the version requirement, which is how it got past compilation to hit this runtime flake in the first place — CI is the real verification signal for this PR.

No file outside `rust/host/tests/fixtures/mint_via_rust_matches_ruby.rb` touched. `rubocop` on the file: same 4 pre-existing offenses as on `main` (unrelated to this change — confirmed via `git stash`), no new ones; the edit actually removed 2 pre-existing `Style/Semicolon` offenses as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
