### PR TITLE
a projection's refusal names what is visible

### DIFF
--- a/lib/hecks/runtime/reaction_invocation.rb
+++ b/lib/hecks/runtime/reaction_invocation.rb
@@ -52,8 +52,16 @@ module Hecks
                     visible = normalized_scopes.find { |scope| scope.facts.key?(source) }
                     unless visible
                       names = normalized_scopes.map(&:name).join(" then ")
+                      # WHAT IS VISIBLE, NAMED. A refusal that only says which name is
+                      # missing sent a modeler guessing field after field
+                      # (`number`, `reference`…) at a fan-out row that is addressed
+                      # by ONE key — `account`, the lowercase aggregate — which
+                      # nothing else in the domain spells out. The names each scope
+                      # actually offers are the whole diagnosis; the refusal now
+                      # lists them, scope by scope.
+                      offered = normalized_scopes.map { |scope| "#{scope.name}: #{scope.facts.keys.sort.join(', ')}" }.join("; ")
                       raise UnknownArgument,
-                            "#{label}'s with: reads :#{source}, which is not visible in #{names}"
+                            "#{label}'s with: reads :#{source}, which is not visible in #{names} (visible — #{offered})"
                     end
                     visible.facts.fetch(source)
                   end

--- a/spec/runtime/reaction_visibility_spec.rb
+++ b/spec/runtime/reaction_visibility_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe "policy and process lexical visibility" do
       )
     end.to raise_error(
       Hecks::Runtime::UnknownArgument,
-      /ApplyProposal's trigger's with: reads :parent_reading, which is not visible in event payload/
+      /ApplyProposal's trigger's with: reads :parent_reading, which is not visible in event payload.*\(visible — /
     )
   end
 


### PR DESCRIPTION
`ReactionInvocation.resolve_mapping`'s UnknownArgument said which name a `with:` could not read and nothing about which names it could. For a `for_each` policy the row is addressed by one key — the lowercase aggregate (`account`) — that no declared attribute spells out; downstream, a modeler guessed `number`, `reference`… at it across nine attempts and three prompt revisions. The refusal now appends each scope's own names: `… not visible in event payload and fan-out row (visible — event payload and fan-out row: account, reference, standing)`.

- `rspec spec/runtime spec/fuzzing/fan_out_spec.rb`: green; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc36TdgHxuFhxs5eAjcGXr