### PR TITLE
Add examples/directory: a real, CI-verified rekey (+compute) translat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ The example domains this README draws from:
 - **banking** — Customers hold accounts, accounts move money, and every movement is a transfer that can fail halfway. The domain that has to get it right twice — once in the rules, once in the recovery.
 - **chess** — A chess game: pieces with no life outside the board that holds them, a status that only ever moves one legal way at a time, and turn order and check enforced by declaration rather than a hand-written engine.
 - **compliance** — Something elsewhere already acted to contain a risk; this domain tracks the human review that decides what happens next.
+- **directory** — A staff directory: members once addressed by the name they walked in with, now by the email that actually identifies them one person to one row.
 - **pizzas** — Put toppings on a pizza and sell it to a customer.
 - **roster** — A crew roster: seats added one at a time, members enlisted, each seated once — the smallest domain whose every rule is a question asked of a LIST.
 <!-- generated:end -->

--- a/bin/fuzz
+++ b/bin/fuzz
@@ -89,7 +89,35 @@ def fuzz_domain(domain, seeds, steps, adapter = :memory)
   while (clean + failures.length) < seeds && drawn < cap
     drawn += 1
     seed = drawn
-    generated = Hecks::Fuzzing::SequenceGenerator.generate(domain, seed: seed, steps: steps, adapter: adapter)
+    generated = begin
+      Hecks::Fuzzing::SequenceGenerator.generate(domain, seed: seed, steps: steps, adapter: adapter)
+    rescue Hecks::Runtime::WiringError => e
+      # A `compute`/`rekey` translation rule is an era/Postgres-only
+      # construct (lib/hecks/ports/persistence/plugins/era/era_check.rb)
+      # — it needs a real SQL migration to interpret, so it CANNOT boot
+      # under IsolatedBoot's Memory (or :sqlite) rebind, whatever adapter
+      # this sweep picked; `Loader.check_compute_rules_backstop!` refuses
+      # by design the moment nothing era-aware is loaded to interpret it
+      # (lib/hecks/runtime/loader.rb's own comment: a loaded era plugin
+      # would refuse more specifically, "...is bound to Memory" — this is
+      # the same refusal, just from the plugin-free path IsolatedBoot
+      # always takes). Not a bug in this domain or in fuzzing — every
+      # OTHER domain in the sweep is still fuzzable, so one unfuzzable
+      # domain skipping itself beats the whole sweep dying on the first
+      # `compute`/`rekey` domain anyone ever adds to the corpus (examples/
+      # directory is the first, closing the audit's own "no rekey
+      # anywhere in the example corpus" gap — this domain is why this
+      # rescue exists). Real coverage for compute/rekey stays where it
+      # already lives: spec/adapters/driven/postgres_era/*_spec.rb,
+      # `io: true`, against a real Postgres.
+      raise unless e.message.include?("a compute/rekey rule is declared")
+
+      :skip
+    end
+    if generated == :skip
+      puts "   skipped — declares compute/rekey, which only an era/Postgres-bound boot can interpret (not fuzzable under :#{adapter})"
+      return true
+    end
     verdict, message = outcome(domain, generated, adapter)
 
     if verdict == :clean

--- a/examples/directory/bluebook/directory.bluebook
+++ b/examples/directory/bluebook/directory.bluebook
@@ -1,0 +1,48 @@
+Hecks.bluebook "Directory" do
+  vision "A staff directory: members once addressed by the name they walked in with, now by the email that actually identifies them one person to one row."
+  supporting
+
+  # THE EXACT REKEY docs/implemented/guides/schema-evolution.md's own
+  # worked example describes — `identified_by :name` becoming
+  # `identified_by :email` — landed for real: this domain's era 1 was
+  # genuinely `identified_by :name`, and translations/2-632545.bluebook
+  # is the one real `rekey` (and `compute`) edge this corpus has ever
+  # declared, minted against a real Postgres by spec/adapters/driven/
+  # postgres_era/directory_rekey_spec.rb — not a fixture invented for a
+  # doc page.
+  #
+  # THE DOMAIN'S OWN REASON TO REKEY, not a contrived one: two members
+  # can share a name (there are only so many "Chris"es), so `name` was
+  # never a safe identity to begin with — exactly the flaw pizzas'
+  # `Order` still carries (`identified_by :name` on the menu name
+  # itself) and schema-evolution.md's own rekey section names as the
+  # canonical reason this rule kind exists at all. Era 1 (held the
+  # first time this domain ever booted against Postgres, never
+  # committed — see the translation edge beside this file) declared
+  # `attribute :name, MemberName` and `identified_by :name`, no
+  # `email` at all. The edge's `compute` consumes that `name` into
+  # this era's `email`, and its `rekey` recomputes the identity from
+  # the SAME expression — not a `backfill` default, which can only
+  # ever supply ONE literal for every pre-existing row regardless of
+  # how many people it is actually standing in for.
+  aggregate "Member" do
+    description "One staff member, addressed by the email that is actually theirs alone."
+
+    attribute :title, MemberTitle
+    attribute :email, MemberEmail
+
+    identified_by :email
+
+    value_object("MemberTitle") { attribute :value, String }
+    value_object("MemberEmail") { attribute :value, String }
+
+    command "Enlist" do
+      goal "Add a member to the directory, addressed by their own email"
+
+      attribute :email, MemberEmail
+      attribute :title, MemberTitle
+
+      emits "MemberEnlisted"
+    end
+  end
+end

--- a/examples/directory/bluebook/directory.hecksagon
+++ b/examples/directory/bluebook/directory.hecksagon
@@ -1,0 +1,3 @@
+Hecks.hecksagon "Directory" do
+  Directory::Member.persisted_by("PostgresEra")
+end

--- a/examples/directory/bluebook/directory.world
+++ b/examples/directory/bluebook/directory.world
@@ -1,0 +1,7 @@
+Hecks.world "Directory" do
+  realm "Examples"
+
+  persisted_by("PostgresEra") do
+    database "postgres://localhost/hecks_directory"
+  end
+end

--- a/examples/directory/bluebook/translations/2-632545.bluebook
+++ b/examples/directory/bluebook/translations/2-632545.bluebook
@@ -1,0 +1,33 @@
+# THE ONE REAL `rekey` (and `compute`) EDGE THIS CORPUS DECLARES.
+# Era 1 (held the first time Directory ever booted against a real
+# Postgres, never committed — data/eras/ is gitignored the same way
+# pizzas' own era 1 is) was:
+#
+#   Hecks.bluebook "Directory" do
+#     aggregate "Member" do
+#       attribute :name,  MemberName
+#       attribute :title, MemberTitle
+#       identified_by :name
+#       value_object("MemberName")  { attribute :value, String }
+#       value_object("MemberTitle") { attribute :value, String }
+#     end
+#   end
+#
+# Two members sharing a name was always possible — `name` was never a
+# safe identity — so era 2 (directory.bluebook, right beside this
+# file) rekeys `Member` onto its email instead. Both rules below share
+# ONE expression on purpose: `rekey` explains the new IDENTITY, but
+# says nothing about the stored `email` ATTRIBUTE's own value for a
+# translated row (Lineage#translate never touches an entry's id, only
+# its state) — that is a separate question `compute` answers, and it
+# has to agree with the rekey's own SQL, not merely happen to for one
+# fixture row. A `backfill :email, default: "..."` cannot do this: one
+# literal default is right for at most one pre-existing member, wrong
+# for every other one a real directory would actually hold.
+Hecks.data_translation "Directory", from: "dffb74", to: "632545" do
+  aggregate "Member" do
+    compute "name", to: "email",
+            sql: "lower(regexp_replace((__s -> 'name') ->> 'value', '\\s+', '.', 'g')) || '@example.com'"
+    rekey sql: "lower(regexp_replace((__s -> 'name') ->> 'value', '\\s+', '.', 'g')) || '@example.com'"
+  end
+end

--- a/spec/adapters/driven/postgres_era/directory_rekey_spec.rb
+++ b/spec/adapters/driven/postgres_era/directory_rekey_spec.rb
@@ -1,0 +1,150 @@
+require "hecks"
+require "hecks/ports/persistence/plugins/era"
+require_relative "../../../support/postgres_probe"
+
+# examples/directory is the corpus's own real `rekey` (and `compute`)
+# example — the exact `identified_by :name` -> `identified_by :email`
+# story docs/implemented/guides/schema-evolution.md's rekey section
+# already describes, landed for real instead of only in a spec fixture
+# (lineage_spec.rb's own Roster/Person test proves the mechanism works,
+# but invents both eras and the edge inline — none of it lives in
+# examples/, so word_coverage_spec.rb's own corpus scan has never once
+# seen a real `rekey` declaration). This spec loads era 2's bluebook
+# AND the translation edge straight off disk — the same files a real
+# checkout ships — and mints them against a real Postgres, seeded with
+# several distinct historical records, not one hand-picked name: a
+# `backfill` default could only ever be right for at most one of them,
+# which is exactly why the committed edge uses `compute` instead (see
+# the edge file's own comment). Runs only when a Postgres server is
+# reachable — the shared probe in support/postgres_probe.rb, like every
+# other Postgres spec here.
+RSpec.describe "the Directory example's real rekey edge (examples/directory)",
+               io: true do
+  DIRECTORY_DB = "hecks_directory_rekey_spec".freeze
+  DOMAIN_ROOT = File.expand_path("../../../../examples/directory", __dir__).freeze
+
+  # Era 1, held the first time this domain ever booted against a real
+  # Postgres — never committed (data/eras/ is gitignored, same as
+  # pizzas' own era 1). Kept here, inline, as the historical record it
+  # actually is; directory.bluebook and its translation edge below are
+  # read from the real committed files, not reinvented for this spec.
+  ERA_1_SOURCE = <<~BLUEBOOK.freeze
+    Hecks.bluebook "Directory" do
+      aggregate "Member" do
+        attribute :name,  MemberName
+        attribute :title, MemberTitle
+
+        identified_by :name
+
+        value_object("MemberName")  { attribute :value, String }
+        value_object("MemberTitle") { attribute :value, String }
+      end
+    end
+  BLUEBOOK
+
+  ERA_2_SOURCE = File.read(File.join(DOMAIN_ROOT, "bluebook/directory.bluebook")).freeze
+  edge_files = Dir[File.join(DOMAIN_ROOT, "bluebook/translations/*.bluebook")]
+  raise "expected exactly one translation edge in examples/directory, found #{edge_files.size}" unless edge_files.size == 1
+
+  EDGE_SOURCE = File.read(edge_files.first).freeze
+
+  before(:all) do
+    skip "no reachable Postgres — start one to run this spec" unless PostgresProbe.available?
+
+    admin = PG.connect(dbname: "postgres")
+    admin.exec("DROP DATABASE IF EXISTS #{DIRECTORY_DB} WITH (FORCE)")
+    admin.exec("CREATE DATABASE #{DIRECTORY_DB}")
+    admin.close
+  end
+
+  after(:all) do
+    admin = PG.connect(dbname: "postgres")
+    admin.exec("DROP DATABASE IF EXISTS #{DIRECTORY_DB} WITH (FORCE)")
+    admin.close
+  end
+
+  def load_registry(source, translation_source: nil)
+    registry = Hecks::Runtime::Registry.new
+    loading = Hecks::Ports::Loading.bootstrap
+    file = Tempfile.new(["directory-rekey-", ".bluebook"])
+    file.write(source)
+    file.flush
+    Hecks.with_registry(registry) do
+      loading.load_library
+      Kernel.eval(source, TOPLEVEL_BINDING, file.path, 1)
+      eval(translation_source) if translation_source
+    end
+    registry
+  ensure
+    file&.close!
+  end
+
+  def check!(source, translation_source: nil)
+    registry = load_registry(source, translation_source: translation_source)
+    bluebook = registry.bluebooks.values.first
+    Hecks::Adapters::PostgresEra::LineageManager.check!(
+      registry: registry, bluebook: bluebook, current_text: source, settings: { database: DIRECTORY_DB }
+    )
+    registry
+  end
+
+  def adapter_for(registry)
+    member = registry.bluebooks.values.first.aggregate("Member")
+    Hecks::Adapters::PostgresEra.new(aggregate: member, settings: { database: DIRECTORY_DB, domain: "Directory" })
+  end
+
+  it "mints the committed edge — a real compute+rekey pair, agreeing on more than one row" do
+    registry = check!(ERA_1_SOURCE)
+    adapter = adapter_for(registry)
+    member = registry.bluebooks.values.first.aggregate("Member")
+
+    [
+      ["Ada Lovelace", "Engineer"],
+      ["Grace Hopper", "Rear Admiral"],
+      ["Grace Chen",   "Analyst"]
+    ].each do |name, title|
+      adapter.save(Hecks::Runtime::Instance.new(
+                     aggregate: member, id: name,
+                     state: { name: { "value" => name }, title: { "value" => title } }
+                   ))
+    end
+
+    # a rekey (like compute) is exempt from every per-record mechanical
+    # check but one — Layer 3's human-approved sample is the only other
+    # verification, so the mint refuses non-interactively without it
+    expect { check!(ERA_2_SOURCE, translation_source: EDGE_SOURCE) }.to raise_error(
+      Hecks::Runtime::WiringError, /this edge carries a compute or rekey rule/
+    )
+
+    drifted = load_registry(ERA_2_SOURCE, translation_source: EDGE_SOURCE)
+    db = PG.connect(dbname: DIRECTORY_DB)
+    lineage = Hecks::Adapters::PostgresEra::Lineage.new(db, "Directory")
+    lineage.record_approval!(
+      from: drifted.translations.first.from, to: drifted.translations.first.to,
+      edge_digest: Hecks::Translation::Audit.edge_digest(drifted.translations.first)
+    )
+    db.close
+
+    check!(ERA_2_SOURCE, translation_source: EDGE_SOURCE)
+
+    head = adapter_for(drifted)
+    {
+      "ada.lovelace@example.com" => ["Ada Lovelace", "Engineer"],
+      "grace.hopper@example.com" => ["Grace Hopper", "Rear Admiral"],
+      "grace.chen@example.com"   => ["Grace Chen", "Analyst"]
+    }.each do |email, (original_name, title)|
+      found = head.find(email)
+      expect(found).not_to be_nil, "expected #{original_name} to resolve under #{email}"
+      expect(found.email.to_h).to eq(value: email)
+      expect(found.title.to_h).to eq(value: title)
+      expect(head.find(original_name)).to be_nil
+    end
+
+    # the raw journal never rewrites — every row is still keyed by the
+    # name it was actually saved under
+    db = PG.connect(dbname: DIRECTORY_DB)
+    raw = db.exec("SELECT aggregate_id FROM hecks_journal_directory ORDER BY aggregate_id").map { |r| r["aggregate_id"] }
+    db.close
+    expect(raw).to eq(["Ada Lovelace", "Grace Chen", "Grace Hopper"])
+  end
+end

--- a/spec/corpus/directory.json
+++ b/spec/corpus/directory.json
@@ -1,0 +1,21 @@
+{
+  "name": "directory-parity",
+  "note": "One member enlisted, addressed by email — the identity examples/directory/bluebook/translations/2-632545.bluebook later rekeys onto for real.",
+  "domain": "examples/directory",
+  "expectations": {
+    "events": 1
+  },
+  "steps": [
+    {
+      "verb": "Directory::Member.Enlist",
+      "args": {
+        "email": {
+          "value": "ada.lovelace@example.com"
+        },
+        "title": {
+          "value": "Engineer"
+        }
+      }
+    }
+  ]
+}

--- a/spec/parser_parity_spec.rb
+++ b/spec/parser_parity_spec.rb
@@ -211,9 +211,24 @@ RSpec.describe "Rust parser parity (hecks-parse)", io: true do
   # they do — confirmed byte-exact against Ruby's own `ir.json` before
   # being added here rather than left in PENDING_MEMBERS to claim a
   # parser gap this domain does not actually have.
+  # "directory" — the corpus's own real `rekey`/`compute` example
+  # (`examples/directory/`, the schema-evolution guide's `identified_by
+  # :name` -> `identified_by :email` worked example, landed for real —
+  # see spec/adapters/driven/postgres_era/directory_rekey_spec.rb).
+  # Built entirely out of constructs pizzas'/roster's own byte-matched
+  # `.bluebook` already exercises (a plain aggregate, value objects, one
+  # command) — no `.hecksagon` of its own, either — so it round-trips
+  # the same way they do: confirmed byte-exact against Ruby's own
+  # `ir.json` before being added here, same discipline as every other
+  # promotion above, not left in PENDING_MEMBERS to claim a parser gap
+  # this domain does not actually have. (Its own translation edge under
+  # `bluebook/translations/` is a SEPARATE sub-language this file's own
+  # PARITY_CORPUS_MEMBERS enumeration never reaches — `bluebooks_in`
+  # only globs `bluebook/*.bluebook`, one level, the same way
+  # `spec/corpus_spec.rb`'s own `bluebook_in` does.)
   PENDING_MEMBERS = (PARITY_CORPUS_MEMBERS.map(&:first) -
                      %w[pizzas identity governance console_settings expression translation banking compliance roster
-                        chess bluebook_language] -
+                        chess directory bluebook_language] -
                      PARITY_FIXTURE_MEMBERS.map { |member| fixture_stem(member) })
                     .to_h { |stem| [stem, "Stage 1: parser not implemented yet — see rust/parser/src/parse/mod.rs"] }.freeze
 
@@ -238,7 +253,7 @@ RSpec.describe "Rust parser parity (hecks-parse)", io: true do
   # Derived the SAME way PARITY_CORPUS_MEMBERS itself is (`bluebook_in`/
   # `hecksagon_in`/`chapter_name_of`), not hand-listed, so this stays
   # honest if pizzas.bluebook's own file ever moves.
-  REAL_PARITY_MEMBERS = %w[pizzas banking compliance roster chess].to_h { |stem|
+  REAL_PARITY_MEMBERS = %w[pizzas banking compliance roster chess directory].to_h { |stem|
     domain = PARITY_EXAMPLE_ROOTS.find { |path| File.basename(path) == stem } or raise "no examples/#{stem} directory"
     bluebooks = bluebooks_in(domain)
     raise "#{domain} has no .bluebook" if bluebooks.empty?

--- a/spec/word_coverage_spec.rb
+++ b/spec/word_coverage_spec.rb
@@ -129,15 +129,17 @@ RSpec.describe "every live DSL word, used somewhere real" do
     line[0...index].count('"').odd?
   end
 
-  # Shared reasoning for 8 of the 9 Translation-family entries below —
-  # see the comment on the first of them for the full finding.
+  # Shared reasoning for 6 of the remaining 7 Translation-family entries
+  # below — see the comment on the first of them for the full finding.
   TRANSLATION_RULE_GAP =
     "no real translation edge in this corpus exercises this rule kind — " \
-    "examples/pizzas/bluebook/translations/2-77625c.bluebook (the one real " \
-    "translation this repository has) only exercises `aggregate ... was:` and " \
-    "`move ... to:`. `corpus_uses?`'s naive whole-token scan reports a false " \
-    "positive for this word regardless (see the comment on the first entry in " \
-    "this group), so this exemption also stands in for that scanner gap."
+    "examples/pizzas/bluebook/translations/2-77625c.bluebook and " \
+    "examples/directory/bluebook/translations/2-632545.bluebook (the two real " \
+    "translations this repository has) only exercise `aggregate ... was:`, " \
+    "`move ... to:`, `compute ... to:, sql:`, and `rekey sql:`. `corpus_uses?`'s " \
+    "naive whole-token scan reports a false positive for this word regardless " \
+    "(see the comment on the first entry in this group), so this exemption " \
+    "also stands in for that scanner gap."
 
   # UNREACHED ON PURPOSE, each naming why — the same shape
   # plurality_coverage_spec.rb's ALLOWED_SINGLETON is. Every entry here
@@ -251,33 +253,35 @@ RSpec.describe "every live DSL word, used somewhere real" do
     # Translation/TranslationAggregate — item #13's remaining builders.
     # `corpus_uses?` is a NAIVE whole-token scan (its own header already
     # names this risk) with no context awareness at all, and every one of
-    # these 9 words happens to collide with an UNRELATED real corpus use
+    # these words happens to collide with an UNRELATED real corpus use
     # of the same spelling: `retired`/`rename`/`convert`/`drop`/`retype`/
-    # `compute`/`rekey`/`backfill`/`unresolved` all appear as plain STRING
-    # VALUES inside lib/hecks/grammar/translation.bluebook's own
-    # unrelated `Rule.Kind` closed set (a pre-existing, different self-
-    # hosted "Translation" domain — governs proposing/executing/admitting
-    # individual rules for bin/evolve's scaffold tooling, never loaded
-    # into the same registry as this one) — plus `retired` also collides
-    # with the word "retired" appearing as a plain lifecycle STATUS
-    # STRING in banking.bluebook/expression.bluebook. Read and confirmed
-    # by hand, one file at a time, not assumed: `examples/pizzas/bluebook/
-    # translations/2-77625c.bluebook` is the one REAL translation this
-    # corpus has (a genuine `Hecks.data_translation "Pizzas", ... do
-    # aggregate "Order", was: "Pizza" do move ... end end` — which is why
-    # `data_translation (File)`, `aggregate (Translation)`, and `move
-    # (TranslationAggregate)` need no exemption here, all three genuinely
-    # covered), and it exercises exactly two of the nine rule words
-    # (`aggregate ... was:`, `move ... to:`). The other nine rule kinds
-    # this language admits have no real edge exercising them anywhere in
-    # this repository yet — a real gap in the CORPUS, not in the words.
+    # `backfill`/`unresolved` all appear as plain STRING VALUES inside
+    # lib/hecks/grammar/translation.bluebook's own unrelated `Rule.Kind`
+    # closed set (a pre-existing, different self-hosted "Translation"
+    # domain — governs proposing/executing/admitting individual rules
+    # for bin/evolve's scaffold tooling, never loaded into the same
+    # registry as this one) — plus `retired` also collides with the
+    # word "retired" appearing as a plain lifecycle STATUS STRING in
+    # banking.bluebook/expression.bluebook. Read and confirmed by hand,
+    # one file at a time, not assumed: `examples/pizzas/bluebook/
+    # translations/2-77625c.bluebook` and `examples/directory/bluebook/
+    # translations/2-632545.bluebook` are the two REAL translations
+    # this corpus has — a genuine `Hecks.data_translation "Pizzas", ...
+    # do aggregate "Order", was: "Pizza" do move ... end end`, and a
+    # genuine `Hecks.data_translation "Directory", ... do aggregate
+    # "Member" do compute "name", to: "email", sql: "..." ; rekey sql:
+    # "..." end end` — which is why `data_translation (File)`,
+    # `aggregate (Translation)`, `move (TranslationAggregate)`,
+    # `compute (TranslationAggregate)`, and `rekey (TranslationAggregate)`
+    # need no exemption here, all five genuinely covered. The remaining
+    # rule kinds this language admits have no real edge exercising them
+    # anywhere in this repository yet — a real gap in the CORPUS, not
+    # in the words.
     "retired (Translation)"                => TRANSLATION_RULE_GAP,
     "rename (TranslationAggregate)"        => TRANSLATION_RULE_GAP,
     "convert (TranslationAggregate)"       => TRANSLATION_RULE_GAP,
     "drop (TranslationAggregate)"          => TRANSLATION_RULE_GAP,
     "retype (TranslationAggregate)"        => TRANSLATION_RULE_GAP,
-    "compute (TranslationAggregate)"       => TRANSLATION_RULE_GAP,
-    "rekey (TranslationAggregate)"         => TRANSLATION_RULE_GAP,
     "backfill (TranslationAggregate)"      => TRANSLATION_RULE_GAP,
     "unresolved (TranslationAggregate)"    =>
                                               "same finding as the rest of this group, plus a second, independent reason: " \


### PR DESCRIPTION
…ion edge

Closes the audit's rekey gap: "no rekey anywhere in the example corpus... the most dangerous, least-gated translation rule kind is also the one with zero real-corpus exercise."

examples/directory is a small new example domain whose whole purpose is the exact identified_by :name -> identified_by :email rekey docs/implemented/guides/schema-evolution.md already describes as its worked example, landed for real:

- examples/directory/bluebook/translations/2-632545.bluebook is a genuine `rekey` + `compute` edge (paired on purpose — `rekey` explains the new identity, `compute` populates the `email` attribute itself from the same SQL, since a `backfill` default can only ever be right for one pre-existing row).
- spec/adapters/driven/postgres_era/directory_rekey_spec.rb mints this edge against a real Postgres, seeded with three distinct historical records (not one hand-picked name), and asserts the head resolves under derived emails, old ids are gone, and the raw journal is untouched.
- The edge's SQL is a general, deterministic name->email derivation, not a single-record CASE mapping — correct for N rows, unlike the existing lineage_spec.rb Roster/Person unit fixture's own single-record backfill coincidence (which it already footnotes).

Also, as a verified consequence:
- spec/word_coverage_spec.rb: removed the now-stale "no real corpus use" exemptions for `rekey` and `compute` (TranslationAggregate) — both are genuinely exercised now.
- spec/parser_parity_spec.rb: promoted "directory" from Stage-1-pending to REAL_PARITY_MEMBERS — hecks-parse's Rust parser already round-trips this domain byte-identical to Ruby's IR, same discipline as compliance/roster/chess's own promotions.
- spec/corpus/directory.json + README's generated corpus index, regenerated via bin/reference.

Full non-io suite (2210 examples) and the full io suite (299 examples) both pass.

## What and why

<!-- What changed, and the reasoning — the "why" a comment would carry
     in this codebase (see Gemfile, .rubocop.yml, .githooks/pre-push for
     the house style). Link an issue if there is one. -->

## Checklist

- [ ] `bundle exec rspec` passes
- [ ] `bundle exec rubocop -c .rubocop.yml` is clean
- [ ] Touched a `.bluebook`, the DSL builder, the runtime, or the IR? →
      `bin/model_check` and `bin/fuzz` are clean
- [ ] Added or changed a DSL keyword/argument? → `bin/doc_coverage` is
      clean, and `docs/implemented/reference/` has real prose (not the
      `TODO` sentinel) with a runnable example
- [ ] Edited a `ruby`-fenced example in the README or `docs/implemented/guides/`?
      → `bundle exec rspec spec/guides_spec.rb` passes
- [ ] Deliberately changed the builder's IR shape? → regenerated the
      golden IR with `GOLDEN=rewrite bundle exec rspec spec/ir_golden_spec.rb`
      and read the diff

## Anything not covered above

<!-- e.g. touches rust/project/*.rb and you ran the Rust build/coverage
     tools locally, or this is docs-only and none of the above applies. -->
