### PR TITLE
ci: install the wasm32-wasip1 rustup target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,19 +85,27 @@ jobs:
       # this step), so the gap went uncaught until the next push that DID
       # compile.
       #
-      # `--toolchain stable` MATTERS — `rustup target add` with no
-      # `--toolchain` installs onto whatever rustup's DEFAULT toolchain
-      # currently is, but `bin/project_wasm` explicitly builds via
-      # `rustup run stable` (its own comment explains why: a bare `cargo`
-      # can resolve to a toolchain that never saw the target at all). On
-      # this runner the default isn't necessarily named "stable" — a
-      # first attempt at this fix added the target to the default
-      # toolchain and still hit `error[E0463]: can't find crate for
-      # 'std'` under `rustup run stable`, confirmed live in CI, not
-      # merely suspected. Naming the toolchain explicitly here matches
-      # the exact one the build actually runs under.
+      # BOTH THE DEFAULT TOOLCHAIN AND "stable" NAMED EXPLICITLY, because
+      # confirmed live in CI they are NOT the same toolchain on this
+      # runner. `bin/project_wasm` itself checks in two places that
+      # disagree if only one is covered: its own precheck (`rustup target
+      # list --installed`, no `--toolchain` — the DEFAULT) has to see the
+      # target before it will even attempt a build, but the build itself
+      # runs via `rustup run stable` (that script's own comment explains
+      # why: a bare `cargo` can resolve to a toolchain that never saw the
+      # target at all). Attempt 1 (`rustup target add wasm32-wasip1`, no
+      # flag) satisfied neither the "stable" build directly, since it's a
+      # different toolchain — E0463 "can't find crate for `std`". Attempt
+      # 2 (`--toolchain stable` only) satisfied the build but broke the
+      # precheck instead — back to "wasm32-wasip1 isn't installed for
+      # this toolchain", now from the default side. Installing onto both
+      # names, unconditionally, is the only version of this that isn't
+      # betting on the two ever being the same toolchain on some future
+      # runner image too.
       - name: Install the wasm32-wasip1 target
-        run: rustup target add wasm32-wasip1 --toolchain stable
+        run: |
+          rustup target add wasm32-wasip1
+          rustup target add wasm32-wasip1 --toolchain stable
 
       # bin/rust_conformance's `native` mode (0012/0013) — regenerated
       # from the CURRENT generator, not just the checked-in rust/src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,18 @@ jobs:
       - name: Create the pizzas example's database
         run: createdb -h localhost -U postgres hecks_pizzas
 
+      # `bin/project_wasm` (spec/project_deploy_parity_gate_spec.rb, Phase
+      # 8) needs the wasm32-wasip1 target installed, and ubuntu-latest's
+      # preinstalled toolchain doesn't carry it — every other Rust step
+      # below builds for the host target and never needed this until #407
+      # added the WASM parity gate; that PR's own CI run never reached
+      # this spec (it never got past compiling, the same bug fixed above
+      # this step), so the gap went uncaught until the next push that DID
+      # compile. `rustup target add` is idempotent and ~instant when the
+      # target's already present, so this costs nothing on a cache hit.
+      - name: Install the wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+
       # bin/rust_conformance's `native` mode (0012/0013) — regenerated
       # from the CURRENT generator, not just the checked-in rust/src/
       # generated/ snapshot (which could silently drift from it), then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,21 @@ jobs:
       # added the WASM parity gate; that PR's own CI run never reached
       # this spec (it never got past compiling, the same bug fixed above
       # this step), so the gap went uncaught until the next push that DID
-      # compile. `rustup target add` is idempotent and ~instant when the
-      # target's already present, so this costs nothing on a cache hit.
+      # compile.
+      #
+      # `--toolchain stable` MATTERS — `rustup target add` with no
+      # `--toolchain` installs onto whatever rustup's DEFAULT toolchain
+      # currently is, but `bin/project_wasm` explicitly builds via
+      # `rustup run stable` (its own comment explains why: a bare `cargo`
+      # can resolve to a toolchain that never saw the target at all). On
+      # this runner the default isn't necessarily named "stable" — a
+      # first attempt at this fix added the target to the default
+      # toolchain and still hit `error[E0463]: can't find crate for
+      # 'std'` under `rustup run stable`, confirmed live in CI, not
+      # merely suspected. Naming the toolchain explicitly here matches
+      # the exact one the build actually runs under.
       - name: Install the wasm32-wasip1 target
-        run: rustup target add wasm32-wasip1
+        run: rustup target add wasm32-wasip1 --toolchain stable
 
       # bin/rust_conformance's `native` mode (0012/0013) — regenerated
       # from the CURRENT generator, not just the checked-in rust/src/

--- a/rust/src/kernel/read_model.rs
+++ b/rust/src/kernel/read_model.rs
@@ -404,7 +404,7 @@ mod snake_alias_tests {
     fn find_accepts_both_the_declared_and_the_snake_cased_spelling() {
         let table = [ReadModelDef {
             verb: "Banking.CustomerPortfolio",
-            reference_name: "reference",
+            reference_name: Some("reference"),
             heads: &[],
             filtered_head: None,
             conditions: &[],
@@ -412,6 +412,9 @@ mod snake_alias_tests {
             offset: None,
             limit: None,
             authorization: None,
+            group_by: None,
+            count: false,
+            median_field: None,
         }];
 
         assert!(find(&table, "Banking.CustomerPortfolio").is_some());


### PR DESCRIPTION
Follow-up to #412. Once #412's compile fix let the `rspec` job's io+fuzzing step actually run to completion for the first time since #407, it hit a second, previously-masked gap: `spec/project_deploy_parity_gate_spec.rb`'s Phase 8 parity gate shells out to `bin/project_wasm`, which needs the `wasm32-wasip1` rustup target — added alongside that spec in #407, but never installed in the CI workflow (#407's own CI run never got far enough to exercise it either).

Verified locally: `CI=true bundle exec rspec spec/project_deploy_parity_gate_spec.rb --tag io` passes 6/6 with the target installed.

See the CI run on main after merging #412: https://github.com/chrisyoung/hecks/actions/runs/33146538812 — checks/runtime_changed/rspec:parallel/exemplar-module build all green, only this one io-tagged spec red, with the exact "wasm32-wasip1 isn't installed" error this fixes.