### PR TITLE
Update repo references to heckslabs/hecks after org transfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 jobs:
   rspec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,4 +122,4 @@ entries below are grouped by theme, not itemized commit-by-commit; see
   found independently, alongside H1 above, while reconciling docs
   against code in both directions.
 
-[Unreleased]: https://github.com/chrisyoung/hecks/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/heckslabs/hecks/compare/v0.3.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ has to re-verify by hand.
 ## Getting running
 
 ```sh
-git clone https://github.com/chrisyoung/hecks
+git clone https://github.com/heckslabs/hecks
 cd hecks
 bundle install
 bin/console          # boots the pizzas example, drops you into IRB with its door installed

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ There is no published gem. You clone the repository, and the
 repository is the tool:
 
 ```sh
-git clone https://github.com/chrisyoung/hecks
+git clone https://github.com/heckslabs/hecks
 cd hecks
 bundle install
 bin/console examples/banking     # drops into IRB with the domain booted

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ and will be taken seriously.
 ## Reporting a vulnerability
 
 **Preferred: GitHub Security Advisories.** Use this repository's
-["Report a vulnerability"](https://github.com/chrisyoung/hecks/security/advisories/new)
+["Report a vulnerability"](https://github.com/heckslabs/hecks/security/advisories/new)
 form (under the Security tab) to open a private advisory. It reaches
 the maintainer without ever becoming a public issue, and keeps
 discussion, a fix, and the disclosure timeline attached to one thread.

--- a/docs/implemented/guides/getting-started.md
+++ b/docs/implemented/guides/getting-started.md
@@ -20,7 +20,7 @@ This is a research language, published as the `hecks` gem (currently
 it — clone it and the repository is the tool:
 
 ```sh
-git clone https://github.com/chrisyoung/hecks
+git clone https://github.com/heckslabs/hecks
 cd hecks
 bundle install
 bin/console          # boots the pizzas example — try it first

--- a/hecks.gemspec
+++ b/hecks.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
     Nothing is scripted: no handler body, no class you write, no schema
     you migrate.
   DESC
-  spec.homepage = "https://github.com/chrisyoung/hecks"
+  spec.homepage = "https://github.com/heckslabs/hecks"
   spec.license  = "Apache-2.0"
 
   spec.required_ruby_version = ">= 3.2"


### PR DESCRIPTION
chrisyoung/hecks was transferred to the heckslabs org to enable GitHub merge queue (restricted to org-owned repos). This updates clone URLs, gemspec homepage, security advisory link, and changelog compare link.

Historical audit docs in docs/audits/ keep their original issue/PR links since GitHub's transfer redirect keeps them working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)