### PR TITLE
behaviors: close 4 silent-pass paths + Memory-only isolation guard

### DIFF
--- a/docs/implemented/guides/behaviors.md
+++ b/docs/implemented/guides/behaviors.md
@@ -136,8 +136,15 @@ that is a missing word in the bluebook, not a reason to add a sixth
 `Hecks::Behaviors.run(path)` runs one file and returns one result
 per test — `:pass`, `:fail`, or `:error`, each with a message.
 `Hecks::Behaviors.run_all(dir)` sweeps every `.behaviors` file under
-a directory. Boot is a fresh `Hecks.boot_files` call per test — cheap,
-and never shared, so one test's state can never leak into the next's.
+a directory. Boot is ONE `Hecks.boot_files` call per SUITE, not per
+test — a real boot is expensive enough (chess: 76 tests, 155s of pure
+boot time) that per-test booting doesn't scale — and the runtime is
+reset between tests instead (`Registry#reset_runtime_state!`).
+Isolation from that reset is real for `Memory`-bound aggregates, which
+is why a behaviors suite's `loads` is required to resolve every
+aggregate to a `Memory` binding: pointing `loads` at a domain's real,
+non-`Memory` hecksagon is refused at boot, precisely so state can never
+leak from one test into the next — or into a real database.
 
 ```ruby
 require "hecks/behaviors"
@@ -146,7 +153,7 @@ path   = File.join(InMemoryDomain::ROOT, "examples/pizzas/bluebook/pizzas.behavi
 result = Hecks::Behaviors.run(path)
 
 result.parse_error                              # => nil
-result.runs.size                                 # => 6
+result.runs.size                                 # => 7
 result.runs.map(&:status).uniq                   # => [:pass]
 result.runs.first.description                    # => "CreatePizza puts a fresh pizza on the menu, available for sale"
 ```

--- a/examples/pizzas/bluebook/pizzas.behaviors
+++ b/examples/pizzas/bluebook/pizzas.behaviors
@@ -62,4 +62,10 @@ Hecks.behaviors "Pizzas" do
     input  ceiling: { cents: 1000 }
     expect count: 1
   end
+
+  test "Available's own row can be checked directly, not just counted" do
+    tests "Available", on: "Order", kind: :query
+    setup  "CreatePizza", name: { value: "Only One" }, pizza: { price_cents: { cents: 950 }, size: { value: "small" } }
+    expect status: "available", name: { value: "Only One" }
+  end
 end

--- a/lib/hecks/behaviors/dsl.rb
+++ b/lib/hecks/behaviors/dsl.rb
@@ -41,9 +41,38 @@ module Hecks
                            "say which command or query this example exercises"
         end
 
+        validate_expect!
+
         TestCase.new(description: @description, tests_command: @tests_command,
                      on_aggregate: @on_aggregate, kind: @kind,
                      setups: @setups, input: @input, expect: @expect)
+      end
+
+      private
+
+      # Closes the silent-pass paths a free-form `expect(**kwargs)` merge
+      # otherwise leaves open: a test with no `expect` at all asserts
+      # nothing and passes whenever dispatch doesn't raise; `count:` on a
+      # command and `emits:` on a query are each read by neither runner
+      # (Expectations#run_command/#run_query), so they're accepted here
+      # and then silently ignored at run time. Checking both at BUILD
+      # time, not in the runners, makes them errors on the file that
+      # wrote them rather than green checks nobody questions.
+      def validate_expect!
+        if @expect.empty?
+          raise Malformed, "test #{@description.inspect} has no `expect` — say what this " \
+                           "example proves (ok:, refused:, emits:, count:, or a field name)"
+        end
+
+        if @kind == :command && @expect.key?(:count)
+          raise Malformed, "test #{@description.inspect}: `expect count:` only applies to " \
+                           "queries — a command has no row count to check"
+        end
+
+        if @kind == :query && @expect.key?(:emits)
+          raise Malformed, "test #{@description.inspect}: `expect emits:` only applies to " \
+                           "commands — a query never dispatches, so it never emits"
+        end
       end
     end
 

--- a/lib/hecks/behaviors/expectations.rb
+++ b/lib/hecks/behaviors/expectations.rb
@@ -3,6 +3,7 @@ require_relative "../runtime/loader"
 require_relative "../runtime/errors"
 require_relative "../runtime/value"
 require_relative "../runtime/reaction_invocation"
+require_relative "../ports/persistence/binding_policy"
 
 # Hecks::Behaviors::Expectations
 #
@@ -83,7 +84,40 @@ module Hecks
         key   = files.map { |file| [file, File.exist?(file) ? File.mtime(file).to_f : nil] }
 
         RUNTIMES_LOCK.synchronize do
-          RUNTIMES[key] ||= Hecks::Runtime::Loader.boot_files(files, install_facade: false)
+          RUNTIMES[key] ||= boot_and_guard(files)
+        end
+      end
+
+      # `reset_runtime_state!` only drops repository OBJECTS between
+      # tests (registry.rb) — sufficient isolation for `Memory`, whose
+      # `@records` is a plain per-instance ivar, so a fresh object really
+      # is a fresh store. Against anything else (Sqlite, Postgres) the
+      # rows themselves stay put: tests leak into each other, and a
+      # suite booted against a domain's REAL hecksagon writes to a real
+      # database. Refusing that wiring here, at boot, is the same shape
+      # of guard `BindingPolicy` already applies to a missing bind — the
+      # project's identity is refusing bad wiring up front, not
+      # discovering it mid-suite.
+      def boot_and_guard(files)
+        runtime = Hecks::Runtime::Loader.boot_files(files, install_facade: false)
+        guard_memory_only!(runtime)
+        runtime
+      end
+
+      def guard_memory_only!(runtime)
+        runtime.registry.bluebooks.each_value do |bluebook|
+          bluebook.aggregates.each do |aggregate|
+            bind = Ports::Persistence::BindingPolicy.resolve(runtime.registry, bluebook.name, aggregate)
+            next if bind.adapter == Ports::Persistence::DEFAULT_ADAPTER
+
+            raise Malformed,
+                  "#{bluebook.name}::#{aggregate.hecks_name} is persisted_by " \
+                  "#{bind.adapter.inspect}, not #{Ports::Persistence::DEFAULT_ADAPTER.inspect} — " \
+                  "a behaviors suite's `loads` must resolve every aggregate to an in-memory " \
+                  "binding, or tests leak state into each other and write to a real database. " \
+                  "Load a Memory-bound sibling hecksagon instead of the domain's real one — see " \
+                  "examples/pizzas/bluebook/pizzas.behaviors's own `loads` comment for the pattern."
+          end
         end
       end
 
@@ -182,7 +216,33 @@ module Hecks
           return fail_result(test, "expected count: #{expected}, got #{count}") if count != expected
         end
 
-        check_ok(test) || pass_result(test)
+        return check_ok(test) || pass_result(test) unless field_expectations?(test)
+
+        row = query_row(test, rows)
+        return row if row.is_a?(Result)
+
+        check_ok(test) || check_fields(test, row) || pass_result(test)
+      end
+
+      def field_expectations?(test)
+        test.expect.keys.any? { |key| !SPECIAL_KEYS.include?(key) }
+      end
+
+      # A field expectation on a query names one row's shape, so it only
+      # makes sense once the query has settled on exactly one — the same
+      # reason `expect status: "sold"` on a multi-row answer would be
+      # ambiguous about which row it's describing. `check_fields` itself
+      # stays row-shaped (it already is, for `run_command`'s settled
+      # state); this picks which row it reads.
+      def query_row(test, rows)
+        return rows unless rows.is_a?(Array)
+
+        case rows.size
+        when 1 then rows.first
+        when 0 then fail_result(test, "expect names a field, but the query returned no rows")
+        else fail_result(test, "expect names a field, but the query returned #{rows.size} rows — " \
+                               "narrow it with `input`/`expect count: 1` first")
+        end
       end
 
       def check_ok(test)

--- a/spec/behaviors/expectations_spec.rb
+++ b/spec/behaviors/expectations_spec.rb
@@ -137,4 +137,47 @@ RSpec.describe Hecks::Behaviors::Expectations do
       expect(run.message).to include("dispatch succeeded")
     end
   end
+
+  # run_query used to never call check_fields at all — a field
+  # expectation (or a typo'd key) on a query silently passed no matter
+  # what the query actually answered.
+  describe "field expectations on a query" do
+    let(:suite) { Hecks::Behaviors::BehaviorsSuite.new(loads: [File.join(root, "pizzas.bluebook"), memory_hecksagon]) }
+
+    def create_setup(name)
+      Hecks::Behaviors::TestSetup.new(command: "CreatePizza",
+                                      args:    { name: { value: name }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } } })
+    end
+
+    def query_test(setups:, expect:)
+      Hecks::Behaviors::TestCase.new(description: "q", tests_command: "Available", on_aggregate: "Order",
+                                     kind: :query, setups: setups, input: {}, expect: expect)
+    end
+
+    it "checks a field on the query's single row" do
+      test = query_test(setups: [create_setup("Solo")], expect: { status: "available" })
+      expect(described_class.run_one(test, suite).status).to eq(:pass)
+    end
+
+    it "fails when the field doesn't match" do
+      test = query_test(setups: [create_setup("Solo2")], expect: { status: "sold" })
+      run = described_class.run_one(test, suite)
+      expect(run.status).to eq(:fail)
+      expect(run.message).to include("status")
+    end
+
+    it "fails a typo'd key instead of silently ignoring it" do
+      test = query_test(setups: [create_setup("Solo3")], expect: { staytus: "available" })
+      run = described_class.run_one(test, suite)
+      expect(run.status).to eq(:fail)
+      expect(run.message).to include("staytus")
+    end
+
+    it "refuses to guess which row a field expectation describes when more than one comes back" do
+      test = query_test(setups: [create_setup("A"), create_setup("B")], expect: { status: "available" })
+      run = described_class.run_one(test, suite)
+      expect(run.status).to eq(:fail)
+      expect(run.message).to include("2 rows")
+    end
+  end
 end

--- a/spec/behaviors/fixtures/count_on_command.behaviors
+++ b/spec/behaviors/fixtures/count_on_command.behaviors
@@ -1,0 +1,12 @@
+# `count:` is never read by run_command — it used to build and pass
+# unconditionally. Build-time validation refuses it instead.
+Hecks.behaviors "CountOnCommand" do
+  vision "count: on a command is meaningless and should refuse to build."
+  loads "../../../examples/pizzas/bluebook/pizzas.bluebook", "../../../examples/pizzas/pizzas_behaviors.hecksagon"
+
+  test "counts a command" do
+    tests "CreatePizza", on: "Order"
+    input name: { value: "Miscounted" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+    expect count: 3
+  end
+end

--- a/spec/behaviors/fixtures/emits_on_query.behaviors
+++ b/spec/behaviors/fixtures/emits_on_query.behaviors
@@ -1,0 +1,11 @@
+# `emits:` is never read by run_query — it used to build and pass
+# unconditionally. Build-time validation refuses it instead.
+Hecks.behaviors "EmitsOnQuery" do
+  vision "emits: on a query is meaningless and should refuse to build."
+  loads "../../../examples/pizzas/bluebook/pizzas.bluebook", "../../../examples/pizzas/pizzas_behaviors.hecksagon"
+
+  test "emits from a query" do
+    tests "Available", on: "Order", kind: :query
+    expect emits: ["Whatever"]
+  end
+end

--- a/spec/behaviors/fixtures/no_expect.behaviors
+++ b/spec/behaviors/fixtures/no_expect.behaviors
@@ -1,0 +1,11 @@
+# A test with no `expect` at all used to pass vacuously whenever
+# dispatch didn't raise — build-time validation refuses this instead.
+Hecks.behaviors "NoExpect" do
+  vision "A test asserting nothing should refuse to build, not pass."
+  loads "../../../examples/pizzas/bluebook/pizzas.bluebook", "../../../examples/pizzas/pizzas_behaviors.hecksagon"
+
+  test "asserts nothing" do
+    tests "CreatePizza", on: "Order"
+    input name: { value: "Ghost" }, pizza: { price_cents: { cents: 900 }, size: { value: "small" } }
+  end
+end

--- a/spec/behaviors/fixtures/sqlite_binding.behaviors
+++ b/spec/behaviors/fixtures/sqlite_binding.behaviors
@@ -1,0 +1,15 @@
+# `loads` resolving an aggregate to a non-Memory adapter (here: the
+# same `delegates_to` fixture bound to Sqlite instead of its default
+# Memory) should refuse at boot — a behaviors suite's isolation
+# between tests only holds for Memory (registry.rb's
+# `reset_runtime_state!` drops repository OBJECTS, not rows).
+Hecks.behaviors "SqliteBinding" do
+  vision "loads pointed at a non-Memory-bound hecksagon should refuse at boot."
+  loads "../../fixtures/delegates_to/delegates_to.bluebook", "../../fixtures/delegates_to/delegates_to_sqlite.hecksagon"
+
+  test "would touch a real sqlite file" do
+    tests "OpenBoard"
+    input name: { value: "b1" }
+    expect ok: true
+  end
+end

--- a/spec/behaviors/runner_spec.rb
+++ b/spec/behaviors/runner_spec.rb
@@ -24,6 +24,36 @@ RSpec.describe Hecks::Behaviors do
     end
   end
 
+  # Each of these used to build and pass vacuously — a free-form
+  # `expect(**kwargs)` merge with no build-time guard, and each runner
+  # (run_command/run_query) reading only a subset of the keys.
+  describe "expect validation closes the silent-pass paths" do
+    it "refuses a test with no expect at all" do
+      result = described_class.run(fixture("no_expect.behaviors"))
+      expect(result.parse_error).to include("has no `expect`")
+    end
+
+    it "refuses count: on a command" do
+      result = described_class.run(fixture("count_on_command.behaviors"))
+      expect(result.parse_error).to include("count:` only applies to queries")
+    end
+
+    it "refuses emits: on a query" do
+      result = described_class.run(fixture("emits_on_query.behaviors"))
+      expect(result.parse_error).to include("emits:` only applies to commands")
+    end
+  end
+
+  describe "persistence isolation" do
+    it "refuses a suite whose loads resolves to a non-Memory binding" do
+      result = described_class.run(fixture("sqlite_binding.behaviors"))
+      expect(result.parse_error).to be_nil # the DSL itself is well-formed
+      expect(result.runs.first.status).to eq(:error)
+      expect(result.runs.first.message).to include("SqlitePersistence")
+      expect(result.runs.first.message).to include("Memory")
+    end
+  end
+
   describe "a sweep that never confuses a stale suite for a fresh one" do
     it "does not let a no-op file after a real one reuse the prior suite" do
       real  = described_class.run(fixture("pizzas_edge_cases.behaviors"))
@@ -83,8 +113,9 @@ RSpec.describe Hecks::Behaviors do
     it "sweeps every .behaviors file under a directory and reports how many it found" do
       sweep = described_class.run_all(File.expand_path("fixtures", __dir__))
 
-      expect(sweep.files_swept).to eq(5)
-      expect(sweep.summary[:parse_errors]).to eq(3) # no_vision, no_loads, no_op
+      expect(sweep.files_swept).to eq(9)
+      expect(sweep.summary[:parse_errors]).to eq(6) # no_vision, no_loads, no_op,
+      # no_expect, count_on_command, emits_on_query
     end
   end
 end

--- a/spec/fixtures/delegates_to/delegates_to_sqlite.hecksagon
+++ b/spec/fixtures/delegates_to/delegates_to_sqlite.hecksagon
@@ -1,0 +1,9 @@
+# A NON-MEMORY BINDING for the same fixture `delegates_to.bluebook` — a
+# behaviors suite that loads this instead of the default (unhecksagon'd,
+# Memory) binding exercises the isolation guard
+# (Expectations.guard_memory_only!) without ever touching a real
+# sqlite file: the guard reads BindingPolicy's own resolved adapter
+# name and refuses before any repository is built.
+Hecks.hecksagon "DelegatesTo" do
+  DelegatesTo::Board.persisted_by("SqlitePersistence")
+end


### PR DESCRIPTION
Fixes the four silent-pass paths in the `.behaviors` DSL flagged in a live audit against `d85d847`:

1. No `expect` at all → passed vacuously whenever dispatch didn't raise.
2. `count:` on a command → accepted, never read by `run_command`.
3. `emits:` on a query → accepted, never read by `run_query`.
4. Any field expectation (including a typo like `emmits:`) on a query → `run_query` never called `check_fields`.

**Fix, in order of the report's own recommended value/effort:**

- `TestCaseBuilder#build` (`dsl.rb`) now requires a non-empty `expect` and rejects `count:` on a command / `emits:` on a query at build time — closes paths 1–3 by construction.
- `run_query` (`expectations.rb`) now calls `check_fields` against the query's row, narrowed to exactly one (erroring if the query returned zero or more than one row and a field was asked for) — closes path 4, and makes the typo-catching behavior `run_command` already had symmetric across both runners.
- `guard_memory_only!` refuses to boot a suite whose `loads` resolves any aggregate to a non-`Memory` persistence binding — `Registry#reset_runtime_state!`'s isolation only holds for `Memory` (a plain per-instance `@records` ivar); against Sqlite/Postgres the rows stay put, so a suite accidentally pointed at a domain's real hecksagon would leak state across tests and write to a real database.
- Corrected `docs/implemented/guides/behaviors.md`'s claim that boot is "a fresh call per test... never shared" — it's one boot per suite (per `expectations.rb`'s own comment), reset between tests; the doc now says so and explains the real isolation story (the guard above).
- `pizzas.behaviors` gains a query field-expectation test (`Available's own row can be checked directly, not just counted`) — the first in the corpus, since no existing test exercised the path this PR fixes.

All four closed paths, plus the new guard, have regression coverage in `spec/behaviors/runner_spec.rb` and `spec/behaviors/expectations_spec.rb`, backed by new fixtures.

Not included: binding `refused:` to a named condition's identity instead of a message substring — real design work the original report says should ride along with ADR 0025's named-condition step rather than being done twice.

Full suite: 2241 examples, 0 failures. `bundle exec rubocop`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)