### PR TITLE
Close the expression-operator ledger bypass: admit 8 vendored operators for real

### DIFF
--- a/docs/implemented/guides/running-a-runtime.md
+++ b/docs/implemented/guides/running-a-runtime.md
@@ -527,6 +527,11 @@ and held equal to it by `spec/operator_conformance_spec.rb`:
 | `.empty?`, `.size` | sized | 1 | `Array`, `String`, `Hash` only |
 | `.to_s` | to_string | 1 | `String`, `Integer`, `Float`, `Boolean`, `nil` only — raises `EvaluationError` on anything else |
 | `.any?`, `.none?`, `.all?`, `.find` | enumeration | 2 | `list.any? { \|x\| predicate }` — the block's parameter is bound for the predicate (a whole boolean expression, blocks nest freely); `.find { }` may carry a dotted path, `list.find { \|x\| … }.a.b`, and is nil when nothing matches. Braces only, never `do…end` |
+| `.match?` | pattern_match | 2 | `receiver.match?(/pattern/flags)` — a real Ruby-Regexp source between the slashes; `i`/`m`/`x` flags supported |
+| `.present?`, `.blank?` | presence | 1 | Rails-standard semantics: `nil`/`false` are blank, `String`/`Array` are blank when empty, everything else is present |
+| `.split` | text | 2 | `receiver.split("SEP")` — produces an `Array`, literal separator only |
+| `.start_with?`, `.end_with?` | text | 2 | `String` receiver only |
+| `.first`, `.last` | positional | 1 | over an array-typed receiver (an `ArrayLiteral`, a `.split` result, or a list-typed field of scalar elements) — `nil` on an empty list |
 
 Every one of the six comparison operators reduces to two primitives —
 `less_than` and `equal` — combined with a boolean algebra rather than
@@ -565,11 +570,13 @@ Hecks::Bluebook::Expression::Evaluator.parse("old.balance.cents == balance.cents
 ```
 
 Below `Compare`, the left and right sides are `Resolver` leaves — a
-smaller grammar for the non-boolean part: integer/float/string/bool/nil
-literals, `+` addition, `.modulo`, a sign test, `.empty?`/`.size`,
-`.to_s`, the block-taking enumeration operators (`.any?`/`.none?`/
-`.all?`/`.find { |x| … }`, whose body is a whole boolean expression
-parsed by `Evaluator` again), and the true leaf, `Lookup` — a bare or dotted name resolved
+smaller grammar for the non-boolean part: integer/float/string/bool/nil/
+array literals, `+` addition, `.modulo`, a sign test, `.empty?`/`.size`,
+`.to_s`, `.match?`, `.present?`/`.blank?`, `.split`, `.start_with?`/
+`.end_with?`, `.first`/`.last`, the block-taking enumeration operators
+(`.any?`/`.none?`/`.all?`/`.find { |x| … }`, whose body is a whole
+boolean expression parsed by `Evaluator` again), and the true leaf,
+`Lookup` — a bare or dotted name resolved
 against `attrs` then `state`, per `fetch` above. A `given` that only
 ever reads a bare instance field, no operator at all, still parses —
 into a `Resolve` node, whose value is checked for Ruby truthiness

--- a/lib/hecks/bluebook/expression/projection.json
+++ b/lib/hecks/bluebook/expression/projection.json
@@ -149,6 +149,54 @@
       "category": "enumeration",
       "precedence": 10,
       "arity": 2
+    },
+    {
+      "symbol": ".match?",
+      "category": "pattern_match",
+      "precedence": 7,
+      "arity": 2
+    },
+    {
+      "symbol": ".present?",
+      "category": "presence",
+      "precedence": 7,
+      "arity": 1
+    },
+    {
+      "symbol": ".blank?",
+      "category": "presence",
+      "precedence": 7,
+      "arity": 1
+    },
+    {
+      "symbol": ".split",
+      "category": "text",
+      "precedence": 7,
+      "arity": 2
+    },
+    {
+      "symbol": ".start_with?",
+      "category": "text",
+      "precedence": 7,
+      "arity": 2
+    },
+    {
+      "symbol": ".end_with?",
+      "category": "text",
+      "precedence": 7,
+      "arity": 2
+    },
+    {
+      "symbol": ".first",
+      "category": "positional",
+      "precedence": 7,
+      "arity": 1
+    },
+    {
+      "symbol": ".last",
+      "category": "positional",
+      "precedence": 7,
+      "arity": 1
     }
   ],
   "normalisations": [

--- a/lib/hecks/bluebook/expression/resolver.rb
+++ b/lib/hecks/bluebook/expression/resolver.rb
@@ -58,6 +58,26 @@ module Hecks
         Size           = Struct.new(:receiver, keyword_init: true)
         Lookup         = Struct.new(:path, keyword_init: true)
 
+        # UPDATE 2026-08-27: every "vendored addition, not (yet) upstream
+        # hecks" comment on this file's own MatchesRegex/Presence/Split/
+        # First/Last/StartsWith/EndsWith below (plus ArrayLiteral above)
+        # described a REAL gap, found the hard way, in the history each
+        # comment tells — and that history stays exactly as written,
+        # on purpose. What changed is the PRESENT TENSE claim "not (yet)
+        # upstream": a review of this exact migration found these eight
+        # symbols had working Ruby parse/interpret arms but had NEVER
+        # gone through Propose -> Render -> Admit
+        # (lib/hecks/grammar/expression_operators.json) the way every
+        # other operator here has — a closed-vocabulary guard
+        # (spec/operator_conformance_spec.rb) built entirely over TABLES
+        # structurally could not see hand-coded Struct/parse/interpret
+        # additions, so eight operators ran in Ruby, admitted nowhere,
+        # invisible to the one guard whose whole job was "reads in every
+        # target." All eight are now ledger-admitted for real, with full
+        # Rust kernel parity (rust/src/kernel/expression_operators/
+        # {pattern_match,presence,text,positional}.rs) — the two-tier
+        # gap is closed, not merely tracked.
+        #
         # `receiver.match?(/pattern/)` -- vendored addition, not (yet)
         # upstream hecks (migration plan task 8): confirmed the
         # SINGLE most impactful corpus-wide dispatch-time gap of the

--- a/lib/hecks/grammar/expression.bluebook
+++ b/lib/hecks/grammar/expression.bluebook
@@ -10,11 +10,14 @@ Hecks.bluebook "Expression" do
     # has two rules that are not operators: parenthesization (a structural
     # strip-and-recurse, no symbol of its own) and the bare-leaf fallback
     # (whatever matches nothing else falls through to the inner grammar).
-    # Its inner grammar has three more: integer/float/string/bool/nil
-    # literals and the dotted-lookup fallback are TERMINAL productions —
-    # they recognize text, they do not combine operands, and they have
-    # nothing meaningful to render per target (a literal's spelling does
-    # not differ between targets the way an operation's might).
+    # Its inner grammar has three more: integer/float/string/bool/nil/
+    # array literals and the dotted-lookup fallback are TERMINAL
+    # productions — they recognize text, they do not combine operands,
+    # and they have nothing meaningful to render per target (a literal's
+    # spelling does not differ between targets the way an operation's
+    # might — `rust/src/kernel/expr.rs`'s own `Expr::Array` is a LEAF
+    # there too, for the identical reason, not routed through
+    # `OperatorCategory`).
     # Forcing them into this shape would stretch `renderings` and the
     # Arity invariant past what they mean. They stay declared only in
     # prose — named here rather than silently left out.

--- a/lib/hecks/grammar/expression_operators.json
+++ b/lib/hecks/grammar/expression_operators.json
@@ -1,6 +1,6 @@
 {
   "name": "expression-operators",
-  "note": "The admission ledger \u2014 every operator and normalisation rule the expression machinery runs, driven through the grammar chapter's own lifecycle. Propose, then a rendering per target, then Admit, so the 'reads in every target' guard gates each admission for real. spec/operator_conformance_spec.rb replays this and holds the evaluator's tables equal to what survives \u2014 an operator absent here is not a slow operator, it is not an operator.",
+  "note": "The admission ledger — every operator and normalisation rule the expression machinery runs, driven through the grammar chapter's own lifecycle. Propose, then a rendering per target, then Admit, so the 'reads in every target' guard gates each admission for real. spec/operator_conformance_spec.rb replays this and holds the evaluator's tables equal to what survives — an operator absent here is not a slow operator, it is not an operator.",
   "steps": [
     {
       "verb": "Expression::Operator.Propose",
@@ -1055,6 +1055,502 @@
       "args": {
         "symbol": {
           "value": ".find"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".match?"
+        },
+        "category": {
+          "value": "pattern_match"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 2
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "call_pattern_match"
+        },
+        "position": {
+          "value": 13
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".match?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "receiver.match?(/pattern/)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".match?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "receiver.match?(/pattern/) -> regex crate, Ruby-Regexp-compatible subset"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".match?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".present?"
+        },
+        "category": {
+          "value": "presence"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 1
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "suffix_match"
+        },
+        "position": {
+          "value": 14
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".present?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.present?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".present?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.present? -> !blank(a)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".present?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".blank?"
+        },
+        "category": {
+          "value": "presence"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 1
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "suffix_match"
+        },
+        "position": {
+          "value": 15
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".blank?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.blank?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".blank?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.blank? -> blank(a)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".blank?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".split"
+        },
+        "category": {
+          "value": "text"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 2
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "call_pattern_match"
+        },
+        "position": {
+          "value": 16
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".split"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.split(\"SEP\")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".split"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.split(\"SEP\") -> Value::Array of Value::Str"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".split"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".start_with?"
+        },
+        "category": {
+          "value": "text"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 2
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "call_pattern_match"
+        },
+        "position": {
+          "value": 17
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".start_with?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.start_with?(\"prefix\")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".start_with?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.start_with?(\"prefix\")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".start_with?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".end_with?"
+        },
+        "category": {
+          "value": "text"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 2
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "call_pattern_match"
+        },
+        "position": {
+          "value": 18
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".end_with?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.end_with?(\"suffix\")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".end_with?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.end_with?(\"suffix\")"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".end_with?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".first"
+        },
+        "category": {
+          "value": "positional"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 1
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "suffix_match"
+        },
+        "position": {
+          "value": 19
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".first"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.first"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".first"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.first -> first element or Nil"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".first"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".last"
+        },
+        "category": {
+          "value": "positional"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 1
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "suffix_match"
+        },
+        "position": {
+          "value": 20
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".last"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.last"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".last"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.last -> last element or Nil"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".last"
         }
       }
     },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,5 +3,52 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rust"
 version = "0.1.0"
+dependencies = [
+ "regex",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,20 @@ name = "rust"
 version = "0.1.0"
 edition = "2021"
 
+# ONE DELIBERATE, DOCUMENTED EXCEPTION to this crate's own zero-Cargo-
+# dependency discipline (ADR 0012 — WASM-via-WASI binary size and
+# auditability; json.rs's and arithmetic.rs's own headers state the same
+# constraint for themselves). `expression_operators/pattern_match.rs`
+# (`.match?`) is the reason — see that file's own header for why a
+# hand-rolled regex subset was rejected in favour of one well-audited,
+# pure-Rust crate. `default-features = false` keeps out `perf` (SIMD/
+# `memchr`-driven, unneeded for the small per-call patterns this
+# grammar's own predicates use) — `std`/`unicode` alone cover Ruby-
+# Regexp-style `\d`/`\w`/case-insensitive matching without the extra
+# code size.
+[dependencies]
+regex = { version = "1", default-features = false, features = ["std", "unicode"] }
+
 [lib]
 name = "rust"
 path = "src/lib.rs"

--- a/rust/project/expr_emitter.rb
+++ b/rust/project/expr_emitter.rb
@@ -27,7 +27,21 @@ module RustProjection
       when ev::Resolve
         emit_resolver(node.expr)
       else
-        raise "unhandled evaluator node #{node.class} — the real grammar has no such node; this generator is stale"
+        # NAME THE OPERATOR, DON'T ACCUSE THE GRAMMAR. Used to say "the
+        # real grammar has no such node" unconditionally — true only for
+        # a node type this file has genuinely never heard of (a real
+        # emitter bug). It was FALSE the day the resolver vendored eight
+        # operators (`.match?`/`.present?`/`.blank?`/`.split`/
+        # `.start_with?`/`.end_with?`/`.first`/`.last`) straight into
+        # `resolver.rb` without a matching `emit_resolver` arm here — the
+        # grammar had exactly such a node, admitted and running in Ruby,
+        # and this message told whoever hit it to look in the wrong
+        # place. Every node type this generator has NO arm for at all is
+        # still a real bug (this `else` firing on an `ev::` node should
+        # never happen, `Evaluator.parse` has no eighth node kind), so
+        # this stays a hard failure — it just stops lying about which
+        # file is stale.
+        raise "unhandled evaluator node #{node.class} — no Rust rendering exists for it in this generator (rust/project/expr_emitter.rb#emit_bool)"
       end
     end
 
@@ -102,8 +116,25 @@ module RustProjection
       when r::Find
         "Expr::Find { receiver: Box::new(#{emit_resolver(node.receiver)}), param: #{node.param.inspect}, " \
           "predicate: Box::new(#{emit_bool(node.predicate)}), path: &[#{node.path.map(&:inspect).join(', ')}] }"
+      when r::ArrayLiteral
+        "Expr::Array(vec![#{node.elements.map { |element| emit_resolver(element) }.join(', ')}])"
+      when r::MatchesRegex
+        "Expr::MatchesRegex { receiver: Box::new(#{emit_resolver(node.receiver)}), pattern: #{node.pattern.inspect}.to_string(), flags: #{node.flags.inspect}.to_string() }"
+      when r::Presence
+        "Expr::Presence { receiver: Box::new(#{emit_resolver(node.receiver)}), negated: #{node.negated} }"
+      when r::Split
+        "Expr::Split { receiver: Box::new(#{emit_resolver(node.receiver)}), separator: #{node.separator.inspect}.to_string() }"
+      when r::StartsWith
+        "Expr::StartsWith { receiver: Box::new(#{emit_resolver(node.receiver)}), substring: #{node.substring.inspect}.to_string() }"
+      when r::EndsWith
+        "Expr::EndsWith { receiver: Box::new(#{emit_resolver(node.receiver)}), substring: #{node.substring.inspect}.to_string() }"
+      when r::First then "Expr::First(Box::new(#{emit_resolver(node.receiver)}))"
+      when r::Last  then "Expr::Last(Box::new(#{emit_resolver(node.receiver)}))"
       else
-        raise "unhandled resolver node #{node.class} — the real grammar has no such node; this generator is stale"
+        # See `emit_bool`'s own `else` arm for why this no longer blames
+        # the grammar unconditionally — the identical fix, mirrored here
+        # for the resolver's own leaf grammar.
+        raise "unhandled resolver node #{node.class} — no Rust rendering exists for it in this generator (rust/project/expr_emitter.rb#emit_resolver)"
       end
     end
   end

--- a/rust/src/kernel/attribute_shapes/scalar.rs
+++ b/rust/src/kernel/attribute_shapes/scalar.rs
@@ -37,7 +37,7 @@ pub fn to_s(v: &Value) -> Option<Value> {
         Value::Int(i) => Some(Value::Str(i.to_string())),
         Value::Float(f) => Some(Value::Str(f.to_string())),
         Value::Bool(b) => Some(Value::Str(b.to_string())),
-        Value::List(_) | Value::Nil => None,
+        Value::List(_) | Value::Nil | Value::Array(_) => None,
     }
 }
 

--- a/rust/src/kernel/expr.rs
+++ b/rust/src/kernel/expr.rs
@@ -55,6 +55,18 @@ pub enum Value {
     Bool(bool),
     List(usize),
     Nil,
+    /// A real, fully-materialised list of `Value`s — distinct from
+    /// `List(usize)` (a length-only reading of a FIELD; see this enum's
+    /// own header) — produced by an `ArrayLiteral` (`Resolver::
+    /// ArrayLiteral`, `[a, b]`, `Expr::Array` below) or a `.split` call.
+    /// `expression_operators::text::split` produces it;
+    /// `expression_operators::positional` (`.first`/`.last`) is its main
+    /// consumer. NOT how a literal-array `.include?` haystack reaches
+    /// the kernel — `rust/project/expr_emitter.rb`'s own `emit_include`
+    /// rewrites that specific shape into an OR-of-equalities at codegen
+    /// time instead (see its header for why), so this variant never
+    /// needs to carry `.include?`'s own membership test.
+    Array(Vec<Value>),
 }
 
 impl Value {
@@ -294,6 +306,36 @@ pub enum Expr {
     /// first element the predicate accepts, projected through `path`
     /// (empty for a bare `.find { }`), or nil when nothing matches.
     Find { receiver: Box<Expr>, param: &'static str, predicate: Box<Expr>, path: &'static [&'static str] },
+    /// `[a, b, c]` — `Resolver::ArrayLiteral`. A LEAF, like `Int`/`Str`/
+    /// `Nil` above, not an expression-ledger OPERATOR — see expression.
+    /// bluebook's own "WHAT IS NOT HERE" comment on the `Operator`
+    /// aggregate: a literal's spelling doesn't differ per target the
+    /// way an operation's might, so `interpret`'s leaf match handles
+    /// this directly rather than routing it through `category_of`/
+    /// `dispatch_operator`, the identical treatment every other literal
+    /// already gets.
+    Array(Vec<Expr>),
+    /// `receiver.match?(/pattern/flags)` — `Resolver::MatchesRegex`. The
+    /// pattern text is a real Ruby-Regexp source, taken as-is between
+    /// the slashes (see `expression_operators::pattern_match`'s own
+    /// header for why this crate takes a `regex` dependency for it).
+    MatchesRegex { receiver: Box<Expr>, pattern: String, flags: String },
+    /// `receiver.present?` / `receiver.blank?` — `Resolver::Presence`,
+    /// one node for the symbol pair, `negated` distinguishing them
+    /// (`.blank?` is `.present?` negated) exactly the way `SignTest`
+    /// above is one node for three symbols.
+    Presence { receiver: Box<Expr>, negated: bool },
+    /// `receiver.split("SEP")` — `Resolver::Split`. Produces a real
+    /// `Value::Array`, not `Value::List` — see that variant's own header.
+    Split { receiver: Box<Expr>, separator: String },
+    /// `receiver.start_with?("prefix")` — `Resolver::StartsWith`.
+    StartsWith { receiver: Box<Expr>, substring: String },
+    /// `receiver.end_with?("suffix")` — `Resolver::EndsWith`.
+    EndsWith { receiver: Box<Expr>, substring: String },
+    /// `receiver.first` — `Resolver::First`.
+    First(Box<Expr>),
+    /// `receiver.last` — `Resolver::Last`.
+    Last(Box<Expr>),
 }
 
 /// `state`/`attrs` from `Evaluator.call(expr, state, attrs)` — `args` is
@@ -319,6 +361,7 @@ pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
         Bool(v) => Ok(Value::Bool(*v)),
         Nil => Ok(Value::Nil),
         Lookup(path) => lookup(path, ctx),
+        Array(elements) => Ok(Value::Array(elements.iter().map(|e| interpret(e, ctx)).collect::<Result<Vec<_>, _>>()?)),
         _ => dispatch_operator(category_of(expr), expr, ctx),
     }
 }
@@ -341,7 +384,11 @@ fn category_of(expr: &Expr) -> OperatorCategory {
         Empty(..) | Size(..) => OperatorCategory::Sized,
         ToS(..) => OperatorCategory::ToString,
         BlockPredicate { .. } | Find { .. } => OperatorCategory::Enumeration,
-        Int(..) | Float(..) | Str(..) | Bool(..) | Nil | Lookup(..) => {
+        MatchesRegex { .. } => OperatorCategory::PatternMatch,
+        Presence { .. } => OperatorCategory::Presence,
+        Split { .. } | StartsWith { .. } | EndsWith { .. } => OperatorCategory::Text,
+        First(..) | Last(..) => OperatorCategory::Positional,
+        Int(..) | Float(..) | Str(..) | Bool(..) | Nil | Lookup(..) | Array(..) => {
             unreachable!("interpret's own leaf arms handle these before category_of is ever called")
         }
     }
@@ -373,6 +420,10 @@ fn dispatch_operator(category: OperatorCategory, expr: &Expr, ctx: &EvalContext)
         },
         OperatorCategory::ToString => to_string::interpret(expr, ctx),
         OperatorCategory::Enumeration => enumeration::interpret(expr, ctx),
+        OperatorCategory::PatternMatch => pattern_match::interpret(expr, ctx),
+        OperatorCategory::Presence => presence::interpret(expr, ctx),
+        OperatorCategory::Text => text::interpret(expr, ctx),
+        OperatorCategory::Positional => positional::interpret(expr, ctx),
     }
 }
 

--- a/rust/src/kernel/expression_operators/comparison.rs
+++ b/rust/src/kernel/expression_operators/comparison.rs
@@ -61,7 +61,11 @@ fn less_than(lhs: &Value, rhs: &Value) -> Result<bool, Refusal> {
     }
 }
 
-fn values_equal(lhs: &Value, rhs: &Value) -> bool {
+/// `pub(crate)`, not private — `membership.rs`'s own `Value::Array`
+/// haystack arm reuses this SAME numeric-coerced equality (`Evaluator#
+/// includes?`'s own `Array` branch: `found.any? { |item| equal?(item,
+/// wanted) }`) rather than re-deriving it a second time.
+pub(crate) fn values_equal(lhs: &Value, rhs: &Value) -> bool {
     match (scalar::numeric(lhs), scalar::numeric(rhs)) {
         (Some(l), Some(r)) => l == r,
         _ => lhs == rhs,

--- a/rust/src/kernel/expression_operators/membership.rs
+++ b/rust/src/kernel/expression_operators/membership.rs
@@ -3,10 +3,18 @@
 // interpretation (evaluator.rb's `includes?`), read directly.
 //
 // Real corpus `given`/`ensures`/invariant text only ever calls `.include?`
-// with a String haystack — `INCLUDE_HAYSTACKS` (evaluator.rb) also admits
-// Array on the Ruby side, but no example domain's canonical text exercises
-// it, so it isn't generated here yet (flagged, not silently assumed away
-// — see the error text below, which names the gap instead of hiding it).
+// with a String haystack directly, OR a literal-array haystack
+// (`["issued", "active"].include?(status)`) — `rust/project/
+// expr_emitter.rb`'s own `emit_include` rewrites the LATTER into an
+// OR-of-equalities at codegen time (see its header), so it never reaches
+// this file as a `Value::Array` at all. A `Value::Array` DOES reach here
+// for real, though, the moment a haystack is COMPUTED rather than
+// written literally — `x.split("::").include?("a")` composes `Split`
+// (`expression_operators::text`) with `.include?` exactly this way, and
+// unlike the literal case there is no fixed set of elements at codegen
+// time to rewrite into equalities, so this is where that composition
+// actually needs to work. `INCLUDE_HAYSTACKS` (evaluator.rb) admits
+// Array on the Ruby side for the identical reason.
 //
 // `expr.rs`'s `category_of` guarantees this is only ever called with
 // `Include` — see `logical.rs`'s header for why the trailing arm below
@@ -22,6 +30,10 @@ pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
 
     match (eval(haystack, ctx)?, eval(needle, ctx)?) {
         (Value::Str(h), Value::Str(n)) => Ok(Value::Bool(h.contains(&n))),
-        (h, n) => Err(eval_error(format!("include? on {h:?} with {n:?} — Array haystacks not generated yet"))),
+        // `Evaluator#includes?`'s own `Array` branch: `found.any? { |item| equal?(item, wanted) }`
+        // — numeric-coerced equality, the same primitive `comparison::apply`'s
+        // own `values_equal` already provides, reused rather than re-derived.
+        (Value::Array(h), n) => Ok(Value::Bool(h.iter().any(|item| super::comparison::values_equal(item, &n)))),
+        (h, n) => Err(eval_error(format!("include? on {h:?} with {n:?} — a real (non-literal, non-split) Array haystack is not generated yet"))),
     }
 }

--- a/rust/src/kernel/expression_operators/mod.rs
+++ b/rust/src/kernel/expression_operators/mod.rs
@@ -14,6 +14,10 @@ pub mod sign_test;
 pub mod sized;
 pub mod to_string;
 pub mod enumeration;
+pub mod pattern_match;
+pub mod presence;
+pub mod text;
+pub mod positional;
 
 /// One variant per real expression-operator category the Ruby
 /// grammar admits, in the order Grammar.admitted_operators's own `category` field declares them. Every match
@@ -32,6 +36,10 @@ pub enum OperatorCategory {
     Sized,
     ToString,
     Enumeration,
+    PatternMatch,
+    Presence,
+    Text,
+    Positional,
 }
 
 impl OperatorCategory {
@@ -49,8 +57,12 @@ impl OperatorCategory {
             OperatorCategory::Sized => "sized",
             OperatorCategory::ToString => "to_string",
             OperatorCategory::Enumeration => "enumeration",
+            OperatorCategory::PatternMatch => "pattern_match",
+            OperatorCategory::Presence => "presence",
+            OperatorCategory::Text => "text",
+            OperatorCategory::Positional => "positional",
         }
     }
 
-    pub const ALL: &'static [OperatorCategory] = &[OperatorCategory::Logical, OperatorCategory::Membership, OperatorCategory::Comparison, OperatorCategory::Arithmetic, OperatorCategory::SignTest, OperatorCategory::Sized, OperatorCategory::ToString, OperatorCategory::Enumeration];
+    pub const ALL: &'static [OperatorCategory] = &[OperatorCategory::Logical, OperatorCategory::Membership, OperatorCategory::Comparison, OperatorCategory::Arithmetic, OperatorCategory::SignTest, OperatorCategory::Sized, OperatorCategory::ToString, OperatorCategory::Enumeration, OperatorCategory::PatternMatch, OperatorCategory::Presence, OperatorCategory::Text, OperatorCategory::Positional];
 }

--- a/rust/src/kernel/expression_operators/pattern_match.rs
+++ b/rust/src/kernel/expression_operators/pattern_match.rs
@@ -1,0 +1,108 @@
+// Implements the Ruby grammar's "pattern_match" expression-operator
+// category (projection.json: `.match?`, its one member) — `Resolver::
+// MatchesRegex` (resolver.rb's `matches_regex?`), read directly:
+// `receiver.match?(/pattern/flags)` against a real Ruby-Regexp-style
+// pattern, taken as-is between the slashes (no sub-grammar to recurse
+// into, same precedent `pattern`/`flags` on the Ruby struct already set).
+//
+// THE ONE DEPENDENCY THIS CRATE HAS. Every other file under
+// rust/src/kernel/ holds itself to zero Cargo dependencies (ADR 0012 —
+// WASM-via-WASI binary size and auditability; see json.rs's and
+// arithmetic.rs's own headers for the same constraint stated twice
+// already). `regex` is a deliberate, single, documented exception: the
+// resolver.rb comment on `MatchesRegex` itself calls `.match?` "the
+// SINGLE most impactful corpus-wide dispatch-time gap of the whole
+// migration" — email/phone/ISO-8601-timestamp/zip format-validation
+// rules, in nearly every value_object across every corpus this
+// migration touched — and no hand-rolled subset (character classes,
+// anchors, quantifiers, alternation) gets real Ruby-Regexp parity
+// without becoming a second regex engine maintained by hand, a far
+// larger and more failure-prone undertaking than one well-audited,
+// pure-Rust dependency. `regex` itself has no transitive C dependency
+// (confirmed via `cargo tree`, the same check rust/host's own Cargo.toml
+// comments already lean on for every dependency THAT crate accepts) —
+// it does not reopen the cross-compile/aarch64-toolchain problem
+// `rust/host/Cargo.toml`'s own comments document at length for crates
+// that DO carry one.
+//
+// `expr.rs`'s `category_of` guarantees `interpret` below is only ever
+// called with `MatchesRegex` — see `logical.rs`'s header for why the
+// trailing arm is a router-bug guard, not a real refusal path.
+
+use crate::kernel::expr::{eval_error, interpret as eval, EvalContext, Expr, Value};
+use crate::kernel::Refusal;
+use regex::RegexBuilder;
+
+pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
+    let Expr::MatchesRegex { receiver, pattern, flags } = expr else {
+        return Err(Refusal::TypeMismatch(format!("pattern_match::interpret called with a non-match? node {expr:?} — a router bug")));
+    };
+
+    let text = coerce_text(&eval(receiver, ctx)?)?;
+
+    // `Resolver#matches_regex?`, read directly: `i`/`m`/`x` map straight
+    // onto RegexBuilder's own case_insensitive/multi_line/... flags —
+    // Ruby's `/x` (extended, whitespace-and-comments-ignored) is the one
+    // that needs a name change (`ignore_whitespace` here) since the two
+    // libraries spell the same feature differently, not a semantic gap.
+    let mut builder = RegexBuilder::new(pattern);
+    builder.case_insensitive(flags.contains('i'));
+    builder.multi_line(flags.contains('m'));
+    builder.ignore_whitespace(flags.contains('x'));
+
+    let re = builder
+        .build()
+        .map_err(|e| eval_error(format!("match? given an invalid pattern {pattern:?} — {e}")))?;
+
+    Ok(Value::Bool(re.is_match(&text)))
+}
+
+/// `Resolver#matches_regex?`'s own `case receiver_value` — String/Symbol
+/// (this kernel has no `Symbol` `Value`, so just `Str`), Integer/Float
+/// stringified, `nil` as `""`; anything else refuses by name rather than
+/// stringifying a shape `.match?` was never meant to receive.
+fn coerce_text(v: &Value) -> Result<String, Refusal> {
+    match v {
+        Value::Str(s) => Ok(s.clone()),
+        Value::Int(i) => Ok(i.to_string()),
+        Value::Float(f) => Ok(f.to_string()),
+        Value::Nil => Ok(String::new()),
+        Value::Bool(_) | Value::List(_) | Value::Array(_) => Err(eval_error(format!("match? expects a scalar, got {v:?}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matches(receiver: Expr, pattern: &str, flags: &str) -> Value {
+        let expr = Expr::MatchesRegex { receiver: Box::new(receiver), pattern: pattern.to_string(), flags: flags.to_string() };
+        let ctx = EvalContext { args: &crate::kernel::expr::NoFields, instance: &crate::kernel::expr::NoFields };
+        eval(&expr, &ctx).expect("evaluates")
+    }
+
+    #[test]
+    fn matches_a_simple_anchored_pattern() {
+        assert_eq!(matches(Expr::Str("12345".to_string()), r"\A\d{5}\z", ""), Value::Bool(true));
+        assert_eq!(matches(Expr::Str("1234".to_string()), r"\A\d{5}\z", ""), Value::Bool(false));
+    }
+
+    #[test]
+    fn the_i_flag_ignores_case() {
+        assert_eq!(matches(Expr::Str("HELLO".to_string()), "hello", ""), Value::Bool(false));
+        assert_eq!(matches(Expr::Str("HELLO".to_string()), "hello", "i"), Value::Bool(true));
+    }
+
+    #[test]
+    fn coerces_non_string_scalars_to_text() {
+        assert_eq!(matches(Expr::Int(12345), r"\A\d+\z", ""), Value::Bool(true));
+        assert_eq!(matches(Expr::Nil, r"\A\z", ""), Value::Bool(true));
+    }
+
+    #[test]
+    fn an_invalid_pattern_refuses_cleanly() {
+        let expr = Expr::MatchesRegex { receiver: Box::new(Expr::Str("x".to_string())), pattern: "(".to_string(), flags: String::new() };
+        let ctx = EvalContext { args: &crate::kernel::expr::NoFields, instance: &crate::kernel::expr::NoFields };
+        assert!(eval(&expr, &ctx).is_err());
+    }
+}

--- a/rust/src/kernel/expression_operators/positional.rs
+++ b/rust/src/kernel/expression_operators/positional.rs
@@ -1,0 +1,151 @@
+// Implements the Ruby grammar's "positional" expression-operator
+// category (projection.json: `.first`, `.last` — two symbols, two
+// interpreter nodes sharing one category, the same `sized.rs`-style
+// pairing) — `Resolver::First`/`::Last` (resolver.rb), read directly:
+// duck-typed on "responds to first/last" in Ruby, which this kernel
+// reads as two real shapes rather than one duck type — a `Value::Array`
+// (an `ArrayLiteral` or a `.split` result, elements already known) and a
+// `Lookup` naming a real list-typed FIELD (the corpus origin case:
+// `legs.first`, an itinerary's departure leg — resolver.rb's own
+// comment on `First`).
+//
+// A field-list's elements are read via `lookup_items` (the same second
+// reading `expression_operators::enumeration` already uses for `.any?`/
+// `.find`'s own receiver) rather than `Value::List(usize)` — that shape
+// is LENGTH ONLY (`expr.rs`'s own header), nothing to take a first/last
+// element FROM. Only a SCALAR-element list collapses to a `Value` this
+// way; a list of composite entities (`Field::Nested`) has no `Value`
+// shape to return as — refused BY NAME, the same "not generated yet"
+// wording `membership.rs`'s own Array-haystack gap already uses, rather
+// than silently misrepresenting an object as some scalar it isn't.
+//
+// `expr.rs`'s `category_of` guarantees `interpret` below is only ever
+// called with `First`/`Last` — see `logical.rs`'s header for why the
+// trailing arm is a router-bug guard, not a real refusal path.
+
+use crate::kernel::expr::{eval_error, interpret as eval, lookup_items, EvalContext, Expr, Field, Value};
+use crate::kernel::Refusal;
+
+pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
+    let (op, receiver, take_first) = match expr {
+        Expr::First(receiver) => ("first", receiver, true),
+        Expr::Last(receiver) => ("last", receiver, false),
+        _ => return Err(Refusal::TypeMismatch(format!("positional::interpret called with a non-positional node {expr:?} — a router bug"))),
+    };
+
+    match receiver.as_ref() {
+        Expr::Lookup(path) => {
+            let items = lookup_items(path, ctx, op)?;
+            field_value(if take_first { items.into_iter().next() } else { items.into_iter().last() }, op)
+        }
+        other => match eval(other, ctx)? {
+            Value::Array(mut elements) => {
+                Ok(if take_first {
+                    elements.into_iter().next()
+                } else {
+                    elements.pop()
+                }
+                .unwrap_or(Value::Nil))
+            }
+            v => Err(eval_error(format!("{op} expects a list, got {v:?}"))),
+        },
+    }
+}
+
+/// The one element `lookup_items` handed back (or none, for an empty
+/// list — Ruby's own `Array#first`/`#last` answer `nil` there, not a
+/// refusal). A `Field::Nested` element — a list of composite entities,
+/// not scalars — has no `Value` shape to collapse into; see this file's
+/// own header for why that is refused rather than invented.
+fn field_value(item: Option<Field<'_>>, op: &str) -> Result<Value, Refusal> {
+    match item {
+        None => Ok(Value::Nil),
+        Some(Field::Value(v)) => Ok(v),
+        Some(Field::Nested(_)) => Err(eval_error(format!("{op} on a list of objects is not generated yet — only scalar-element lists are"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::expr::{Fielded, NoFields};
+
+    fn run(expr: Expr, instance: &dyn Fielded) -> Value {
+        let ctx = EvalContext { args: &NoFields, instance };
+        eval(&expr, &ctx).expect("evaluates")
+    }
+
+    #[test]
+    fn first_and_last_over_an_array_literal() {
+        let arr = Expr::Array(vec![Expr::Int(1), Expr::Int(2), Expr::Int(3)]);
+        assert_eq!(run(Expr::First(Box::new(arr.clone())), &NoFields), Value::Int(1));
+        assert_eq!(run(Expr::Last(Box::new(arr)), &NoFields), Value::Int(3));
+    }
+
+    #[test]
+    fn first_and_last_over_an_empty_array_literal_answer_nil() {
+        let arr = Expr::Array(vec![]);
+        assert_eq!(run(Expr::First(Box::new(arr.clone())), &NoFields), Value::Nil);
+        assert_eq!(run(Expr::Last(Box::new(arr)), &NoFields), Value::Nil);
+    }
+
+    #[test]
+    fn first_and_last_compose_with_split() {
+        let phrase = Expr::Split { receiver: Box::new(Expr::Str("a::b::c".to_string())), separator: "::".to_string() };
+        assert_eq!(run(Expr::Last(Box::new(phrase.clone())), &NoFields), Value::Str("c".to_string()));
+        assert_eq!(run(Expr::First(Box::new(phrase)), &NoFields), Value::Str("a".to_string()));
+    }
+
+    struct Tags {
+        values: Vec<String>,
+    }
+    impl Fielded for Tags {
+        fn field(&self, name: &str) -> Option<Field<'_>> {
+            (name == "tags").then(|| Field::Value(Value::List(self.values.len())))
+        }
+        fn items(&self, name: &str) -> Option<Vec<Field<'_>>> {
+            (name == "tags").then(|| self.values.iter().map(|t| Field::Value(Value::Str(t.clone()))).collect())
+        }
+    }
+
+    #[test]
+    fn first_over_a_real_scalar_element_field() {
+        let tags = Tags { values: vec!["a".to_string(), "b".to_string()] };
+        assert_eq!(run(Expr::First(Box::new(Expr::Lookup("tags"))), &tags), Value::Str("a".to_string()));
+        assert_eq!(run(Expr::Last(Box::new(Expr::Lookup("tags"))), &tags), Value::Str("b".to_string()));
+    }
+
+    #[test]
+    fn first_over_an_empty_field_answers_nil() {
+        let tags = Tags { values: vec![] };
+        assert_eq!(run(Expr::First(Box::new(Expr::Lookup("tags"))), &tags), Value::Nil);
+    }
+
+    struct Leg {
+        origin: String,
+    }
+    impl Fielded for Leg {
+        fn field(&self, name: &str) -> Option<Field<'_>> {
+            (name == "origin").then(|| Field::Value(Value::Str(self.origin.clone())))
+        }
+    }
+    struct Itinerary {
+        legs: Vec<Leg>,
+    }
+    impl Fielded for Itinerary {
+        fn field(&self, name: &str) -> Option<Field<'_>> {
+            (name == "legs").then(|| Field::Value(Value::List(self.legs.len())))
+        }
+        fn items(&self, name: &str) -> Option<Vec<Field<'_>>> {
+            (name == "legs").then(|| self.legs.iter().map(|leg| Field::Nested(leg)).collect())
+        }
+    }
+
+    #[test]
+    fn first_over_a_list_of_objects_refuses_by_name_instead_of_misrepresenting_one() {
+        let itinerary = Itinerary { legs: vec![Leg { origin: "SFO".to_string() }] };
+        let ctx = EvalContext { args: &NoFields, instance: &itinerary };
+        let err = eval(&Expr::First(Box::new(Expr::Lookup("legs"))), &ctx).unwrap_err();
+        assert!(format!("{err:?}").contains("not generated yet"), "{err:?}");
+    }
+}

--- a/rust/src/kernel/expression_operators/presence.rs
+++ b/rust/src/kernel/expression_operators/presence.rs
@@ -1,0 +1,82 @@
+// Implements the Ruby grammar's "presence" expression-operator category
+// (projection.json: `.present?`, `.blank?` — two symbols, one interpreter
+// node sharing a `negated` flag, the exact `SignTest`-style precedent
+// `sign_test.rs`'s own header already documents for a symbol pair sugar
+// over one primitive) — `Resolver::Presence` (resolver.rb's `blank?`),
+// read directly: Rails-standard semantics, not just `!nil?` — `nil`/
+// `false` are blank, and a `Str`/`List`/`Array` is blank when EMPTY, not
+// merely falsy.
+//
+// `expr.rs`'s `category_of` guarantees `interpret` below is only ever
+// called with `Presence` — see `logical.rs`'s header for why the
+// trailing arm is a router-bug guard, not a real refusal path.
+
+use crate::kernel::expr::{interpret as eval, EvalContext, Expr, Value};
+use crate::kernel::Refusal;
+
+pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
+    let Expr::Presence { receiver, negated } = expr else {
+        return Err(Refusal::TypeMismatch(format!("presence::interpret called with a non-presence node {expr:?} — a router bug")));
+    };
+
+    let v = eval(receiver, ctx)?;
+    let present = !blank(&v);
+    Ok(Value::Bool(if *negated { !present } else { present }))
+}
+
+/// `Resolver#blank?`, read directly: `nil`/`false` are blank outright;
+/// `Str`/`Array` (this kernel's ArrayLiteral/Split-produced list, the
+/// same reading Ruby's own `Array#empty?` gives a real Array) are blank
+/// when EMPTY; every other `Value` (`Int`/`Float`/`Bool(true)`/`List`,
+/// a field-list's own bare length) is never blank — a `Value` with no
+/// meaningful "empty" reading is present by definition, the identical
+/// `else false` Ruby's own `case` falls through to.
+fn blank(v: &Value) -> bool {
+    match v {
+        Value::Nil | Value::Bool(false) => true,
+        Value::Str(s) => s.is_empty(),
+        Value::Array(elements) => elements.is_empty(),
+        Value::Int(_) | Value::Float(_) | Value::Bool(true) | Value::List(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::expr::NoFields;
+
+    fn present(receiver: Expr, negated: bool) -> Value {
+        let expr = Expr::Presence { receiver: Box::new(receiver), negated };
+        let ctx = EvalContext { args: &NoFields, instance: &NoFields };
+        eval(&expr, &ctx).expect("evaluates")
+    }
+
+    #[test]
+    fn nil_and_false_are_blank() {
+        assert_eq!(present(Expr::Nil, false), Value::Bool(false));
+        assert_eq!(present(Expr::Bool(false), false), Value::Bool(false));
+    }
+
+    #[test]
+    fn an_empty_string_is_blank_but_a_nonempty_one_is_present() {
+        assert_eq!(present(Expr::Str(String::new()), false), Value::Bool(false));
+        assert_eq!(present(Expr::Str("x".to_string()), false), Value::Bool(true));
+    }
+
+    #[test]
+    fn zero_and_false_scalar_are_present_not_blank() {
+        assert_eq!(present(Expr::Int(0), false), Value::Bool(true));
+    }
+
+    #[test]
+    fn blank_negates_present() {
+        assert_eq!(present(Expr::Nil, true), Value::Bool(true));
+        assert_eq!(present(Expr::Str("x".to_string()), true), Value::Bool(false));
+    }
+
+    #[test]
+    fn an_empty_array_literal_is_blank() {
+        assert_eq!(present(Expr::Array(vec![]), false), Value::Bool(false));
+        assert_eq!(present(Expr::Array(vec![Expr::Int(1)]), false), Value::Bool(true));
+    }
+}

--- a/rust/src/kernel/expression_operators/sized.rs
+++ b/rust/src/kernel/expression_operators/sized.rs
@@ -38,6 +38,12 @@ pub fn empty(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
     match v {
         Value::Str(_) => Ok(Value::Bool(scalar::is_empty(&v).expect("Str always answers is_empty"))),
         Value::List(_) => Ok(Value::Bool(list::is_empty(&v).expect("List always answers is_empty"))),
+        // `Value::Array` (an `ArrayLiteral`/`.split` result — see its own
+        // header) is a materialised list, not a length-only `List` — its
+        // own `.len()` answers `.empty?`/`.size` directly, no
+        // `attribute_shapes::list` indirection needed the way `List`
+        // has (that file is keyed on `Value::List(usize)` specifically).
+        Value::Array(ref elements) => Ok(Value::Bool(elements.is_empty())),
         Value::Int(_) | Value::Float(_) | Value::Bool(_) | Value::Nil => Err(eval_error(format!("empty? expects a list or string, got {v:?}"))),
     }
 }
@@ -51,6 +57,7 @@ pub fn size(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
     match v {
         Value::Str(_) => Ok(Value::Int(scalar::size(&v).expect("Str always answers size"))),
         Value::List(_) => Ok(Value::Int(list::size(&v).expect("List always answers size"))),
+        Value::Array(ref elements) => Ok(Value::Int(elements.len() as i64)),
         Value::Int(_) | Value::Float(_) | Value::Bool(_) | Value::Nil => Err(eval_error(format!("size expects a list or string, got {v:?}"))),
     }
 }

--- a/rust/src/kernel/expression_operators/text.rs
+++ b/rust/src/kernel/expression_operators/text.rs
@@ -1,0 +1,99 @@
+// Implements the Ruby grammar's "text" expression-operator category
+// (projection.json: `.split`, `.start_with?`, `.end_with?` — three
+// symbols, three interpreter nodes sharing one category, the same
+// `sized.rs`-style grouping precedent: different node shapes, one
+// category, because all three ask a question of a STRING specifically)
+// — `Resolver::Split`/`::StartsWith`/`::EndsWith` (resolver.rb's
+// `split_value`/`starts_with?`/`ends_with?`), read directly. String-only,
+// same reasoning the Ruby resolver's own comments give: every corpus
+// usage found splits or checks the ends of a real String field, never a
+// coerced non-string.
+//
+// `expr.rs`'s `category_of` guarantees `interpret` below is only ever
+// called with `Split`/`StartsWith`/`EndsWith` — see `logical.rs`'s
+// header for why the trailing arm is a router-bug guard, not a real
+// refusal path.
+
+use crate::kernel::expr::{eval_error, interpret as eval, EvalContext, Expr, Value};
+use crate::kernel::Refusal;
+
+pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
+    match expr {
+        Expr::Split { receiver, separator } => {
+            let text = require_str(&eval(receiver, ctx)?, "split")?;
+            // Ruby's `String#split(sep)` with a non-empty literal
+            // separator never returns a trailing empty element the way
+            // a raw byte-split naively would for `"a::".split("::")`
+            // (`["a", ""]` in a naive split vs. Ruby's own `["a"]`) —
+            // `Vec<&str>::split` matches Rust's own semantics, not
+            // Ruby's, for that trailing-empty case, so trailing empties
+            // are trimmed the same way Ruby's own `split` (limit
+            // defaulted, not `-1`) already does.
+            let mut parts: Vec<&str> = text.split(separator.as_str()).collect();
+            while parts.last() == Some(&"") {
+                parts.pop();
+            }
+            Ok(Value::Array(parts.into_iter().map(|p| Value::Str(p.to_string())).collect()))
+        }
+        Expr::StartsWith { receiver, substring } => {
+            let text = require_str(&eval(receiver, ctx)?, "start_with?")?;
+            Ok(Value::Bool(text.starts_with(substring.as_str())))
+        }
+        Expr::EndsWith { receiver, substring } => {
+            let text = require_str(&eval(receiver, ctx)?, "end_with?")?;
+            Ok(Value::Bool(text.ends_with(substring.as_str())))
+        }
+        _ => Err(Refusal::TypeMismatch(format!("text::interpret called with a non-text node {expr:?} — a router bug"))),
+    }
+}
+
+fn require_str(v: &Value, op: &str) -> Result<String, Refusal> {
+    match v {
+        Value::Str(s) => Ok(s.clone()),
+        other => Err(eval_error(format!("{op} expects a string, got {other:?}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::expr::NoFields;
+
+    fn run(expr: Expr) -> Value {
+        let ctx = EvalContext { args: &NoFields, instance: &NoFields };
+        eval(&expr, &ctx).expect("evaluates")
+    }
+
+    fn str(s: &str) -> Expr {
+        Expr::Str(s.to_string())
+    }
+
+    #[test]
+    fn split_matches_rubys_trailing_empty_trim() {
+        let phrase = Expr::Split { receiver: Box::new(str("a::b::c::")), separator: "::".to_string() };
+        assert_eq!(
+            run(phrase),
+            Value::Array(vec![Value::Str("a".to_string()), Value::Str("b".to_string()), Value::Str("c".to_string())])
+        );
+    }
+
+    #[test]
+    fn split_on_a_missing_separator_returns_the_whole_string_as_one_element() {
+        let phrase = Expr::Split { receiver: Box::new(str("abc")), separator: "::".to_string() };
+        assert_eq!(run(phrase), Value::Array(vec![Value::Str("abc".to_string())]));
+    }
+
+    #[test]
+    fn start_and_end_with() {
+        assert_eq!(run(Expr::StartsWith { receiver: Box::new(str("{}")), substring: "{".to_string() }), Value::Bool(true));
+        assert_eq!(run(Expr::EndsWith { receiver: Box::new(str("{}")), substring: "}".to_string() }), Value::Bool(true));
+        assert_eq!(run(Expr::StartsWith { receiver: Box::new(str("[]")), substring: "{".to_string() }), Value::Bool(false));
+    }
+
+    #[test]
+    fn a_non_string_receiver_refuses_with_the_operator_named() {
+        let ctx = EvalContext { args: &NoFields, instance: &NoFields };
+        let err = eval(&Expr::StartsWith { receiver: Box::new(Expr::Int(1)), substring: "x".to_string() }, &ctx).unwrap_err();
+        assert!(format!("{err:?}").contains("start_with? expects a string"), "{err:?}");
+    }
+}

--- a/rust/src/kernel/expression_operators/to_string.rs
+++ b/rust/src/kernel/expression_operators/to_string.rs
@@ -8,11 +8,12 @@
 // `3.to_s == "3"`, ...) — `Str`/`Int`/`Float`/`Bool` (the "scalar"
 // attribute shape) and `Nil` (the "optional" shape, absent-or-literal)
 // each get an explicit arm, routed to the file that owns that shape's
-// own `.to_s` rule, rather than reimplemented here. `List` is the one
-// exception: no real corpus predicate ever calls `.to_s` on a
-// list-typed field, and Ruby's own `Array#to_s` (`.inspect`-shaped)
-// isn't ported here, so that arm still refuses, explicitly, rather than
-// silently stringifying a length nobody asked for.
+// own `.to_s` rule, rather than reimplemented here. `List`/`Array` are
+// the exception: no real corpus predicate ever calls `.to_s` on a
+// list-typed field or a materialised array, and Ruby's own `Array#to_s`
+// (`.inspect`-shaped) isn't ported here, so that arm still refuses,
+// explicitly, rather than silently stringifying a length or a joined
+// list nobody asked for.
 //
 // `expr.rs`'s `category_of` guarantees `interpret` below is only ever
 // called with `ToS` — see `logical.rs`'s header for why the trailing arm
@@ -30,6 +31,6 @@ pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
     match eval(receiver, ctx)? {
         v @ (Value::Str(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_)) => Ok(scalar::to_s(&v).expect("scalar shape always stringifies")),
         Value::Nil => Ok(optional::to_s(&Value::Nil).expect("Nil always stringifies to \"\"")),
-        v @ Value::List(_) => Err(eval_error(format!("to_s expects a scalar, got {v:?}"))),
+        v @ (Value::List(_) | Value::Array(_)) => Err(eval_error(format!("to_s expects a scalar, got {v:?}"))),
     }
 }

--- a/spec/operator_conformance_spec.rb
+++ b/spec/operator_conformance_spec.rb
@@ -135,9 +135,14 @@ RSpec.describe "the operator domain" do
   it "orders the inner grammar exactly the way grammar.md documents it" do
     # rule 1 (.length), 2-5 (literals), and 12 (dotted lookup) are
     # terminal productions, not operators — same exclusion. This is rules
-    # 6-11, in order.
+    # 6-11, in order, followed by the eight vendored operators
+    # (`.match?`/`.present?`/`.blank?`/`.split`/`.start_with?`/
+    # `.end_with?`/`.first`/`.last`) admitted after grammar.md was
+    # written — see this file's own header update for the finding that
+    # sent them through the ledger for the first time.
     expect(symbols(by_grammar("inner"))).to eq(
-      ["+", ".positive?", ".negative?", ".zero?", ".empty?", ".to_s", ".modulo", ".size", ".any?", ".none?", ".all?", ".find"]
+      ["+", ".positive?", ".negative?", ".zero?", ".empty?", ".to_s", ".modulo", ".size", ".any?", ".none?", ".all?", ".find",
+       ".match?", ".present?", ".blank?", ".split", ".start_with?", ".end_with?", ".first", ".last"]
     )
   end
 
@@ -158,22 +163,30 @@ RSpec.describe "the operator domain" do
   # cases — so each is held by a behavioral probe, and direction B is
   # the probe table's keys equalling the admitted set.
   PROBES = {
-    "||"         => -> { Evaluator.parse("a || b").is_a?(Evaluator::Or) },
-    "&&"         => -> { Evaluator.parse("a && b").is_a?(Evaluator::And) },
-    "!"          => -> { Evaluator.parse("!a").is_a?(Evaluator::Not) },
-    ".include?"  => -> { Evaluator.parse("list.include?(x)").is_a?(Evaluator::Include) },
-    "+"          => -> { Resolver.parse("a + b").is_a?(Resolver::Addition) },
-    ".modulo"    => -> { Resolver.parse("a.modulo(b)").is_a?(Resolver::Modulo) },
-    ".positive?" => -> { Resolver.parse("a.positive?").is_a?(Resolver::SignTest) },
-    ".negative?" => -> { Resolver.parse("a.negative?").is_a?(Resolver::SignTest) },
-    ".zero?"     => -> { Resolver.parse("a.zero?").is_a?(Resolver::SignTest) },
-    ".empty?"    => -> { Resolver.parse("a.empty?").is_a?(Resolver::Empty) },
-    ".to_s"      => -> { Resolver.parse("a.to_s").is_a?(Resolver::ToS) },
-    ".size"      => -> { Resolver.parse("a.size").is_a?(Resolver::Size) },
-    ".any?"      => -> { Resolver.parse("a.any? { |x| x }").then { |n| n.is_a?(Resolver::BlockPredicate) && n.mode == :any } },
-    ".none?"     => -> { Resolver.parse("a.none? { |x| x }").then { |n| n.is_a?(Resolver::BlockPredicate) && n.mode == :none } },
-    ".all?"      => -> { Resolver.parse("a.all? { |x| x }").then { |n| n.is_a?(Resolver::BlockPredicate) && n.mode == :all } },
-    ".find"      => -> { Resolver.parse("a.find { |x| x }.b").is_a?(Resolver::Find) }
+    "||"           => -> { Evaluator.parse("a || b").is_a?(Evaluator::Or) },
+    "&&"           => -> { Evaluator.parse("a && b").is_a?(Evaluator::And) },
+    "!"            => -> { Evaluator.parse("!a").is_a?(Evaluator::Not) },
+    ".include?"    => -> { Evaluator.parse("list.include?(x)").is_a?(Evaluator::Include) },
+    "+"            => -> { Resolver.parse("a + b").is_a?(Resolver::Addition) },
+    ".modulo"      => -> { Resolver.parse("a.modulo(b)").is_a?(Resolver::Modulo) },
+    ".positive?"   => -> { Resolver.parse("a.positive?").is_a?(Resolver::SignTest) },
+    ".negative?"   => -> { Resolver.parse("a.negative?").is_a?(Resolver::SignTest) },
+    ".zero?"       => -> { Resolver.parse("a.zero?").is_a?(Resolver::SignTest) },
+    ".empty?"      => -> { Resolver.parse("a.empty?").is_a?(Resolver::Empty) },
+    ".to_s"        => -> { Resolver.parse("a.to_s").is_a?(Resolver::ToS) },
+    ".size"        => -> { Resolver.parse("a.size").is_a?(Resolver::Size) },
+    ".any?"        => -> { Resolver.parse("a.any? { |x| x }").then { |n| n.is_a?(Resolver::BlockPredicate) && n.mode == :any } },
+    ".none?"       => -> { Resolver.parse("a.none? { |x| x }").then { |n| n.is_a?(Resolver::BlockPredicate) && n.mode == :none } },
+    ".all?"        => -> { Resolver.parse("a.all? { |x| x }").then { |n| n.is_a?(Resolver::BlockPredicate) && n.mode == :all } },
+    ".find"        => -> { Resolver.parse("a.find { |x| x }.b").is_a?(Resolver::Find) },
+    ".match?"      => -> { Resolver.parse("a.match?(/x/)").is_a?(Resolver::MatchesRegex) },
+    ".present?"    => -> { Resolver.parse("a.present?").is_a?(Resolver::Presence) && !Resolver.parse("a.present?").negated },
+    ".blank?"      => -> { Resolver.parse("a.blank?").is_a?(Resolver::Presence) && Resolver.parse("a.blank?").negated },
+    ".split"       => -> { Resolver.parse('a.split("x")').is_a?(Resolver::Split) },
+    ".start_with?" => -> { Resolver.parse('a.start_with?("x")').is_a?(Resolver::StartsWith) },
+    ".end_with?"   => -> { Resolver.parse('a.end_with?("x")').is_a?(Resolver::EndsWith) },
+    ".first"       => -> { Resolver.parse("a.first").is_a?(Resolver::First) },
+    ".last"        => -> { Resolver.parse("a.last").is_a?(Resolver::Last) }
   }.freeze
 
   it "implements every admitted structural operator, and no other" do
@@ -183,6 +196,97 @@ RSpec.describe "the operator domain" do
     PROBES.each do |symbol, probe|
       expect(probe.call).to be(true), "#{symbol} is admitted but the machinery no longer parses it"
     end
+  end
+
+  # THE GAP THIS FILE'S OWN HEADER NOW NAMES: everything above holds the
+  # ledger equal to the evaluator's TABLES (COMPARISONS, PROBES) — but
+  # eight real node types (MatchesRegex/Presence/Split/StartsWith/
+  # EndsWith/First/Last, admitted above for the first time) used to
+  # reach `resolver.rb` as hand-coded Structs with a parse branch and an
+  # `interpret` arm and NOTHING ELSE — no ledger entry, no PROBES entry,
+  # nothing any table-shaped guard could see, because they were never
+  # table entries; they were leaf-grammar CODE. `operator_conformance_
+  # spec` checking tables could not structurally notice code the tables
+  # never mentioned.
+  #
+  # This closes it at the STRUCT level instead of the table level: every
+  # Class Resolver/Evaluator actually define, found by REFLECTION
+  # (`Module#constants`, not a hand-copied roster that could go stale
+  # exactly the way the ledger itself did), must be either a documented
+  # terminal/helper exclusion or point back to an admitted symbol via
+  # `NODE_TYPE_FOR_SYMBOL`. A ninth operator vendored the same way — a
+  # new Struct in resolver.rb, no ledger entry — fails HERE the moment
+  # the struct exists, whether or not anyone remembers to touch this
+  # file by hand.
+  NODE_TYPE_FOR_SYMBOL = {
+    "||" => Evaluator::Or, "&&" => Evaluator::And, "!" => Evaluator::Not, ".include?" => Evaluator::Include,
+    # All six comparison symbols (`>=`/`<=`/`</`>`/`==`/`!=`) share one
+    # node type — `Evaluator::Compare`, `operator:` naming which of the
+    # six — the identical reduction `SignTest` already applies for
+    # `.positive?`/`.negative?`/`.zero?` below. `COMPARISONS` (`==
+    # OPERATORS.map(&:symbol)`) is the ledger-derived roster itself
+    # (evaluator.rb), not a second hand-copied list of the six symbols.
+    **Evaluator::COMPARISONS.to_h { |symbol| [symbol, Evaluator::Compare] },
+    "+" => Resolver::Addition, ".modulo" => Resolver::Modulo,
+    ".positive?" => Resolver::SignTest, ".negative?" => Resolver::SignTest, ".zero?" => Resolver::SignTest,
+    ".empty?" => Resolver::Empty, ".to_s" => Resolver::ToS, ".size" => Resolver::Size,
+    ".any?" => Resolver::BlockPredicate, ".none?" => Resolver::BlockPredicate, ".all?" => Resolver::BlockPredicate,
+    ".find" => Resolver::Find,
+    ".match?" => Resolver::MatchesRegex, ".present?" => Resolver::Presence, ".blank?" => Resolver::Presence,
+    ".split" => Resolver::Split, ".start_with?" => Resolver::StartsWith, ".end_with?" => Resolver::EndsWith,
+    ".first" => Resolver::First, ".last" => Resolver::Last
+  }.freeze
+
+  # Every real Class either module defines DIRECTLY (`false` — no
+  # inherited constants), found mechanically rather than remembered.
+  # `Struct.new(...)` returns a genuine anonymous `Class`, same as the
+  # bare `NilLiteral = Class.new` (see its own comment in resolver.rb for
+  # why that one isn't a Struct) — `.is_a?(Class)` catches both and
+  # nothing else (the data-table constants beside them — `SIGN_TESTS`,
+  # `BLOCK_PREDICATE_MODES`, `PROJECTION`, `OPERATORS`, ... — are
+  # Array/Hash, never Class).
+  def node_classes(mod) = mod.constants(false).map { |name| mod.const_get(name) }.grep(Class)
+
+  # NOT AST nodes `parse` ever returns, excluded with the SAME reasoning
+  # expression.bluebook's own "WHAT IS NOT HERE" comment on the
+  # `Operator` aggregate already gives for the outer grammar's
+  # parenthesization/bare-leaf-fallback rules and the inner grammar's
+  # literal/dotted-lookup productions: nothing here has a per-target
+  # rendering to admit.
+  #   - literals + Lookup: a spelling that doesn't differ per target.
+  #     `ArrayLiteral` joins them for the identical reason (`expr.rs`'s
+  #     own `Expr::Array` is a LEAF, not routed through OperatorCategory).
+  #   - `Evaluator::Resolve`: the boolean grammar's own "fall through to
+  #     the leaf grammar" wrapper — structural, the same way the outer
+  #     grammar's bare-leaf-fallback rule is, never itself a symbol.
+  #   - `Evaluator::Operator`: a DATA shape (which comparison a `Compare`/
+  #     `SignTest` node carries as its `op:`/`operator:` field), not a
+  #     node `parse` ever returns on its own.
+  NON_OPERATOR_NODE_TYPES = [
+    Resolver::IntegerLiteral, Resolver::FloatLiteral, Resolver::StringLiteral, Resolver::BoolLiteral,
+    Resolver::NilLiteral, Resolver::ArrayLiteral, Resolver::Lookup,
+    Evaluator::Resolve, Evaluator::Operator
+  ].freeze
+
+  it "gives every non-terminal Resolver/Evaluator node type an admitted ledger symbol" do
+    all_nodes      = (node_classes(Evaluator) + node_classes(Resolver)).uniq
+    operator_nodes = all_nodes - NON_OPERATOR_NODE_TYPES
+    covered        = NODE_TYPE_FOR_SYMBOL.values_at(*symbols(ADMITTED)).compact.uniq
+
+    stranded = operator_nodes - covered
+    expect(stranded).to be_empty,
+                        "#{stranded.map(&:name).inspect} — a real AST node type with " \
+                        "no admitted ledger symbol pointing at it. Either it's a genuine terminal/" \
+                        "structural production (add it to NON_OPERATOR_NODE_TYPES, the same reasoning " \
+                        "grammar.md's own exclusions use) or it bypassed Propose/Render/Admit the way " \
+                        "eight vendored operators did (see this file's own header) — admit it in the " \
+                        "ledger, add its symbol to NODE_TYPE_FOR_SYMBOL and a PROBES entry, instead."
+
+    # THE OTHER DIRECTION — `NODE_TYPE_FOR_SYMBOL` itself drifting (a
+    # renamed or removed struct still named here) would silently defeat
+    # the check above by inflating `covered` with a class reflection no
+    # longer finds live.
+    expect(covered - all_nodes).to be_empty
   end
 
   it "orders precedence the way the grammar checks" do


### PR DESCRIPTION
Close the expression-operator ledger bypass: admit 8 vendored operators for real

A review found that .match?/.present?/.blank?/.split/.start_with?/
.end_with?/.first/.last had working Ruby parse/interpret code but had
never gone through Propose -> Render -> Admit
(lib/hecks/grammar/expression_operators.json) — a closed-vocabulary
guard (spec/operator_conformance_spec.rb) built entirely over tables
structurally could not see hand-coded Struct/parse/interpret additions
in resolver.rb.

- Admit all 8 through the real ledger lifecycle, rendered in BOTH
  ruby and rust (full Rust kernel parity, not a Ruby-only decision):
  new pattern_match/presence/text/positional operator categories,
  regenerated via bin/expression_projection and
  bin/project_kernel_capabilities.
- rust/src/kernel: new Value::Array(Vec<Value>) variant (a real
  materialised list, distinct from the length-only Value::List);
  MatchesRegex/Presence/Split/StartsWith/EndsWith/First/Last as new
  Expr variants; ArrayLiteral as a new leaf (Expr::Array, like every
  other literal). One new dependency, regex (pure-Rust, no C
  toolchain), a deliberate documented exception to this crate's own
  zero-Cargo-dependency discipline (ADR 0012).
- Extend operator_conformance_spec from tables to the leaf grammar:
  every Resolver/Evaluator node type, found by reflection (not a
  hand-copied roster), must trace back to an admitted ledger symbol —
  the mechanical check that would have caught all 8 the moment they
  were added, verified to actually catch a 9th one the same way.
- rust/project/expr_emitter.rb: real emit_resolver arms for all 8
  operators plus ArrayLiteral; fixed the emitter's own error message,
  which used to blame the grammar for exactly this class of bug
  instead of naming the missing Rust rendering.
- docs/implemented/guides/running-a-runtime.md: document the 8
  operators in the expression grammar table.

Incidental: fixed a pre-existing, unrelated stale-struct-literal
compile error in rust/src/kernel/read_model.rs's own test module
(ReadModelDef gained count/group_by/median_field fields the test
literal never picked up) that was blocking cargo test --lib entirely.

Verified: cargo test --lib (68/68), cargo clippy (0 warnings),
bin/rust_kernel_coverage (16/16), bundle exec rspec (full default
suite, 0 failures), rubocop clean on touched files.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)