### PR TITLE
Rewrite README for adoption; fix Quickstart-blocking bug; resolve lic…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the
+      purposes of this License, Derivative Works shall not include works
+      that remain separable from, or merely link (or bind by name) to the
+      interfaces of, the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Chris Young
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,24 @@
 # hecks
 
 hecks is an **executable domain specification language**. A `.bluebook`
-file declares a business domain — aggregates, value objects, commands,
-invariants, policies, queries — and that declaration *is* the running
-system. There is no handler code, no separate implementation to keep in
-sync: `given` guards a command, `sets` mutates state, `emits` announces
-an event, and the runtime dispatches all of it directly from the
-declaration. A domain is data, so it can be read, diffed, versioned, and
-compiled into another language the same way any other data can.
+file declares a business domain — its aggregates, rules, and events —
+and that declaration *is* the running system, not a spec that code is
+later written from:
 
-The language surface is small: [22 contexts](docs/implemented/reference/index.md),
-every one of them documented with a runnable example. Most of what's
-below fits on one screen. [Getting started](docs/implemented/guides/getting-started.md)
-is a five-minute read from zero to a booted domain.
+```ruby skip
+given("at most 10 toppings") { toppings.size < 10 }
 
-Ruby is the reference implementation. A generated Rust runtime reads the
-same canonical IR and runs the same domain, checked against Ruby
-continuously — see [Runtimes](#runtimes).
+sets :toppings, append: { name: :topping, amount: :amount }
 
-## Quickstart
-
-```sh
-bin/console
+emits "ToppingAdded"
 ```
 
-Booting installs the door, so a domain is just Ruby:
+`given` refuses a command before it runs; `sets` is the only way state
+changes; `emits` is the only way anything downstream finds out. There
+is no handler body behind those three lines — the runtime dispatches
+directly from the declaration. A domain is data, so it can be read,
+diffed, statically checked, run against generated fuzz sequences, and
+compiled into another language, the same way any other data can.
 
 <!-- doctest:boot
 Kernel.load(File.join(InMemoryDomain::ROOT, "examples/pizzas/bluebook/pizzas.bluebook"))
@@ -45,87 +39,108 @@ order.purchase!(customer_name: { value: "Chris" }, amount: { cents: 1200 })
 
 order.status             # => "sold"
 order.events.last.name   # => "PizzaPurchased"
-
-Order.count              # => 1
-Order.find(order.id).customer_name.to_h   # => { value: "Chris" }
 ```
 
-That block runs on every push, claims and all — not an illustration. So
-does every other `ruby`-fenced example in this README and in
-`docs/implemented/guides/`; `spec/guides_spec.rb` is the harness.
+That block runs on every push, claims and all — not an illustration.
+So does every other `ruby`-fenced example in this README and in
+[the guides](docs/implemented/guides/); `spec/guides_spec.rb` is the
+harness.
 
-A creating command is a module method and returns the new record. A
-command on an existing record is a method on that record — identity is
-already known — and returns `self`, so commands chain. `bin/run <domain>
-<script.json>` executes a step list of commands and queries from JSON and
-reports events, refusals, and rows; `bin/fuzz` generates and runs these
-scripts itself, checked against declared properties.
+**Status:** pre-1.0 (`0.3.0`), no published gem, actively developed.
+See [Project status](#project-status) before depending on this for
+anything real.
 
-## Guides
+## Why
 
-<!-- generated:begin id=guides -->
-- [Aggregates and value objects](docs/implemented/guides/aggregates-and-value-objects.md)
-- [Behaviors](docs/implemented/guides/behaviors.md)
-- [Commands](docs/implemented/guides/commands.md)
-- [Entities](docs/implemented/guides/entities.md)
-- [Extending Hecks](docs/implemented/guides/extending-hecks.md)
-- [Getting started](docs/implemented/guides/getting-started.md)
-- [Guides](docs/implemented/guides/index.md)
-- [Lifecycles](docs/implemented/guides/lifecycles.md)
-- [Policies and process managers](docs/implemented/guides/policies-and-process-managers.md)
-- [Queries and read models](docs/implemented/guides/queries-and-read-models.md)
-- [Running a runtime](docs/implemented/guides/running-a-runtime.md)
-- [Schema evolution](docs/implemented/guides/schema-evolution.md)
-- [Verification](docs/implemented/guides/verification.md)
-- [Wiring](docs/implemented/guides/wiring.md)
-- [Writing an adapter](docs/implemented/guides/writing-an-adapter.md)
-<!-- generated:end -->
+Take one real rule — "a pizza may carry at most 10 toppings." In a
+conventional application that rule tends to end up in several places at
+once: a check in the request handler, maybe a mirror of it in a
+client-side form, an ORM validation or a database constraint, a line in
+a test fixture asserting the boundary. Each copy is correct on its own.
+None of them is *the* rule — the rule is whatever the union of all four
+happens to enforce on a given day, and it drifts the moment one of them
+is touched without the others.
 
-## Reference
-
-<!-- generated:begin id=reference -->
-[The DSL reference](docs/implemented/reference/index.md) — 22 contexts, generated from the aggregate-local tables under `lib/hecks/language/` and held to them by `spec/reference_golden_spec.rb`.
-<!-- generated:end -->
-
-## More docs
-
-- **Resolution rules** — the exact algorithm behind every piece of DSL
-  sugar that lets a bluebook omit something the runtime can derive:
-  [overview](docs/resolution-rules/README.md),
-  [cross-entity given](docs/resolution-rules/cross-entity-given.md),
-  [chapter-given](docs/implemented/resolution-rules/chapter-given.md),
-  [implicit append fields](docs/implemented/resolution-rules/implicit-append-fields.md),
-  [implicit command attributes](docs/implemented/resolution-rules/implicit-command-attributes.md).
-- **Decision log** — [`docs/decisions/`](docs/decisions/) and
-  [`docs/implemented/decisions/`](docs/implemented/decisions/), one
-  document per architectural decision.
-- **Language specification docs** — [the query DSL](docs/query-dsl.md),
-  [command/query form](docs/command-form-and-query-form-bluebook.md),
-  [Rails integration](docs/rails-integration.md).
-- [`docs/HECKS_IMPLEMENTATION_PLAN.md`](docs/HECKS_IMPLEMENTATION_PLAN.md)
-  — the full architecture in one document.
-
-## The domain: bluebook, hecksagon, world
-
-A domain is three files. `.bluebook` declares what the domain *is* —
-aggregates, commands, rules — independent of how any deployment runs it.
-`.hecksagon` wires it to real ports: which adapter persists it, which
-framework it attaches to, which ports it exposes. `.world` holds the one
-thing neither of those names — per-deployment values, like a database
-URL or a Lambda's memory limit. Each file below is real, trimmed to the
-pieces this section shows; the untrimmed originals are
-`examples/pizzas/bluebook/`.
+In hecks that rule is written once, on the command that can violate it:
 
 ```ruby skip
-examples/pizzas/
-  bluebook/
-    pizzas.bluebook        the domain
-    pizzas.hecksagon       the wiring
-    pizzas.world           the per-deployment values
-  data/
+given("at most 10 toppings") { toppings.size < 10 }
 ```
 
-### bluebook
+There is exactly one place this can be checked, because there is
+exactly one path a command can take to reach state — every dispatch
+walks the same fixed order (refuse unknown/missing arguments, check
+role, enforce every `given`, apply the mutation, enforce every
+`ensures`, persist, emit), for every command, in every domain. A rule
+that is checked once, in the one place a violation can occur, cannot
+quietly stop being checked somewhere.
+
+Generalize that from one rule to a whole domain and the shape of the
+bet becomes: **the business specification should be the durable
+artifact, and the implementation running it should be the disposable
+one.** A traditional stack reads roughly as
+
+```
+business requirement → developer/AI interpretation → application code → framework/runtime
+```
+
+— four lossy translations between the rule and the thing enforcing it,
+each one a place the two can diverge. hecks collapses the middle two:
+
+```
+business domain → bluebook (explicit, constrained specification) → validated semantics → runtime/adapter
+```
+
+The specification is what a reviewer reads to know what the business
+actually requires; it is also, unmodified, what runs. Swapping the
+runtime underneath it — a different persistence adapter, a different
+dispatch language entirely — does not touch the specification at all
+(see [Projections](#projections-rust-and-webassembly)).
+
+This is not a hypothetical concern about hecks's own corpus. [ADR
+0025](docs/decisions/0025-the-dsl-names-one-idea-one-way-and-a-word-earns-its-place-by-being-used.md)
+in this repository's own decision log measured it directly: two
+preconditions — "the customer is active" and "the customer is not
+closed" — had been independently typed out, worded slightly
+differently each time, across **44% of all 183 `given` clauses** in
+the corpus, because nothing made the duplication visible until someone
+counted. The fix wasn't a linter; it was a language feature
+(`given("customer is active")`, declared once and referenced by name
+elsewhere) that makes the *duplication itself* impossible to write by
+accident.
+
+### Why this gets sharper with AI-generated code
+
+Generating code has become cheap. Reviewing an ever-growing,
+arbitrary codebase for architectural drift, duplicated business rules,
+and quietly-diverging invariants has not gotten any cheaper, and an AI
+agent editing that codebase inherits the same problem a human
+maintainer has: it has to hold thousands of implementation details in
+mind to avoid breaking one while fixing another, and nothing stops it
+from re-deriving "at most 10 toppings" a fifth way in a fifth file.
+
+hecks's bet is narrower and more mechanical than "AI will manage
+complexity for you": constrain what gets modified — by a human or an
+agent — to a small, closed, checked vocabulary (`aggregate`, `command`,
+`given`, `sets`, `emits`, and a couple dozen more), and let the
+compiler and runtime carry the burden of architectural consistency that
+would otherwise depend on whoever (or whatever) is editing the code
+noticing it. A bluebook that violates an invariant refuses to boot or
+refuses to dispatch, deterministically, regardless of whether a person
+or a model wrote the line. See [AI-native
+development](#ai-native-development) for what that looks like as a
+concrete integration today, not just an argument.
+
+## How it works
+
+A domain is three files, each with one job. `.bluebook` declares what
+the domain *is* — aggregates, commands, rules — independent of how any
+deployment runs it. `.hecksagon` wires it to real ports: which adapter
+persists it, which framework it attaches to. `.world` holds the one
+thing neither of those names — per-deployment values, like a database
+URL. [Wiring](docs/implemented/guides/wiring.md) covers the last two in
+full; here is the first, in full — `examples/pizzas/bluebook/pizzas.bluebook`,
+trimmed to fit:
 
 ```ruby skip
 aggregate "Order" do
@@ -136,7 +151,6 @@ aggregate "Order" do
 
   value_object "PizzaName" do
     attribute :value, String
-
     invariant("a pizza is named") { !value.to_s.empty? }
   end
 
@@ -151,18 +165,13 @@ aggregate "Order" do
 
   command "CreatePizza" do
     role "Chef"
-    goal "Put a new pizza on the menu"
-
     attribute :name,  PizzaName
     attribute :pizza, Pizza
-
     emits "PizzaCreated"
   end
 
   command "AddTopping" do
     role "Chef"
-    goal "Customize a pizza with an ingredient"
-
     reference_to Order
     attribute :topping, ToppingName
     attribute :amount, ToppingAmount
@@ -171,24 +180,49 @@ aggregate "Order" do
     given("at most 10 toppings")            { toppings.size < 10 }
 
     sets :toppings, append: { name: :topping, amount: :amount }
-
     emits "ToppingAdded"
   end
 end
 ```
 
-`given` refuses before `sets` runs; a value object's own `pattern:`
-refuses before its own invariant does — checked in that order, on the
-same booted domain as the Quickstart above:
+An aggregate is the thing with identity — two orders named
+`"Margherita"` *are* the same order, which is exactly what
+`identified_by :name` declares. A value object has none; a `PizzaName`
+is only its value, and its invariant travels with the value everywhere
+it goes. The lifecycle names the states an order may hold and the
+transitions between them. A command says three things and no more:
+what it needs, what it refuses (`given`), what it announces (`emits`).
 
-```ruby
-Order.create_pizza!(name: { value: "" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } })   # ~> TypeMismatch: PizzaName.value must match [^ \t\n\r], got ""
+Nothing here is hand-drawn either — the same declaration draws its own
+diagrams:
+
+<!-- generated:begin id=diagrams -->
+`bin/project_diagrams` reads a booted domain's own declaration and draws it as Mermaid — nine kinds so far: `<Name>_lifecycle.mmd`, `relationships.mmd`, `dispatch.mmd`, `roles.mmd`, `ports.mmd`, `read_models.mmd`, `<Name>_surface.mmd` (what a command does, and what it writes), `<Name>_saga.mmd`, and `frameworks.mmd`. Nothing hand-drawn — the same reason a domain is data at all. Order's own lifecycle, straight off the bluebook above:
+
+```mermaid
+%% GENERATED by bin/project_diagrams from Order's own declared lifecycle (field: status) — DO NOT EDIT BY HAND.
+%% Re-run `bin/project_diagrams <domain-path> Pizzas` after any change.
+stateDiagram-v2
+    [*] --> available
+    available --> sold: Purchase
 ```
 
-A command's mutation either replaces a field (`sets :status, to:
-"sold"`) or appends to a list (`sets :toppings, append: ...`, above).
-Some domains need a number that raises rather than replaces — an
-account's balance, for example:
+The full set for every domain in this checkout — `examples/pizzas`, `examples/banking` — lives in [`docs/generated/diagrams/`](docs/generated/diagrams/), held to the declaration by `spec/diagrams_spec.rb` the same drift-refusing way this page is held to its own source.
+<!-- generated:end -->
+
+The expression inside `given`/`ensures`/`invariant` is Ruby, parsed by
+Prism and reduced to canonical text stored alongside the rest of the
+IR — the same reason the domain as a whole is data rather than code —
+and its grammar is small and closed for the same reason: an operator
+is admitted only once it earns its place rendering a real rule already
+in the corpus. Full grammar and dispatch order in [Running a
+runtime](docs/implemented/guides/running-a-runtime.md).
+
+## Example: a business workflow
+
+Pizzas is deliberately small. This is `examples/banking` — trimmed
+here to one aggregate, the untrimmed original is
+`examples/banking/bluebook/`:
 
 ```ruby bluebook
 Hecks.bluebook "Banking" do
@@ -227,26 +261,18 @@ Hecks.bluebook "Banking" do
 
     command "Open" do
       role "Branch clerk"
-      goal "Give a customer somewhere to keep money"
-
       attribute :number, AccountNumber
-
       sets :number
-
       emits "AccountOpened"
     end
 
     command "Credit" do
       role "Teller"
-      goal "Put money in"
-
       reference_to Account
       attribute :amount, PositiveMoney
 
       given("the account is open") { status == "open" }
-
       sets :balance, increment: :amount
-
       emits "AccountCredited"
     end
   end
@@ -264,268 +290,354 @@ Hecks.hecksagon("Governance") do
 end
 ```
 
+An aggregate, a lifecycle, an invariant, a command, an event — executed:
+
 ```ruby
 account = Account.open!(number: { value: "1001" })
 account.credit!(amount: { cents: 500, currency: "USD" })
 
-account.balance.to_h                                     # => { cents: 500, currency: "USD" }
+account.balance.to_h                                       # => { cents: 500, currency: "USD" }
 account.credit!(amount: { cents: -1, currency: "USD" })    # ~> InvariantViolation: an amount is positive
 ```
 
-(A trimmed subset of `examples/banking/bluebook/` — the full `Account`
-also holds a `kind`, a `daily_limit`, a `ledger` of `LedgerEntry`, and
-the `Customer` it belongs to.)
-
-Every effect a command may cause is one of a closed set of declared
-verbs; every refusal is a named `given` or invariant. A required
-attribute missing from a payload refuses at the gate, before any effect
-resolves. Events are emitted last, after state is persisted. Refusals
-are checked, not incidental: `spec/corpus/` runs a scripted exercise of
-every declared refusal across the whole corpus.
-
-### hecksagon
-
-The only file that names a real adapter, attaches to a real framework,
-or exposes a real port to the outside world:
+The real `Account` — the one in `examples/banking/bluebook/`, not the
+trimmed one above — is where the "one rule, checked once" argument from
+[Why](#why) stops being a toy example. Six different commands can move
+its `balance`; "the balance never goes negative" used to be three
+different `given`/`ensures` clauses, worded differently, with two
+commands that could only *increase* the balance saying nothing at all
+— correctness depended on someone noticing which commands could
+decrease it. It is now one aggregate-level `invariant`, checked after
+every one of those six commands, stated once:
 
 ```ruby skip
-Hecks.hecksagon "Pizzas" do
-  uses_framework "Governance"
-  Pizzas::Order.persisted_by("PostgresEra")
+# examples/banking/bluebook/deposit_accounts.bluebook — the real Account
+invariant("the balance never goes negative") { balance.cents >= 0 }
 
-  # A second front door, called from outside this domain (a payment
-  # processor's webhook, in practice). No given, no sets — this is the
-  # boundary translating an external fact into domain vocabulary. The
-  # rule itself stays on Purchase (pizzas.bluebook), reached only
-  # through a policy beside it.
-  Pizzas::Order.port "PaymentGateway" do
-    operation "Receive" do
-      attribute :customer_name, CustomerName
-      attribute :amount, Price
-      emits "PizzaPaymentReceived"
-    end
-  end
-end
+command "Debit", from: "open" do
+  role "Teller"
+  reference_to Account
+  attribute :amount, PositiveMoney
 
-Hecks.hecksagon "Governance" do
-  Governance::RoleAssignment.persisted_by("Memory")
-  Governance::RoleTransition.persisted_by("Memory")
+  given("customer is active")
+  given("the balance covers it")     { balance.cents >= amount.cents }
+  given("the daily limit allows it") { daily_limit.cents >= amount.cents }
+
+  sets :balance, decrement: :amount
+  sets :ledger,  append: { amount: :amount, narrative: :narrative, direction: { value: "debit" } }
+
+  # "no debit leaves the balance negative" — GONE, not reworded: the
+  # aggregate's own invariant above says it now.
+  ensures("the balance fell by exactly the amount") { old.balance.cents == balance.cents + amount.cents }
+
+  emits "AccountDebited"
 end
 ```
 
-That's `examples/pizzas/bluebook/pizzas.hecksagon`, in full — the same
-`uses_framework`/`persisted_by` calls the Quickstart's hidden boot block
-runs (with `Memory` in place of `PostgresEra`, since the Quickstart needs
-no real database). A port declared here is an ordinary command reached
-by an external caller; no rule lives on it that doesn't already live on
-the aggregate.
-
-### world
-
-Values a `.hecksagon` file's adapter needs but shouldn't hard-code — a
-database URL, a realm, a Lambda's memory and timeout:
-
-```ruby skip
-# examples/pizzas/bluebook/pizzas.world
-Hecks.world "Pizzas" do
-  realm "Examples"
-  persisted_by("PostgresEra") do
-    database "postgres://localhost/hecks_pizzas"
-  end
-end
-```
-
-```ruby skip
-# examples/banking/bluebook/banking.world
-Hecks.world "Banking" do
-  realm "Examples"
-  latest "v1"
-  persisted_by("Heki") do
-    dir "data"
-  end
-
-  projected_by("SqliteProjection") do
-    database "data/banking_projection.sqlite3"
-  end
-
-  deployed_to("AwsLambda") do
-    region "us-east-1"
-    memory 512
-    timeout 10
-    database "Shared"   # no RDS of Banking's own
-    owner "Embryonaut"  # isolated by its own native Postgres schema
-  end
-end
-```
-
-A `.world` block is checked against what its adapter declares — a value
-the adapter doesn't know refuses at boot rather than being silently
-ignored. Fields belong to the **adapter**, not the port: `PostgresEra`
-needs a `database`; `Memory` needs nothing at all.
-
-## The expression sublanguage
-
-A command's predicate is Ruby, parsed by Prism and stored as canonical
-text rather than held as a closure:
-
-```ruby skip
-given("at most 10 toppings") { toppings.size < 10 }
-                     ↓
-            "toppings.size < 10"
-```
-
-The Ruby is what you write; the canonical text is what the runtime reads
-back, diffs, and stores — the same reason a domain as a whole is data
-rather than code.
-
-Admissible grammar:
-
-```ruby skip
-||  →  &&  →  .include?  →  >= <= < > == !=  →  leaves
-```
-
-Leaves are literals, dotted value-object paths, `.size`/`.length`,
-`.positive?`/`.negative?`/`.zero?`, `.modulo(n)`, and the block-taking
-enumeration operators over a list — `.any?`/`.none?`/`.all?`/`.find { |x|
-… }`, the block's body a whole predicate of its own. An operator is admitted
-only once it reads as a real rendering — an operator with no rendering is
-not a slow operator, it is not an operator. That sentence is checked, not
-aspired to: every operator the evaluator runs passes through the grammar
-chapter's own Admit gate on each suite run
-(`lib/hecks/grammar/expression_operators.json`, held by
-`spec/operator_conformance_spec.rb`).
-
-## Runtimes
-
-**Persistence.** `persisted_by` in a `.hecksagon` file picks one; the
-matching `.world` block configures it:
-
-```ruby skip
-Memory         in-process, nothing on disk — tests, bin/console's default
-Sqlite         a local file — no server, no config beyond a path
-Postgres       a real server, no era tracking
-PostgresEra    Postgres plus the era system — see Eras below
-Heki           an append-only journal on disk — no server, real durability
-Folder         reads a domain's own declaration off disk, not a backend
-Prism          Ruby's own parser, extracting predicate source (above)
-```
-
-Swapping `Memory` for `PostgresEra` — a `.hecksagon` line, plus the
-`database` field the `.world` block now needs — is the entire migration.
-The `.bluebook` file never names a backend, so it never changes.
-
-**Dispatch.** Ruby is the reference implementation. `rust/` is a second
-dispatch runtime, generated from the same canonical IR and checked
-against Ruby continuously: `spec/codegen_parity_spec.rb` holds Rust's
-generated output byte-identical to Ruby's, `spec/rust_conformance_spec.rb`
-runs the same corpus scripts through the compiled binary and diffs the
-result against Ruby's. `bin/project_rust` generates typed Rust structs
-and enums for every value object, entity, and aggregate record; `given`/
-`ensures`/mutation logic stays data, interpreted at runtime by one small
-kernel (`rust/src/kernel/{expr,dispatch}.rs`) that walks it the way
-`CommandInterpreter#call` does in Ruby. The parser is generated too, not
-hand-written a second time.
-
-[Running a runtime](docs/implemented/guides/running-a-runtime.md) has
-what a third dispatch runtime, in a different language, needs field by
-field. [`docs/implemented/rust-experiment.md`](docs/implemented/rust-experiment.md)
-documents an earlier, fully hand-written Rust runtime and why it was
-replaced by this architecture.
-
-## Projections
-
-Every deployment artifact is generated from a domain's own declaration —
-none are hand-authored. `bin/project_deploy` reads a `.world` file's
-`deployed_to("AwsLambda")` block and generates a SAM template, Makefile,
-`samconfig.toml`, and bastion config: self-contained, owning its own VPC
-and RDS Postgres instance, no secret typed anywhere (RDS's managed
-master password plus a CloudFormation dynamic reference compose the
-connection string at deploy time). `sam build && sam deploy` from there.
-
-Siblings, same rule — no hand-authored artifact, only a generator run
-against a declaration: `bin/project_wasm` (bluebook → `.wasm`),
-`bin/project_rust` (IR → Rust), `bin/project_oidc` (→
-`<domain>/oidc.json`), `bin/project_cli` (→ a named binary for one
-domain). [The tools](#the-tools) has the rest.
-
-## Diagrams
-
-<!-- generated:begin id=diagrams -->
-`bin/project_diagrams` reads a booted domain's own declaration and draws it as Mermaid — nine kinds so far: `<Name>_lifecycle.mmd`, `relationships.mmd`, `dispatch.mmd`, `roles.mmd`, `ports.mmd`, `read_models.mmd`, `<Name>_surface.mmd` (what a command does, and what it writes), `<Name>_saga.mmd`, and `frameworks.mmd`. Nothing hand-drawn — the same reason a domain is data at all. Order's own lifecycle, straight off the bluebook above:
+`Account`'s own lifecycle, drawn from that same real declaration —
+another aggregate, another set of states, nothing hand-drawn here either:
 
 ```mermaid
-%% GENERATED by bin/project_diagrams from Order's own declared lifecycle (field: status) — DO NOT EDIT BY HAND.
-%% Re-run `bin/project_diagrams <domain-path> Pizzas` after any change.
+%% GENERATED by bin/project_diagrams from Account's own declared lifecycle (field: status) — DO NOT EDIT BY HAND.
+%% Re-run `bin/project_diagrams <domain-path> Banking` after any change.
 stateDiagram-v2
-    [*] --> available
-    available --> sold: Purchase
+    [*] --> open
+    open --> frozen: FreezeAccount
+    frozen --> open: Unfreeze
+    open --> closed: CloseAccount
+    frozen --> closed: CloseAccount
 ```
 
-The full set for every domain in this checkout — `examples/pizzas`, `examples/banking` — lives in [`docs/generated/diagrams/`](docs/generated/diagrams/), held to the declaration by `spec/diagrams_spec.rb` the same drift-refusing way this page is held to its own source.
-<!-- generated:end -->
+## Why this architecture matters
 
-## Eras & the Postgres adapter
+Only what this repository actually does today, checked, not aspired to:
 
-A domain's shape changes; its stored history doesn't. `PostgresEra` holds
-the source text a booted domain was born from, refuses on drift between
-held text and booting text, and requires a deliberate change to ship
-with a translation: `rename`, `convert`, `drop`, `retype`, `retired`, and
-`compute` rules in a `translations/*.bluebook` file, carrying the old
-era's records into the new shape. `compute` is a raw SQL expression,
-evaluated inside Postgres — no second, application-side copy of the
-logic to drift from.
+- **Explicit semantics.** Every effect a command may cause is one of a
+  closed set of declared verbs (`sets`, `increment`/`decrement`,
+  `append`); every refusal is a named `given` or invariant. There is no
+  code path that mutates state outside `sets`.
+- **Static verification.** `bin/model_check` runs structural analysis
+  over a domain's own IR — unreachable lifecycle states, transitions
+  nothing can fire, saga states no handler chain reaches — before
+  anything boots against real data.
+- **Property-based fuzzing, including determinism.** `bin/fuzz`
+  generates random-but-valid command/query sequences from a domain's
+  own IR and checks four properties: every lifecycle value a replay
+  produces was declared, every saga advance follows a declared handler,
+  query answers match a reference implementation, and — the one that
+  actually matters for an event-sourced system — **replaying the same
+  steps against a fresh boot produces byte-identical history.** This
+  runs against the Memory adapter only today; Sqlite and Postgres are
+  not yet covered (tracked in
+  [`docs/future-features.md`](docs/future-features.md)).
+- **A corpus that checks its own refusals.** `spec/corpus/*.json`
+  scripts real command/query sequences — successes and refusals both —
+  replayed by `bin/run` and pinned by `spec/corpus_spec.rb`; a runtime
+  that *accepts* what the corpus says must be refused is the failure
+  that matters more than one that rejects a valid command.
+- **Event-oriented by construction.** `emits` is the only way anything
+  outside a command's own aggregate learns what happened; every emitted
+  event is durably recorded, not just returned to the caller.
+- **Runtime and adapter separation.** `persisted_by` in a `.hecksagon`
+  file is the entire migration between an in-memory adapter and a real
+  database — the `.bluebook` file never names a backend, so it never
+  changes. `Memory`, `Sqlite`, `Postgres`, `PostgresEra` (adds
+  schema-evolution tracking — see [Schema
+  evolution](docs/implemented/guides/schema-evolution.md)), and `Heki`
+  (an append-only journal, no server) all satisfy the same persistence
+  port.
 
-Plain `Postgres` has no era tracking. Memory, Sqlite, and Heki have none
-either — a domain there boots whatever text it's handed.
+The same separation extends past persistence, to dispatch itself —
+which is the more interesting claim, and where it currently matters
+most:
 
-## Language versions
+## Projections: Rust and WebAssembly
 
-Every word of the bluebook surface carries its own lifecycle in
-`syntax.bluebook` — proposed, admitted, deprecated, retired. A proposed
-or retired word reaches no projected parser table: to a projected reader
-it does not exist. A renamed word keeps its old spelling in `was:`, so a
-bluebook written under an earlier spelling keeps parsing. `bin/evolve`
-walks a language change through the stations: snapshot, rewrite,
-regenerate, gate, restore-on-red.
+The point is not "hecks also supports Rust." It's that the bluebook is
+the one authoritative definition of a domain, and everything else —
+including *where code runs* — is a **projection** of that definition,
+generated, not hand-maintained a second time.
 
-## Machine-readable IR
+```
+.bluebook  →  canonical IR  →  generated Rust source  →  native binary
+                                                       →  WASM (WASI or browser)
+```
 
-A booted domain's IR is JSON, not prose — the same structure the golden
-specs pin and the Rust generator reads:
+`bin/project_rust <domain>` reads a booted domain's canonical IR and
+generates typed Rust structs and enums for every value object, entity,
+and aggregate record. `given`/`ensures`/mutation logic stays data,
+interpreted at runtime by one small, hand-written kernel
+(`rust/src/kernel/{expr,dispatch}.rs`) that walks it exactly the way
+`CommandInterpreter#call` does in Ruby — so extending the language
+means extending one interpreter twice, not maintaining a second
+hand-written implementation that silently drifts. The parser is
+generated too (`bin/project_parser_table`, from the language's own
+`Syntax` chapter), not hand-written a second time either.
+
+Ruby is the reference implementation; Rust is checked against it
+continuously, not just at release time: `spec/codegen_parity_spec.rb`
+holds Rust's generated output byte-identical to Ruby's, and
+`spec/rust_conformance_spec.rb` runs the same corpus scripts through
+the compiled binary and diffs the result against Ruby's — in CI, on
+every push. Measured directly in this repository, generating and
+building the `pizzas` domain from a clean `rust/src/generated/`:
 
 ```sh
-bin/ir examples/pizzas              # a domain's full IR
-bin/query_ir examples/pizzas duplicates   # structured queries against it
-bin/hecks_query_ir_mcp                    # the same two queries, as an MCP server
+$ bin/project_rust examples/pizzas      # canonical IR → Rust source
+# ~4s
+
+$ bin/project_wasm examples/pizzas      # cross-compiles the SAME binary to wasm32-wasip1
+# ~13s cargo build --release; produces rust/dist/pizzas.wasm (551 KB)
+
+$ wasmtime run rust/dist/pizzas.wasm < spec/corpus/pizzas.json
+# real dispatch output — instances, events, refusals — matching Ruby's
 ```
 
-`bin/hecks_query_ir_mcp` exposes `QueryIR`'s queries as MCP tools, so a
-coding agent calls them directly instead of shelling out to `bin/query_ir`
-and parsing stdout. `bin/model_check` runs static analysis over the IR —
-unreachable lifecycle states, dead transitions, saga states nothing
-reaches. `bin/shape` prints the exact storage-shape hash an era mints
-from a bluebook, for reading rather than asserting against.
+That WASM artifact is not a second implementation compiled for a
+different target — it is `rust/src/main.rs`'s stdin/stdout JSON CLI,
+unchanged, cross-compiled ([ADR
+0012](docs/implemented/decisions/0012-wasm-via-wasi-stdio.md)): it reads a step
+list on stdin and writes the same `{"instances","events","refusals"}`
+shape the native binary and Ruby both produce, so a runtime built for a
+browser tab, an edge function, or a sandboxed plugin host runs the
+*same checked semantics* — no server, no Ruby, no database — as the
+one CI holds equal to the reference implementation. A separate
+`wasm-bindgen` build (`bin/project_wasm_browser`) targets an ES module
+for the browser specifically.
 
-## The folder convention
+What this buys, concretely: the business definition is not coupled to
+where or how it executes. A human or an AI agent edits the bluebook;
+hecks validates it against the same semantics regardless of target,
+then projects it to whichever execution form the deployment actually
+needs — a Ruby process talking to Postgres, or a portable binary with
+no runtime dependencies at all. Deployment (SAM/Lambda templates via
+`bin/project_deploy`, an OIDC manifest via `bin/project_oidc`, a
+standalone CLI via `bin/project_cli`) is downstream of that same
+projection step, not a separate hand-authored artifact.
 
-A domain's `bluebook/` folder holds only what's its own — see
-[The domain](#the-domain-bluebook-hecksagon-world) above. Ports and
-adapters ship with the library instead, beside their implementation:
+What this does *not* yet claim: no throughput or latency benchmark has
+been run against either binary, `read_model` queries have no generated
+Rust code path yet, and the WASM projector is one command away
+(`bin/project_wasm`) but not part of any deployed pipeline today. See
+[Running a runtime](docs/implemented/guides/running-a-runtime.md) for
+the exact field-by-field contract a third dispatch runtime would need,
+and [the retired first Rust
+runtime](docs/implemented/rust-experiment.md) for why hand-writing a
+second implementation was tried and abandoned before this
+generate-and-check architecture replaced it.
+
+## AI-native development
+
+The thesis from [Why](#why-this-gets-sharper-with-ai-generated-code)
+made concrete: a coding agent working on a hecks domain has a
+narrower, checked surface to operate on than one editing an arbitrary
+codebase, and — as of this repository's most recent work — a real,
+tested way to operate on it without shelling out to ad hoc scripts.
+
+`bin/hecks_mcp_door` (backed by `Hecks::Storehouse`,
+`lib/hecks/storehouse.rb`, tested by `spec/storehouse_spec.rb`) is an
+MCP server exposing one bus for *every* booted domain: `dispatch`
+(commands, with `dry_run` and batched steps), `query`, `state`,
+`history`, `catalog`, `describe`, `validate` (a deep model-check pass),
+`domains` (auto-discovery, so a caller that doesn't already know a
+path can find one), `behaviors`, and `follow` (tails a domain's own
+audit log live). Every call carries a required `summary` and, for
+`dispatch`/`query`, an actual caller identity (`role`/`actor_id`) bound
+for the call — a role-gated command's authorization is checked through
+the bus, not merely documented. `bin/hecks_query_ir_mcp` is a smaller,
+older, read-only sibling exposing structural queries over the language
+itself (`lib/hecks/query_ir.rb`) — meta-tooling for working on hecks,
+not on a business domain. Both are registered in `.mcp.json` in this
+repository.
+
+What this means in practice: an agent can inspect a domain's shape,
+dispatch a real command, read back events and state, and statically
+validate a change — all through the same closed, checked vocabulary a
+human reads in the bluebook — instead of grepping and editing
+arbitrary Ruby files. It does not mean the agent is unsupervised, or
+that the vocabulary is complete (see [Project
+status](#project-status)); it means the interface an agent operates
+through is the same constrained one this whole document has been
+arguing for.
+
+## Project status
+
+`0.3.0`, pre-1.0. No stability guarantee on either the DSL or the
+runtime API, and no published gem — see [Quickstart](#quickstart).
+
+**Working today**, exercised in CI on every push (1,937 rspec examples
+across the full suite, alongside `bin/model_check` and `bin/fuzz`):
+
+- The DSL → IR → dispatch pipeline; the Ruby reference runtime.
+- Persistence adapters: Memory, Sqlite, Postgres, PostgresEra, Heki,
+  Folder.
+- Static model checking, property-based fuzzing (Memory adapter),
+  corpus regression, golden IR snapshots.
+- The generated Rust dispatch runtime, differentially tested against
+  Ruby continuously (not merely at release time).
+- WASM projection (WASI and browser targets) from the same generated
+  Rust.
+- AWS Lambda/SAM deployment projection; Mermaid diagram projection.
+- Both MCP servers described in [AI-native
+  development](#ai-native-development) — the Storehouse dispatch door
+  landed very recently and is the least battle-tested item on this
+  list.
+
+**Experimental or partial:**
+
+- Property-based fuzzing only runs against the Memory adapter; Sqlite
+  and Postgres are unexercised by it.
+- The query DSL has no aggregation yet — no `count`, `sum`, `group_by`.
+- `PostgresEra`'s schema-evolution/translation system works and is
+  exercised in CI, but has open, documented gaps in
+  migration/rekey edge cases.
+- A known, diagnosed, unfixed race exists in nested reaction dispatch
+  (a thread-shared counter) — see `docs/future-features.md`.
+- Rust codegen has no generated path for `read_model` queries yet;
+  those still require Ruby.
+
+**Planned or research only — nothing below is built:**
+
+- Rails integration (`docs/rails-integration.md` — design only).
+- Inbound scheduling ("Drivers": interval/cron/clock triggers declared
+  in the hecksagon).
+- A durable outbox for effect ports.
+- Mutation testing and coverage-guided fuzzing.
+
+[`docs/future-features.md`](docs/future-features.md) is the project's
+own running list of gaps, ranked by how much depends on them — read it
+before assuming a capability exists that isn't demonstrated above.
+
+## Quickstart
+
+There is no published gem. You clone the repository, and the
+repository is the tool:
+
+```sh
+git clone https://github.com/chrisyoung/hecks
+cd hecks
+bundle install
+bin/console examples/banking     # drops into IRB with the domain booted
+```
+
+No server, no setup — `examples/banking` wires `Heki`, a local
+append-only file, so this works offline on a clean clone:
 
 ```ruby skip
-lib/hecks/ports/            the PORT — the how-verb and the signal
-lib/hecks/adapters/driven/
-  sqlite.adapter                 the DECLARATION
-  sqlite.rb                      the IMPLEMENTATION
-  memory.* heki.* postgres.* folder.* prism.*
+customer = Customer.register!(reference: { value: "CUST-1001" }, name: { given: "Chris", family: "Young" }, email: { address: "chris@example.com" })
+account  = Account.open!(customer: "CUST-1001", number: { value: "1001" }, kind: { name: "current" }, daily_limit: { cents: 50_000 })
+account.credit!(amount: { cents: 500, currency: "USD" }, narrative: { text: "Opening deposit" })
+
+account.balance.to_h    # => { cents: 500, currency: "USD" }
+account.status          # => "open"
 ```
 
-A project bringing its own port or adapter puts them in a `ports/` or
-`adapters/` folder above its domains, found by walking up — the
-library's own load runs first, so a project's can only add, never
-replace.
+`bin/console` with no domain argument boots `examples/pizzas` instead —
+the domain [Getting started](docs/implemented/guides/getting-started.md)
+walks through — but that domain's real wiring uses `PostgresEra`, so it
+needs a reachable local Postgres. Reach for `examples/banking` first if
+one isn't already running. To run a scripted step list instead of a
+REPL:
 
-## The corpus
+```sh
+bin/run examples/banking spec/corpus/banking.json
+```
+
+To verify the whole claim, not just the demo:
+
+```sh
+bundle exec rspec       # the whole suite — 1,937 examples
+bin/model_check         # static analysis over a domain's IR
+bin/fuzz                # generated sequences, checked against declared properties
+```
+
+## Architecture and documentation
+
+<!-- generated:begin id=guides -->
+- [Aggregates and value objects](docs/implemented/guides/aggregates-and-value-objects.md)
+- [Behaviors](docs/implemented/guides/behaviors.md)
+- [Commands](docs/implemented/guides/commands.md)
+- [Entities](docs/implemented/guides/entities.md)
+- [Extending Hecks](docs/implemented/guides/extending-hecks.md)
+- [Getting started](docs/implemented/guides/getting-started.md)
+- [Guides](docs/implemented/guides/index.md)
+- [Language versioning](docs/implemented/guides/language-versioning.md)
+- [Lifecycles](docs/implemented/guides/lifecycles.md)
+- [Policies and process managers](docs/implemented/guides/policies-and-process-managers.md)
+- [Queries and read models](docs/implemented/guides/queries-and-read-models.md)
+- [Running a runtime](docs/implemented/guides/running-a-runtime.md)
+- [Schema evolution](docs/implemented/guides/schema-evolution.md)
+- [Verification](docs/implemented/guides/verification.md)
+- [Wiring](docs/implemented/guides/wiring.md)
+- [Writing an adapter](docs/implemented/guides/writing-an-adapter.md)
+<!-- generated:end -->
+
+<!-- generated:begin id=reference -->
+[The DSL reference](docs/implemented/reference/index.md) — 22 contexts, generated from the aggregate-local tables under `lib/hecks/language/` and held to them by `spec/reference_golden_spec.rb`.
+<!-- generated:end -->
+
+Beyond the guides and the DSL reference:
+
+- **[Architecture map](docs/architecture-map.md)** — the `lib/hecks/`
+  and `rust/` directory layout, and the dependency direction the split
+  follows.
+- **[The tools](docs/tools.md)** — every `bin/` script, one line each.
+- **Resolution rules** — the exact algorithm behind every piece of DSL
+  sugar that lets a bluebook omit something the runtime can derive:
+  [overview](docs/resolution-rules/README.md),
+  [cross-entity given](docs/resolution-rules/cross-entity-given.md).
+- **[Decision log](docs/decisions/)** and
+  **[implemented decisions](docs/implemented/decisions/)** — one
+  document per architectural decision, kept even after superseded.
+- **[The query DSL](docs/query-dsl.md)**,
+  **[command/query form](docs/command-form-and-query-form-bluebook.md)**,
+  **[Rails integration](docs/rails-integration.md)** (design only).
+- **[`docs/HECKS_IMPLEMENTATION_PLAN.md`](docs/HECKS_IMPLEMENTATION_PLAN.md)**
+  — the full aspirational architecture in one document. Treat this as a
+  roadmap, not a status report; [Project status](#project-status) above
+  is the status report.
+
+The example domains this README draws from:
 
 <!-- generated:begin id=corpus -->
 - **banking** — Customers hold accounts, accounts move money, and every movement is a transfer that can fail halfway. The domain that has to get it right twice — once in the rules, once in the recovery.
@@ -535,99 +647,17 @@ replace.
 - **roster** — A crew roster: seats added one at a time, members enlisted, each seated once — the smallest domain whose every rule is a question asked of a LIST.
 <!-- generated:end -->
 
-## The tools
+## Contributing
 
-<!-- generated:begin id=tools -->
-| tool | |
-|---|---|
-| `bin/backfill_era_projections` | Proactively backfills `hecks_eras.held_projection` for every row of one domain that predates that column — an explicit, operator-run vers... |
-| `bin/behaviors` | Runs `.behaviors` files — hand-curated examples of how to use a domain, in domain vocabulary — and reports pass/fail/error per test. bin/... |
-| `bin/canonicalise` | Sorts a JSON document's object keys, recursively — key order is not semantics, so a diff a human reads should not have to notice it moved. |
-| `bin/codemod_hoist_local_givens` | A CODEMOD, not an agent — for the corpus duplication `bin/query_ir duplicates` surfaces directly: two or more commands under the SAME own... |
-| `bin/codemod_implicit_append_fields` | A CODEMOD, not an agent — for the class of redundancy `CommandBuilder#resolve_append_fields!` (lib/hecks/bluebook/dsl/ command_builder.rb... |
-| `bin/console` | Boots a domain (pizzas by default) and drops into IRB with its door installed — the fastest way to dispatch a real command by hand. bin/c... |
-| `bin/doc_coverage` | EVERY LIVE WORD SHIPS WITH A RUNNING EXAMPLE, or this refuses. Prose is a declaration, and a declaration nothing runs cannot disagree wit... |
-| `bin/docs` | A domain's usage document, projected from its own bluebook. bin/docs # list every domain in this checkout bin/docs examples/banking # the... |
-| `bin/evolve` | The language-change convention, made executable. Adding a word to the bluebook surface has always been a many-file walk — syntax row, Rub... |
-| `bin/expression_projection` | The expression machinery's tables, projected from the grammar chapter's admitted set and checked in, so the evaluator and the canonical f... |
-| `bin/follow` | Live-tails a domain's own persisted event log — the declared `emits` every command reports, durably recorded (not `registry.event_log`, w... |
-| `bin/fuzz` | Generates random-but-valid command/query sequences from a domain's own IR (Hecks::Fuzzing::SequenceGenerator) and checks each one the way... |
-| `bin/generate` | Prints one randomly generated, valid dispatch sequence for a domain — the same generator bin/fuzz drives, exposed standalone so a sequenc... |
-| `bin/hecks_mcp_door` | AN MCP DOOR ONTO THE STOREHOUSE BUS — one MCP server for EVERY booted domain, not one per command. `docs/hecks-survey-what-we-wish-we-had... |
-| `bin/hecks_query_ir_mcp` | AN MCP SERVER exposing Hecks::QueryIR's two queries as tools, so a coding agent calls them directly instead of shelling out to `bin/query... |
-| `bin/history` | Prints every journal entry a domain's append-only adapters hold, as JSON — the full write history, not just the current head. bin/history... |
-| `bin/ir` | Prints a booted domain's IR as JSON — the same `to_h` the golden specs pin and StorageShape hashes into an era, for reading rather than a... |
-| `bin/merge_tail` | Tail-merge: the one deliberate command. It marks a business event — an old app retiring — never a shape change. One transaction: advance ... |
-| `bin/model_check` | STATIC ANALYSIS OVER THE IR — unreachable lifecycle states, transitions nothing can ever fire, saga states no handler chain reaches, a co... |
-| `bin/narrate` | A domain, read back in English — projected from its own bluebook. bin/narrate # list every domain in this checkout bin/narrate examples/b... |
-| `bin/pattern-cases` | THE RECORDED FIXTURE for `pattern:`, and how to regenerate it : bin/pattern-cases > spec/corpus/fixtures/patterns.json spec/pattern_subse... |
-| `bin/present` | Boots the banking example against the in-memory adapter (same rebind spec/facade/handle_spec.rb already uses — banking.hecksagon itself b... |
-| `bin/project` | Refreshes every read-model projection a domain declares, by hand — the same catch-up a boot runs lazily, forced now rather than on first ... |
-| `bin/project_cli` | Mints a command-line binary for a domain, named after its bluebook. bin/project_cli # every domain in this checkout bin/project_cli qa # ... |
-| `bin/project_deploy` | The AWS DEPLOYMENT projector — docs/decisions/0018-rehydrate-replay-lambda-host.md. Generates the SAM template and build Makefile for rus... |
-| `bin/project_diagrams` | Projects a booted domain's own shape into Mermaid diagrams — one stateDiagram-v2 per lifecycle-bearing aggregate/entity, one erDiagram fo... |
-| `bin/project_field_hints` | Generates rust/host/src/field_hints.rs — the four regex hints Hecks::Forms::FieldShape#text_field (lib/hecks/ forms/field_shape.rb) match... |
-| `bin/project_kernel_capabilities` | Generates the two capability enums the hand-written Rust kernel (rust/src/kernel/attribute_shapes/*.rs, rust/src/kernel/ expression_opera... |
-| `bin/project_model` | Projects the model's holding half from the language that declares it. Behaviour::X is hand-written and untouched; `settle` is the seam. b... |
-| `bin/project_oidc` | Projects every domain's OIDC client/scope manifest into `<domain>/oidc.json` — the artifact half of §11, `Hecks::Projections::OIDC`, made... |
-| `bin/project_parser_table` | Projects the chapter's own Syntax aggregate into the Rust parser's keyword table — the parser's grammar knowledge DERIVED from hecks's se... |
-| `bin/project_refusal_wording` | Generates rust/src/kernel/refusal_wording.rs from `Hecks::Runtime:: RefusalWording::TEMPLATES` (lib/hecks/runtime/refusal_wording.rb) — t... |
-| `bin/project_rust` | Generates Rust source for one domain into rust/src/generated/ — the driver for `RustProjection` (rust/project.rb, alongside the Rust crat... |
-| `bin/project_tenant` | THE TENANT PROVISIONER — same split bin/project_deploy already draws between VALIDATING a declared shape (lib/hecks/deploy's own Tenant.D... |
-| `bin/project_vocabulary` | Projects the language's own closed sets into lib/hecks/vocabulary.rb. A one-line wrapper over the projector registry, deliberately — the ... |
-| `bin/project_wasm` | The WASM projector — wraps THE SAME Rust binary bin/project_rust already generates, rather than a second, WASM-specific implementation (d... |
-| `bin/project_wasm_browser` | The BROWSER wasm-bindgen projector — decision docs/decisions/0015-wasm-bindgen-browser-projection.md. Deliberately a SEPARATE binary from... |
-| `bin/query_ir` | STRUCTURED QUERIES AGAINST THE LANGUAGE'S OWN IR — for a session working ON the language (adding a resolution rule, checking a propagatio... |
-| `bin/reattest_era` | The recovery path after a held-text integrity refusal. The digest is tamper-EVIDENCE — it catches accident and drift, not an adversary (a... |
-| `bin/reference` | Regenerates docs/implemented/reference/ from the language's own Syntax chapter — the tables from the declaration, the prose preserved fro... |
-| `bin/run` | Executes a step list — commands and queries, declared as JSON — and reports instances, events, refusals, reactions, sagas, and query rows... |
-| `bin/rust_conformance` | THE DIFFERENTIAL HARNESS — docs/decisions/0010-ruby-is-the-reference-implementation.md. Ruby is the oracle a second runtime is checked ag... |
-| `bin/rust_coverage` | THE COVERAGE CHECKER — a different question than bin/rust_conformance asks, deliberately, not a replacement for it. bin/rust_conformance ... |
-| `bin/rust_kernel_coverage` | THE MECHANICAL, COMMENT-TAG-FREE HALF OF THE GUARANTEE. bin/project_kernel_capabilities generates the ENUM half — the compiler already re... |
-| `bin/scaffold_translation` | The scaffold writes translations; humans resolve ambiguity. Diffs the held era against the current bluebook and writes the edge file: con... |
-| `bin/shape` | The storage-shape projection of one bluebook file, as JSON — the exact form StorageShape.mint_hash hashes to name an era, printed so a bu... |
-| `bin/smoke_test` | BOOTS A REAL DOMAIN AND ACTUALLY DISPATCHES AGAINST IT — the sibling `bin/model_check` never had. That tool proves a bluebook is STRUCTUR... |
-| `bin/statements` | Prints a booted domain's own declared facts as plain English sentences — the projection itself is Projections::Statements (see its own he... |
-| `bin/stores` | Prints every aggregate's current records, as JSON — the head, not the journal (bin/history prints the full write history instead). bin/st... |
-| `bin/translation_audit` | The audit derives its assertions. Layer 1: every translated state passes the new era's types, invariants, and lifecycle. Layer 2: the com... |
-<!-- generated:end -->
+Issues, examples, and runtime/adapter work are all welcome — this is
+pre-1.0 research software, and the gaps in [Project
+status](#project-status) are real starting points, not a formality.
+Before sending a change: `bundle exec rspec`, `bin/model_check`, and
+`bin/fuzz` are what CI runs, and every `ruby`-fenced example in a guide
+or this README is expected to execute exactly as shown
+(`spec/guides_spec.rb`). There is no `CONTRIBUTING.md` yet — open an
+issue first for anything larger than a small fix.
 
-## The library
+## License
 
-```ruby skip
-lib/hecks/
-  language/     the language, declared in its own bluebooks.  WHAT A BLUEBOOK IS.
-  grammar/      the expression and translation sublanguages, and the Admit gate.
-  bluebook/     dsl → ir → expression.  READING ONE.
-  runtime/      dispatch, instances, the registry.  RUNNING IT.
-  adapters/     driven: memory, sqlite, heki, postgres, folder, prism.
-  translation/  domain-version translation — eras and lineage.
-  projector/    IR serialization — the translation-edge digest reads it.
-
-  facade/               the door.  Class-free, per boot.
-  router/               project-wide dispatch; installs each chapter's namespace at boot.
-  ports/                domain ports — auth, identity, persistence, query.
-  query_specification/  a query's shape, held apart from any engine that answers it.
-  projections/          IR as a capability — emits_ir and its consumers (OIDC, reference, parser table).
-  forms/                IR → HTML, content-negotiated against plain JSON.
-  fuzzing/              generated sequences, checked against declared properties.
-  doc/                  the generated DSL reference (bin/reference).
-  framework/            shared, domain-agnostic bluebooks — Governance, Identity, ConsoleSettings.
-  deploy/               the Deploy bluebook — what deployed_to means.
-```
-
-The split follows the dependency direction, not the topic: the
-expression evaluator lives in the semantic core, not `projector/`,
-because the runtime evaluates every `given` and invariant through it
-directly. Nothing here is required by `require "hecks"` unless a booted
-domain uses it — `forms/` and `fuzzing/` stay out of the core boot
-chain, so a project that never touches one never pays for it.
-
-## Verify
-
-```sh
-bundle exec rspec                 # the whole suite
-bundle exec parallel_rspec spec   # same suite, split across your machine's cores (local only)
-bin/model_check                   # static analysis over the IR — unreachable states, dead transitions
-bin/fuzz                          # generated sequences, checked against declared properties
-```
+Apache License 2.0 — see [`LICENSE`](LICENSE).

--- a/bin/console
+++ b/bin/console
@@ -10,6 +10,13 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "hecks"
 require "irb"
 
+# ADR 0033 — the era/lineage subsystem (including `PostgresEra`) moved
+# behind a loadable persistence plugin core no longer requires by
+# default. The pizzas example this script boots by default wires
+# `PostgresEra`, so this console needs the plugin explicitly, same as
+# bin/project_rust and every other consumer that boots a real domain.
+require "hecks/ports/persistence/plugins/era"
+
 DOMAIN  = ARGV.shift || File.expand_path("../examples/pizzas", __dir__)
 RUNTIME = Hecks.boot(DOMAIN)
 

--- a/bin/ir
+++ b/bin/ir
@@ -10,6 +10,9 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "hecks"
+# ADR 0033 — a domain wired to PostgresEra needs this plugin loaded
+# explicitly; the era/lineage subsystem no longer loads with core.
+require "hecks/ports/persistence/plugins/era"
 
 if ARGV.delete("--meta")
   # THE LANGUAGE'S OWN IR — Bluebook, Aggregate, Command, ValueObject,

--- a/bin/run
+++ b/bin/run
@@ -27,6 +27,9 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "hecks"
+# ADR 0033 — a domain wired to PostgresEra needs this plugin loaded
+# explicitly; the era/lineage subsystem no longer loads with core.
+require "hecks/ports/persistence/plugins/era"
 require "json"
 
 USAGE = "usage: bin/run [domain] <verb [name=value …] | script.json | - | '{\"steps\":[…]}'>".freeze

--- a/docs/architecture-map.md
+++ b/docs/architecture-map.md
@@ -1,0 +1,51 @@
+# The library
+
+```ruby skip
+lib/hecks/
+  language/     the language, declared in its own bluebooks.  WHAT A BLUEBOOK IS.
+  grammar/      the expression and translation sublanguages, and the Admit gate.
+  bluebook/     dsl → ir → expression.  READING ONE.
+  runtime/      dispatch, instances, the registry.  RUNNING IT.
+  adapters/     driven: memory, sqlite, heki, postgres, folder, prism.
+  translation/  domain-version translation — eras and lineage.
+  projector/    IR serialization — the translation-edge digest reads it.
+
+  facade/               the door.  Class-free, per boot.
+  router/               project-wide dispatch; installs each chapter's namespace at boot.
+  ports/                domain ports — auth, identity, persistence, query.
+  query_specification/  a query's shape, held apart from any engine that answers it.
+  projections/          IR as a capability — emits_ir and its consumers (OIDC, reference, parser table).
+  forms/                IR → HTML, content-negotiated against plain JSON.
+  fuzzing/              generated sequences, checked against declared properties.
+  doc/                  the generated DSL reference (bin/reference).
+  framework/            shared, domain-agnostic bluebooks — Governance, Identity, ConsoleSettings.
+  deploy/               the Deploy bluebook — what deployed_to means.
+```
+
+The split follows the dependency direction, not the topic: the
+expression evaluator lives in the semantic core, not `projector/`,
+because the runtime evaluates every `given` and invariant through it
+directly. Nothing here is required by `require "hecks"` unless a
+booted domain uses it — `forms/` and `fuzzing/` stay out of the core
+boot chain, so a project that never touches one never pays for it.
+
+## The second runtime
+
+```ruby skip
+rust/
+  src/kernel/     the hand-written interpreter — walks given/ensures/mutation data, same job as CommandInterpreter#call in Ruby.
+  src/generated/  typed structs and enums per domain, written by bin/project_rust — never hand-edited.
+  parser/         a generated Rust parser, built from the language's own Syntax chapter (bin/project_parser_table).
+  codegen/        the Rust code generator itself, driven from canonical IR.
+  project/        RustProjection (rust/project.rb) — the Ruby-side driver bin/project_rust calls.
+  web/            the wasm-bindgen crate bin/project_wasm_browser builds — a separate cdylib from the WASI binary.
+```
+
+`rust/src/kernel/{expr,dispatch}.rs` is the one part of this tree
+someone still writes by hand — everything else (`generated/`, the
+parser tables, the type shapes) is projected from the same canonical
+IR the Ruby runtime reads. See [Projections: Rust and
+WebAssembly](../README.md#projections-rust-and-webassembly) for what
+that buys, and [Running a
+runtime](implemented/guides/running-a-runtime.md) for the
+field-by-field contract a third dispatch runtime would need.

--- a/docs/decisions/0010-ruby-is-the-reference-implementation.md
+++ b/docs/decisions/0010-ruby-is-the-reference-implementation.md
@@ -1,6 +1,11 @@
 # Ruby is the reference implementation; other runtimes validate against it, continuously
 
-**Status:** Accepted — not yet implemented. Supersedes the "wait for IR stability" entry criterion in [0007](../implemented/decisions/0007-rust-generates-code-not-ruby-source.md)'s original Phase 5 placement.
+**Status:** Accepted — implemented. The differential harness this ADR
+specifies is real and runs in CI: `spec/rust_conformance_spec.rb`,
+`spec/codegen_parity_spec.rb`, and `spec/parser_parity_spec.rb`.
+Supersedes the "wait for IR stability" entry criterion in
+[0007](../implemented/decisions/0007-rust-generates-code-not-ruby-source.md)'s
+original Phase 5 placement.
 
 ## Context
 

--- a/docs/implemented/guides/index.md
+++ b/docs/implemented/guides/index.md
@@ -46,3 +46,6 @@ you're not.
 14. **[Behaviors](behaviors.md)** — hand-curated examples of how a domain
     is used, in its own vocabulary, run as tests: `bin/behaviors`, the
     rspec shim, and what `emits:` sees through a real policy cascade.
+15. **[Language versioning](language-versioning.md)** — how the bluebook
+    surface itself carries `proposed`/`admitted`/`deprecated`/`retired`,
+    and what `bin/evolve` does with a rename.

--- a/docs/implemented/guides/language-versioning.md
+++ b/docs/implemented/guides/language-versioning.md
@@ -1,0 +1,34 @@
+# Language versioning
+
+The bluebook surface is itself declared, in `syntax.bluebook` — which
+means the surface can carry its own lifecycle the same way any other
+word in this language does: `proposed`, `admitted`, `deprecated`,
+`retired`.
+
+A `proposed` or `retired` word reaches no projected parser table. To a
+projected reader — the generated Rust parser, the DSL reference, the
+keyword table any tool builds from `Syntax` — that word does not exist
+yet, or does not exist any more. There is no separate "is this word
+still supported" question to answer by hand; the language's own
+declaration already answers it.
+
+A renamed word keeps its old spelling in `was:`, so a bluebook written
+under an earlier spelling keeps parsing rather than breaking the day a
+word is renamed for clarity:
+
+```ruby skip
+word "sets", was: "assigns"
+```
+
+`bin/evolve` walks a language change through the stations a rename or
+a new word actually needs: snapshot the current state, rewrite the
+corpus to the new spelling, regenerate every projected table (parser,
+reference, vocabulary), gate on the full suite, and restore the
+snapshot on red rather than leaving the tree half-migrated.
+
+This is the same discipline `PostgresEra` applies to a *domain's* own
+vocabulary (see [Schema evolution](schema-evolution.md)), turned on the
+language that hosts every domain: a word can change without every
+bluebook that already used the old spelling breaking, and the record
+of what changed and why lives in the language's own declaration, not
+in a changelog someone has to remember to update.

--- a/docs/implemented/guides/running-a-runtime.md
+++ b/docs/implemented/guides/running-a-runtime.md
@@ -490,6 +490,23 @@ resolved to.
 
 ## The expression grammar
 
+A command's predicate is Ruby, parsed by Prism (Ruby's own parser gem,
+not a second grammar written by hand) and reduced to this canonical
+text at DSL-build time — the same reason a domain as a whole is data
+rather than code:
+
+```ruby skip
+given("at most 10 toppings") { toppings.size < 10 }
+                     ↓
+            "toppings.size < 10"
+```
+
+An operator is admitted to this grammar only once it reads as a real
+rendering of a real rule already in the corpus — an operator with no
+rendering is not a slow operator, it is not an operator. Every operator
+the evaluator runs passes through this admission gate on each suite
+run, checked, not aspired to.
+
 `given`, `ensures`, and every value-object `invariant` are strings —
 already normalized at DSL-build time (whitespace collapsed, `.length`
 rewritten to `.size`), so the SAME text you see in the IR is exactly

--- a/docs/implemented/guides/schema-evolution.md
+++ b/docs/implemented/guides/schema-evolution.md
@@ -16,6 +16,15 @@ documents the other answer: the shape change is declared, the same way
 everything else here is declared, and a real tool tells you — before
 you boot — whether every old record survives it.
 
+This is `PostgresEra`'s job specifically, not Postgres's in general.
+Plain `Postgres` has no era tracking — it boots whatever text it is
+handed, the same as `Memory`, `Sqlite`, and `Heki`, none of which carry
+a translation system either. `PostgresEra` is the one binding that
+holds the source text a booted domain was born from, refuses on drift
+between held text and booting text, and requires a deliberate
+`translations/*.bluebook` file the moment a shape change would
+otherwise silently reinterpret old rows.
+
 ## It already happened here
 
 This is not a hypothetical. `examples/pizzas` lived through exactly this,

--- a/docs/implemented/guides/wiring.md
+++ b/docs/implemented/guides/wiring.md
@@ -13,17 +13,40 @@ will listen to it, and which values differ from one deployment to the
 next. The domain says WHAT: the wiring says
 WHERE, and neither file is allowed to say the other's part.
 
-## The folder convention, briefly
+## The folder convention
 
-`README.md`'s own **folder convention** section is the source of
-truth here and is not repeated in full below; read it first if it has not been read yet.
-The shape it settles: a domain's own `bluebook/` folder holds exactly
-three files with three different jobs — `.bluebook` (what the domain
-IS), `.hecksagon` (how THIS deployment wires it), `.world` (what
-values THIS deployment uses) — and ports/adapters live with the
-library or a project's own `ports/`/`adapters/` folder, never inside a
-domain's own folder. Everything below is what actually goes inside the
-second and third of those three files.
+A domain's own `bluebook/` folder holds exactly three files with three
+different jobs — `.bluebook` (what the domain IS), `.hecksagon` (how
+THIS deployment wires it), `.world` (what values THIS deployment
+uses) — and nothing else:
+
+```ruby skip
+examples/pizzas/
+  bluebook/
+    pizzas.bluebook        the domain
+    pizzas.hecksagon       the wiring
+    pizzas.world           the per-deployment values
+  data/
+```
+
+Ports and adapters ship with the library instead, beside their own
+implementation, never inside a domain's folder:
+
+```ruby skip
+lib/hecks/ports/            the PORT — the how-verb and the signal
+lib/hecks/adapters/driven/
+  sqlite.adapter                 the DECLARATION
+  sqlite.rb                      the IMPLEMENTATION
+  memory.* heki.* postgres.* folder.* prism.*
+```
+
+A project bringing its own port or adapter puts them in a `ports/` or
+`adapters/` folder above its domains, found by walking up — the
+library's own load runs first, so a project's can only add, never
+replace.
+
+Everything below is what actually goes inside the second and third of
+those three files.
 
 ## The declaration
 
@@ -234,6 +257,40 @@ Hecks.world "Pizzas" do
   end
 end
 ```
+
+A `.world` block can carry more than one adapter binding, plus a
+deployment target. `examples/banking/bluebook/banking.world`, quoted
+verbatim:
+
+```ruby skip
+Hecks.world "Banking" do
+  realm "Examples"
+  latest "v1"
+  persisted_by("Heki") do
+    dir "data"
+  end
+
+  projected_by("SqliteProjection") do
+    database "data/banking_projection.sqlite3"
+  end
+
+  deployed_to("AwsLambda") do
+    region "us-east-1"
+    memory 512
+    timeout 10
+    database "Shared"    # no RDS of Banking's own
+    owner "ExampleTeam"  # isolated by its own native Postgres schema
+  end
+end
+```
+
+`deployed_to("AwsLambda")` is read by `bin/project_deploy` (see
+[Projections: Rust and
+WebAssembly](../../../README.md#projections-rust-and-webassembly) in
+the README, and [architecture-map.md](../../architecture-map.md) for
+the projector inventory) to generate a self-contained SAM template,
+build Makefile, and bastion config — its own VPC and RDS Postgres
+instance, no secret typed anywhere.
 
 ## Writing your own port or adapter
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,59 @@
+# The tools
+
+Every script under `bin/` in one table — each summary is the tool's own
+opening comment, truncated. Read the tool itself for the full
+description, or run it with no arguments (most support `--help` or
+print a usage line on a missing argument).
+
+| tool | |
+|---|---|
+| `bin/backfill_era_projections` | Proactively backfills `hecks_eras.held_projection` for every row of one domain that predates that column — an explicit, operator-run vers... |
+| `bin/behaviors` | Runs `.behaviors` files — hand-curated examples of how to use a domain, in domain vocabulary — and reports pass/fail/error per test. bin/... |
+| `bin/canonicalise` | Sorts a JSON document's object keys, recursively — key order is not semantics, so a diff a human reads should not have to notice it moved. |
+| `bin/codemod_hoist_local_givens` | A CODEMOD, not an agent — for the corpus duplication `bin/query_ir duplicates` surfaces directly: two or more commands under the SAME own... |
+| `bin/codemod_implicit_append_fields` | A CODEMOD, not an agent — for the class of redundancy `CommandBuilder#resolve_append_fields!` (lib/hecks/bluebook/dsl/ command_builder.rb... |
+| `bin/console` | Boots a domain (pizzas by default) and drops into IRB with its door installed — the fastest way to dispatch a real command by hand. bin/c... |
+| `bin/doc_coverage` | EVERY LIVE WORD SHIPS WITH A RUNNING EXAMPLE, or this refuses. Prose is a declaration, and a declaration nothing runs cannot disagree wit... |
+| `bin/docs` | A domain's usage document, projected from its own bluebook. bin/docs # list every domain in this checkout bin/docs examples/banking # the... |
+| `bin/evolve` | The language-change convention, made executable. Adding a word to the bluebook surface has always been a many-file walk — syntax row, Rub... |
+| `bin/expression_projection` | The expression machinery's tables, projected from the grammar chapter's admitted set and checked in, so the evaluator and the canonical f... |
+| `bin/follow` | Live-tails a domain's own persisted event log — the declared `emits` every command reports, durably recorded (not `registry.event_log`, w... |
+| `bin/fuzz` | Generates random-but-valid command/query sequences from a domain's own IR (Hecks::Fuzzing::SequenceGenerator) and checks each one the way... |
+| `bin/generate` | Prints one randomly generated, valid dispatch sequence for a domain — the same generator bin/fuzz drives, exposed standalone so a sequenc... |
+| `bin/hecks_mcp_door` | AN MCP DOOR ONTO THE STOREHOUSE BUS — one MCP server for EVERY booted domain, not one per command. `docs/hecks-survey-what-we-wish-we-had... |
+| `bin/hecks_query_ir_mcp` | AN MCP SERVER exposing Hecks::QueryIR's two queries as tools, so a coding agent calls them directly instead of shelling out to `bin/query... |
+| `bin/history` | Prints every journal entry a domain's append-only adapters hold, as JSON — the full write history, not just the current head. bin/history... |
+| `bin/ir` | Prints a booted domain's IR as JSON — the same `to_h` the golden specs pin and StorageShape hashes into an era, for reading rather than a... |
+| `bin/merge_tail` | Tail-merge: the one deliberate command. It marks a business event — an old app retiring — never a shape change. One transaction: advance ... |
+| `bin/model_check` | STATIC ANALYSIS OVER THE IR — unreachable lifecycle states, transitions nothing can ever fire, saga states no handler chain reaches, a co... |
+| `bin/narrate` | A domain, read back in English — projected from its own bluebook. bin/narrate # list every domain in this checkout bin/narrate examples/b... |
+| `bin/pattern-cases` | THE RECORDED FIXTURE for `pattern:`, and how to regenerate it : bin/pattern-cases > spec/corpus/fixtures/patterns.json spec/pattern_subse... |
+| `bin/present` | Boots the banking example against the in-memory adapter (same rebind spec/facade/handle_spec.rb already uses — banking.hecksagon itself b... |
+| `bin/project` | Refreshes every read-model projection a domain declares, by hand — the same catch-up a boot runs lazily, forced now rather than on first ... |
+| `bin/project_cli` | Mints a command-line binary for a domain, named after its bluebook. bin/project_cli # every domain in this checkout bin/project_cli qa # ... |
+| `bin/project_deploy` | The AWS DEPLOYMENT projector — docs/decisions/0018-rehydrate-replay-lambda-host.md. Generates the SAM template and build Makefile for rus... |
+| `bin/project_diagrams` | Projects a booted domain's own shape into Mermaid diagrams — one stateDiagram-v2 per lifecycle-bearing aggregate/entity, one erDiagram fo... |
+| `bin/project_field_hints` | Generates rust/host/src/field_hints.rs — the four regex hints Hecks::Forms::FieldShape#text_field (lib/hecks/ forms/field_shape.rb) match... |
+| `bin/project_kernel_capabilities` | Generates the two capability enums the hand-written Rust kernel (rust/src/kernel/attribute_shapes/*.rs, rust/src/kernel/ expression_opera... |
+| `bin/project_model` | Projects the model's holding half from the language that declares it. Behaviour::X is hand-written and untouched; `settle` is the seam. b... |
+| `bin/project_oidc` | Projects every domain's OIDC client/scope manifest into `<domain>/oidc.json` — the artifact half of §11, `Hecks::Projections::OIDC`, made... |
+| `bin/project_parser_table` | Projects the chapter's own Syntax aggregate into the Rust parser's keyword table — the parser's grammar knowledge DERIVED from hecks's se... |
+| `bin/project_refusal_wording` | Generates rust/src/kernel/refusal_wording.rs from `Hecks::Runtime:: RefusalWording::TEMPLATES` (lib/hecks/runtime/refusal_wording.rb) — t... |
+| `bin/project_rust` | Generates Rust source for one domain into rust/src/generated/ — the driver for `RustProjection` (rust/project.rb, alongside the Rust crat... |
+| `bin/project_tenant` | THE TENANT PROVISIONER — same split bin/project_deploy already draws between VALIDATING a declared shape (lib/hecks/deploy's own Tenant.D... |
+| `bin/project_vocabulary` | Projects the language's own closed sets into lib/hecks/vocabulary.rb. A one-line wrapper over the projector registry, deliberately — the ... |
+| `bin/project_wasm` | The WASM projector — wraps THE SAME Rust binary bin/project_rust already generates, rather than a second, WASM-specific implementation (d... |
+| `bin/project_wasm_browser` | The BROWSER wasm-bindgen projector — decision docs/decisions/0015-wasm-bindgen-browser-projection.md. Deliberately a SEPARATE binary from... |
+| `bin/query_ir` | STRUCTURED QUERIES AGAINST THE LANGUAGE'S OWN IR — for a session working ON the language (adding a resolution rule, checking a propagatio... |
+| `bin/reattest_era` | The recovery path after a held-text integrity refusal. The digest is tamper-EVIDENCE — it catches accident and drift, not an adversary (a... |
+| `bin/reference` | Regenerates docs/implemented/reference/ from the language's own Syntax chapter — the tables from the declaration, the prose preserved fro... |
+| `bin/run` | Executes a step list — commands and queries, declared as JSON — and reports instances, events, refusals, reactions, sagas, and query rows... |
+| `bin/rust_conformance` | THE DIFFERENTIAL HARNESS — docs/decisions/0010-ruby-is-the-reference-implementation.md. Ruby is the oracle a second runtime is checked ag... |
+| `bin/rust_coverage` | THE COVERAGE CHECKER — a different question than bin/rust_conformance asks, deliberately, not a replacement for it. bin/rust_conformance ... |
+| `bin/rust_kernel_coverage` | THE MECHANICAL, COMMENT-TAG-FREE HALF OF THE GUARANTEE. bin/project_kernel_capabilities generates the ENUM half — the compiler already re... |
+| `bin/scaffold_translation` | The scaffold writes translations; humans resolve ambiguity. Diffs the held era against the current bluebook and writes the edge file: con... |
+| `bin/shape` | The storage-shape projection of one bluebook file, as JSON — the exact form StorageShape.mint_hash hashes to name an era, printed so a bu... |
+| `bin/smoke_test` | BOOTS A REAL DOMAIN AND ACTUALLY DISPATCHES AGAINST IT — the sibling `bin/model_check` never had. That tool proves a bluebook is STRUCTUR... |
+| `bin/statements` | Prints a booted domain's own declared facts as plain English sentences — the projection itself is Projections::Statements (see its own he... |
+| `bin/stores` | Prints every aggregate's current records, as JSON — the head, not the journal (bin/history prints the full write history instead). bin/st... |
+| `bin/translation_audit` | The audit derives its assertions. Layer 1: every translated state passes the new era's types, invariants, and lifecycle. Layer 2: the com... |


### PR DESCRIPTION
…ense gap

Rewrites the root README around a 60-second understand-then-adopt arc: what hecks is, why the durable-specification bet matters more with AI-generated code, a before/after on one real rule, a business-workflow example (banking), verified Rust/WASM projection numbers, the MCP dispatch door, transparent project-status tiers, and a 5-minute Quickstart that actually works with zero external dependencies.

Also:
- Fixes a real bug: bin/console/bin/run/bin/ir crashed on a clean checkout because pizzas' real .hecksagon wires PostgresEra, whose adapter class isn't loaded without the era plugin (ADR 0033 extraction). Same one-line require already used by 5 other bin/ scripts.
- Adds LICENSE (Apache-2.0, matching hecks.gemspec's spec.license, which previously had no backing file in the repo).
- Corrects ADR 0010's stale "not yet implemented" status against the Ruby/Rust differential harness that is demonstrably live in CI.
- Moves README-only content out to docs/ before trimming it from the README, so nothing is lost: the folder convention and the AWS Lambda .world example into wiring.md, the era/adapter comparison into schema-evolution.md, the expression-grammar framing into running-a-runtime.md, language versioning into a new guide, and the lib/ + rust/ directory map and the full bin/ tool table into new docs/architecture-map.md and docs/tools.md.

Verified: full rspec suite (1,937 examples, 0 failures), every ruby-fenced example in the new README and all guides via spec/guides_spec.rb's doctest harness, the README's generated guides/reference/corpus/diagrams blocks via spec/reference_golden_spec.rb, bin/model_check, bin/fuzz, and the Rust/WASM pipeline numbers (bin/project_rust, bin/project_wasm, wasmtime) measured directly against examples/pizzas.