### PR TITLE
forms: fix path-segment URL encoding, honest role badge, CSRF omission

### DIFF
--- a/bin/present
+++ b/bin/present
@@ -67,4 +67,5 @@ port, error = Hecks::Forms::PortArgument.parse(ARGV)
 abort "bin/present: #{error}" if error
 
 puts "command_form.bluebook/query_form.bluebook — Banking, in memory — http://localhost:#{port}/"
+puts "development server: no authentication, no CSRF protection, no caller identity — do not expose beyond localhost"
 Rackup::Server.start(app: app, Port: port, server: "webrick")

--- a/docs/command-form-and-query-form-bluebook.md
+++ b/docs/command-form-and-query-form-bluebook.md
@@ -250,9 +250,23 @@ splitting it would mean two copies drifting, for no reader's benefit:
   pass does; what's here is the forms/views layer and the content
   negotiation underneath it, nothing about styling frameworks or
   push-updated pages.
-- **Not deployed.** `bin/present` boots the banking example in memory, for
-  local use — the same `webrick`/`rackup` dev-server shape `bin/console`
-  and friends already use, not a production server story.
+- **No authentication, no CSRF protection, no caller identity.** Every
+  command dispatches via `@dispatcher.dispatch(...)` with no
+  `Hecks.as_caller` anywhere in the directory — nobody is bound, so
+  `CommandRules::Authorization`'s `refuse_role_mismatch` (opt-in on both
+  sides) never runs, even though `command_form_renderer.rb` prints the
+  command's `role:` next to the form. There is no CSRF token, no
+  Origin/Referer check, no SameSite handling, and no session anywhere in
+  the directory — any page open in the same browser can POST a
+  state-changing command to a running `bin/present`. This is a security
+  boundary, not a packaging detail: see the next item.
+- **Not deployed, and not safe to expose.** `bin/present` boots the
+  banking example in memory, for local use — the same
+  `webrick`/`rackup` dev-server shape `bin/console` and friends already
+  use, not a production server story. Concretely, because of the item
+  above: do not put this behind a public URL or bind it to
+  anything but localhost. It is a prototype for exploring the forms
+  shape, not a hardened surface.
 
 ## Running it
 

--- a/lib/hecks/forms/app.rb
+++ b/lib/hecks/forms/app.rb
@@ -189,7 +189,7 @@ module Hecks
         result = @dispatcher.dispatch("#{domain}::#{aggregate.hecks_name}.#{command.hecks_name}", **envelope)
         # L12 — the id is free-form (S3), so it must be percent-encoded as
         # a path segment here, not just interpolated raw.
-        redirect("/#{domain}/#{aggregate.hecks_name}/#{Escape.url(result.id)}.html")
+        redirect("/#{domain}/#{aggregate.hecks_name}/#{Escape.path(result.id)}.html")
       rescue *Runtime::DOMAIN_REFUSALS, ArgumentError, TypeError, JSON::ParserError => e
         status = e.is_a?(Runtime::NotFound) ? 404 : 422
         command_form(domain, aggregate, command, action, status: status, values: raw, error: e)

--- a/lib/hecks/forms/command_form_renderer.rb
+++ b/lib/hecks/forms/command_form_renderer.rb
@@ -57,7 +57,7 @@ module Hecks
       def self.header(domain, aggregate, command)
         <<~HTML
           <h1>#{Escape.html("#{domain}::#{aggregate.hecks_name}.#{command.hecks_name}")}</h1>
-          #{command.role ? %(<span class="badge role">role: #{Escape.html(command.role)}</span>) : ''}
+          #{command.role ? %(<span class="badge role" title="Declared on the command; this prototype dispatches with no caller bound, so the check does not run.">role: #{Escape.html(command.role)} (not enforced here)</span>) : ''}
           #{command.creates? ? %(<span class="badge">creates a new #{Escape.html(aggregate.hecks_name)}</span>) : ''}
           #{command.goal ? %(<p class="goal">#{Escape.html(command.goal)}</p>) : ''}
           #{givens_callout(command)}

--- a/lib/hecks/forms/html.rb
+++ b/lib/hecks/forms/html.rb
@@ -28,24 +28,34 @@ module Hecks
       # the same escaping and leaving the reader to check they match.
       def self.attr(value) = html(value)
 
-      # L12 (docs/audits/2026-08-10-main-bug-audit.md) — safe as a URL PATH
-      # segment or query-string VALUE. `html`/`attr` guard against the
-      # value becoming markup, but say nothing about it staying inside the
-      # URL syntax position it was placed in: an aggregate's identity is
-      # free-form unless its value object declares a `pattern:` (see S3 in
-      # the same audit), so `&`, `+`, `?`, `#`, and `/` are all otherwise
-      # legal id characters, and each would corrupt an href/Location built
-      # by naive interpolation (a stray `&` smuggles a second query
-      # parameter, `#` truncates the path at a fragment, `/` splits the
-      # path into an extra segment, ...). Percent-encodes via
-      # `application/x-www-form-urlencoded` (`+` for space) — the same
-      # encoding this directory already uses for a query value elsewhere
-      # (query_form_renderer.rb's `quick_links`), now shared here so every
-      # id-in-a-link call site uses the one guard instead of remembering
-      # it individually. Callers still wrap the ASSEMBLED href/Location in
-      # `attr` (or `html`) as usual — this only covers the id's own
-      # component, not the surrounding markup.
+      # L12 (docs/audits/2026-08-10-main-bug-audit.md) — safe as a
+      # query-string VALUE. `html`/`attr` guard against the value becoming
+      # markup, but say nothing about it staying inside the URL syntax
+      # position it was placed in: an aggregate's identity is free-form
+      # unless its value object declares a `pattern:` (see S3 in the same
+      # audit), so `&`, `+`, `?`, `#`, and `/` are all otherwise legal id
+      # characters, and each would corrupt an href/Location built by naive
+      # interpolation (a stray `&` smuggles a second query parameter, `#`
+      # truncates the path at a fragment, `/` splits the path into an
+      # extra segment, ...). Percent-encodes via
+      # `application/x-www-form-urlencoded` (`+` for space) — correct ONLY
+      # for a query-string value (query_form_renderer.rb's `quick_links`,
+      # record_renderer.rb's `?to=`). For a URL PATH segment use `path`
+      # below instead — `+` is a literal plus there, not an escaped space,
+      # so this method would corrupt any id containing a space. Callers
+      # still wrap the ASSEMBLED href/Location in `attr` (or `html`) as
+      # usual — this only covers the id's own component, not the
+      # surrounding markup.
       def self.url(value) = URI.encode_www_form_component(value.to_s)
+
+      # Same guard as `url`, for a URL PATH segment instead of a
+      # query-string value. `encode_www_form_component` renders space as
+      # `+`, which is only meaningful inside a query string — in a path
+      # segment `+` is a literal plus, so an id like "John Smith" would
+      # round-trip to "John+Smith" and 404 against the real id "John
+      # Smith". Reuse the same percent-encoding and just correct that one
+      # character back to `%20`.
+      def self.path(value) = URI.encode_www_form_component(value.to_s).gsub("+", "%20")
     end
 
     # A tiny attribute-hash -> string helper, shared by every renderer in

--- a/lib/hecks/forms/record_table.rb
+++ b/lib/hecks/forms/record_table.rb
@@ -46,7 +46,7 @@ module Hecks
         # is itself attribute-escaped (belt-and-suspenders — nothing else
         # in `href` is untrusted, but this matches the convention used
         # everywhere else an href is built from parts).
-        href = "/#{domain}/#{aggregate.hecks_name}/#{Escape.url(instance.id)}.html"
+        href = "/#{domain}/#{aggregate.hecks_name}/#{Escape.path(instance.id)}.html"
         "<tr><td><a href=\"#{Escape.attr(href)}\">#{Escape.html(instance.id)}</a></td>#{cells}</tr>"
       end
 


### PR DESCRIPTION
Addresses the four items filed by a review of `lib/hecks/forms/`:

1. **`Escape.url` was wrong for path segments.** `URI.encode_www_form_component` encodes space as `+`, correct for a query-string value but a literal plus in a path segment. Two call sites (`app.rb`'s post-command redirect, `record_table.rb`'s row links) built links to the app's own records that 404'd for any id containing a space — a successful command redirected to a broken URL. Added `Escape.path` for path segments; `record_renderer.rb`'s `?to=` query value keeps `Escape.url`.
2. **The role badge claimed an authorization the app doesn't enforce.** `command_form_renderer.rb` rendered `role: Teller` next to a form, but nothing in the directory calls `Hecks.as_caller`, so `CommandRules::Authorization#refuse_role_mismatch` (opt-in on both sides) never runs. The badge now says the role is declared but not enforced here.
3. **CSRF/auth/caller-identity wasn't on the omissions list.** The doc's "what this deliberately leaves out" section is otherwise thorough (11 items) but said nothing about this. Added the item, and reframed "Not deployed" as a security statement rather than a packaging one.
4. **`bin/present` now prints a one-line banner** on boot: no auth, no CSRF, do not expose beyond localhost.

Verified: `ruby -c` on all changed files, a standalone check of `Escape.path`'s encoding, and the full pre-push suite (270 specs, fuzzer, model checker, rubocop) — all green.
