### PR TITLE
Fix PostgresEra unresolvable since ADR 0033 (#389): autoload it, not a require in every bin/*

### DIFF
--- a/lib/hecks/adapters/driven.rb
+++ b/lib/hecks/adapters/driven.rb
@@ -11,12 +11,25 @@ end
 require_relative "driven/memory"
 require_relative "driven/sqlite"
 require_relative "driven/postgres"
-# `PostgresEra` — NOT required here on purpose, same reasoning as
-# `SequentialIdentity` below: ADR 0033 moved it, and the rest of the
-# era/lineage/translation subsystem, behind a loadable persistence plugin
-# (`hecks/ports/persistence/plugins/era`) rather than requiring every app
-# to carry it whether or not anything ever binds `persisted_by
-# "PostgresEra"`. An app that wants it requires the plugin explicitly.
+# `PostgresEra` is NOT `require_relative`d here — ADR 0033 moved it, and
+# the rest of the era/lineage/translation subsystem, behind a loadable
+# persistence plugin (`hecks/ports/persistence/plugins/era`) rather than
+# requiring every app to carry it whether or not anything ever binds
+# `persisted_by "PostgresEra"`. `Module#autoload` is the one-line seam
+# that makes that genuinely load-nothing-until-asked instead of pushing
+# an explicit `require` onto every one of the ~15 generic `bin/*` tools
+# that boot an arbitrary checked-in domain (several of which — pizzas,
+# compliance, chess, roster — bind PostgresEra): the FIRST real
+# `Adapters.const_get("PostgresEra")` (`registry/verification.rb`'s own
+# adapter resolution, unchanged) transparently `require`s the plugin
+# entry point, which defines the constant AND calls `register_plugin`
+# as its own side effect (`plugins/era.rb`'s last line) — the exact
+# same effect an explicit `require "hecks/ports/persistence/plugins/
+# era"` has, just deferred to the moment something is actually asked
+# for `PostgresEra` rather than sprinkled across every caller that
+# might. A domain that never binds it never triggers the autoload, so
+# never loads a line of era code — unchanged from ADR 0033's own goal.
+Hecks::Adapters.autoload(:PostgresEra, "hecks/ports/persistence/plugins/era")
 require_relative "driven/lambda"
 require_relative "driven/heki"
 require_relative "driven/prism"

--- a/spec/load_hygiene_spec.rb
+++ b/spec/load_hygiene_spec.rb
@@ -91,6 +91,29 @@ RSpec.describe "load hygiene", io: true do
                          colliding.map { |name, files| "  #{name}: #{files.uniq.join(', ')}" }.join("\n")
   end
 
+  # ADR 0033's own contract, exercised the one way that can catch it: a
+  # domain bound to a loadable persistence plugin (PostgresEra) has to
+  # boot with NOTHING pre-required, in a genuinely fresh process — every
+  # spec in this suite shares one process with `spec_helper.rb`'s own
+  # eager `require "hecks/ports/persistence/plugins/era"`, so a
+  # `Hecks.boot` call inside an ordinary example can never actually
+  # observe the plugin unloaded, no matter what regresses in
+  # `adapters/driven.rb`'s own `Adapters.autoload(:PostgresEra, ...)`.
+  # Found live: exactly that autoload missing (a plain `require_relative`
+  # comment with no code behind it) broke every one of ~15 generic
+  # `bin/*` tools against every PostgresEra-bound example domain, with
+  # the whole suite green throughout.
+  it "boots a domain bound to a lazily-loaded persistence plugin (PostgresEra) with nothing pre-required" do
+    domain = File.join(ROOT_DIR, "examples/pizzas")
+    script = "require 'hecks'; Hecks.boot(#{domain.inspect})"
+    _out, err, status = Open3.capture3("ruby", "-I", LIB, "-e", script)
+
+    expect(status.success?).to be(true),
+                               "a fresh process could not boot a PostgresEra-bound domain with " \
+                               "nothing pre-required — Adapters.autoload(:PostgresEra, ...) in " \
+                               "adapters/driven.rb regressed:\n#{err.lines.first(10).join}"
+  end
+
   it "loads the whole framework with the subsystem wrappers in reverse order" do
     wrappers = File.read(File.join(LIB, "hecks.rb"))
                    .scan(%r{^require_relative "(hecks/[^"]+)"}).flatten


### PR DESCRIPTION
## The regression

#389 (ADR 0033) moved `PostgresEra` and the rest of the era/lineage subsystem behind a loadable persistence plugin and stopped requiring it unconditionally from core. That broke booting **any** domain bound to `PostgresEra` — confirmed against every one of ~15 generic `bin/*` tools (`bin/run`, `bin/history`, `bin/follow`, `bin/console` — whose *default* domain is pizzas — etc.):

```
uninitialized constant Hecks::Adapters::PostgresEra
```

Four of this repo's own example domains (pizzas, compliance, chess, roster) bind `PostgresEra`.

## Why not just add a `require`

The ADR's own text anticipated a real deployed app adding one `require "hecks/ports/persistence/plugins/era"` line to its own bootstrap. This repo's example/generic tooling has no such bootstrap distinct from whichever `bin/*` script boots a given domain — so the direct translation of that fix is repeating the same one-line require across every current *and future* generic CLI tool that can be pointed at an arbitrary domain. Tried this first, reverted it: it's ~15 near-identical edits today, and any future tool needs to remember it too.

## The fix

Ruby's own `Module#autoload`, declared once, in `lib/hecks/adapters/driven.rb`:

```ruby
Hecks::Adapters.autoload(:PostgresEra, "hecks/ports/persistence/plugins/era")
```

`Adapters.const_get("PostgresEra")` (the existing, unchanged choke point in `registry/verification.rb`) already triggers Ruby's native autoload transparently. The first *real* reference — i.e. a domain that actually binds `PostgresEra` — pulls in the plugin entry point, which defines the constant **and** calls `register_plugin` as its own side effect (`plugins/era.rb`'s last line) — every effect an explicit `require` has, just deferred to the moment it's actually needed instead of pushed onto every caller. A domain that never binds it still never triggers the autoload — confirmed: `Ports::Persistence.plugin?(:era)` stays `false` after booting a non-era domain (banking), and flips to `true` only after booting one that binds it (pizzas). ADR 0033's own stated goal — an app that never binds `PostgresEra` loads zero era code — is unchanged.

## Tests

- Added a regression spec (`spec/load_hygiene_spec.rb`) that boots a `PostgresEra`-bound domain (pizzas) in a genuinely fresh subprocess with nothing pre-required — the only way to catch this at all, since every spec in the suite already shares one process with `spec_helper.rb`'s own eager plugin require, and can never observe it unloaded otherwise. Confirmed to fail against the original code (reproducing the exact reported error) via a temporary stash-and-revert, before the fix.
- Full suite green (1936 examples), rubocop clean, fuzzer green, docs coverage clean, full pre-push gate passed.
- Verified live end-to-end: `bin/follow examples/pizzas` (merged in #376/#387) now boots and streams a real dispatched event, exactly the workflow that surfaced this regression in the first place.