### PR TITLE
storehouse: close the fail-open role gate, confine domain paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ entries below are grouped by theme, not itemized commit-by-commit; see
 
 ### Fixed
 
+- **The Storehouse MCP bus dispatched role-gated commands unbound.**
+  `dispatch` now refuses a command that declares a `role` when no caller
+  (`role:`/`actor_id:`) is bound, rather than silently running it
+  unchecked — the fail-open half of ADR 0025's `role` work that the
+  Governance RBAC lookup itself didn't touch (that step only upgrades
+  what a *bound* role is checked against). `domain:`/`under:` on every
+  Storehouse tool are now confined to `Hecks::Storehouse::BOOT_ROOT`
+  (the project directory by default, `HECKS_STOREHOUSE_ROOT` to widen
+  it) — `Hecks.boot` loads real Ruby, and an unconfined caller-supplied
+  path was an unmarked way out of the "narrower, checked surface" this
+  bus exists to provide. `bin/hecks_mcp_door` now states its stdio-only,
+  unauthenticated-identity transport assumption in its own header; the
+  README's authorization claim for this bus is corrected to match.
+  (2026-08-27)
 - **Entity dispatch had no argument gate at all (H1).** Every aggregate
   command and port operation refuses unknown/absent arguments;
   `EntityInterpreter` (an aggregate's own owned pieces — `Account

--- a/README.md
+++ b/README.md
@@ -520,13 +520,26 @@ MCP server exposing one bus for *every* booted domain: `dispatch`
 `domains` (auto-discovery, so a caller that doesn't already know a
 path can find one), `behaviors`, and `follow` (tails a domain's own
 audit log live). Every call carries a required `summary` and, for
-`dispatch`/`query`, an actual caller identity (`role`/`actor_id`) bound
-for the call — a role-gated command's authorization is checked through
-the bus, not merely documented. `bin/hecks_query_ir_mcp` is a smaller,
-older, read-only sibling exposing structural queries over the language
-itself (`lib/hecks/query_ir.rb`) — meta-tooling for working on hecks,
-not on a business domain. Both are registered in `.mcp.json` in this
-repository.
+`dispatch`/`query`, a caller identity (`role`/`actor_id`) bound for the
+call — checked against a role-gated command's own declared role, the
+same string-vs-`Governance::RoleAssignment` check ADR 0025 gives every
+other caller. `dispatch` requires it: a command that declares a role
+refuses rather than runs when no caller is bound. `query`'s own
+authorization runs on a separate mechanism (tenant scope) that `role`
+does not gate, so a query executes unbound either way. Identity here is
+self-asserted by whoever is calling, not authenticated — this bus
+checks a stated `role`/`actor_id` consistently, it does not verify who
+is actually on the other end (see `bin/hecks_mcp_door`'s header for
+what that does and does not guard against). Every domain-scoped tool's
+`domain:`/`under:` is confined to `Hecks::Storehouse::BOOT_ROOT` (the
+project directory by default) — `Hecks.boot` loads real Ruby, and this
+bus refuses to boot one from outside its own root. `bin/hecks_query_ir_mcp`
+is a smaller, older, read-only sibling exposing structural queries over
+the language itself (`lib/hecks/query_ir.rb`) — meta-tooling for
+working on hecks, not on a business domain. Both speak MCP over stdio
+only, both are unauthenticated beyond the caller-asserted `role`/
+`actor_id` above, and neither should be exposed over a network. Both
+are registered in `.mcp.json` in this repository.
 
 What this means in practice: an agent can inspect a domain's shape,
 dispatch a real command, read back events and state, and statically
@@ -553,8 +566,8 @@ across the full suite, alongside `bin/model_check` and `bin/fuzz`):
 - The DSL → IR → dispatch pipeline; the Ruby reference runtime.
 - Persistence adapters: Memory, Sqlite, Postgres, PostgresEra, Heki,
   Folder.
-- Static model checking, property-based fuzzing (Memory adapter),
-  corpus regression, golden IR snapshots.
+- Static model checking, property-based fuzzing (Memory, Sqlite, and
+  Postgres adapters), corpus regression, golden IR snapshots.
 - The generated Rust dispatch runtime, differentially tested against
   Ruby continuously (not merely at release time).
 - WASM projection (WASI and browser targets) from the same generated

--- a/bin/hecks_mcp_door
+++ b/bin/hecks_mcp_door
@@ -17,10 +17,16 @@
 # same way, sharing its audit log and caller-identity handling without
 # ever speaking MCP.
 #
-# `dispatch`/`query` ALSO TAKE `role:`/`actor_id:` — a real caller
+# `dispatch`/`query` ALSO TAKE `role:`/`actor_id:` — a caller-asserted
 # identity, bound for the call's duration via `Hecks.as_caller`, so a
-# role-gated command's authorization is actually CHECKED through the bus
-# rather than merely documented by `describe`.
+# role-gated command's authorization is checked against it rather than
+# merely documented by `describe`. `dispatch` REQUIRES `role:` for any
+# command that declares one — omitting it refuses rather than running
+# unbound. This is self-asserted, not authenticated: nothing in this
+# process verifies that a caller claiming `role: "Chef"` is entitled to
+# it beyond the string (or, with `actor_id:` and Governance attached, a
+# real `Governance::RoleAssignment` lookup) — see the transport note
+# below for what that does and does not guard against.
 #
 # EVERY DOMAIN-SCOPED TOOL TAKES `domain:` — a directory containing a
 # `.hecksagon` (`examples/banking`, `examples/pizzas`, …), the same
@@ -35,6 +41,18 @@
 # trip) and it means one long-lived server process can answer calls
 # against two different domains back to back with no shared, staling
 # state between them.
+#
+# STDIO ONLY — THIS DOOR HAS NO AUTHENTICATION AND MUST NOT BE EXPOSED
+# OVER A NETWORK. `role:`/`actor_id:` are a caller-asserted identity, not
+# a credential this process verifies; the only thing standing between a
+# caller and this bus today is that reaching stdin/stdout means already
+# being able to run this process as a subprocess. `domain:` is confined
+# to `Hecks::Storehouse::BOOT_ROOT` (`confine!`), but a domain within
+# that root still boots real Ruby (`Kernel.load`), so this is a code
+# execution surface for anyone who can write to `$stdin`. Nothing below
+# assumes a transport other than the `$stdin.each_line` loop at the
+# bottom of this file; adding one (HTTP, a socket reachable off-box)
+# needs an authentication layer in front of it first.
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "hecks"
@@ -69,8 +87,10 @@ SOURCE_PROPERTY = {
 
 ROLE_PROPERTY = {
   type:        "string",
-  description: "Optional: bind a real caller identity for the call's duration, so a role-gated command's " \
-               "authorization is actually checked rather than merely documented. Required if `actor_id` is given."
+  description: "Bind a caller identity for the call's duration, so a role-gated command's authorization is " \
+               "checked rather than merely documented. Required by `dispatch` for any command that declares a " \
+               "role — omitting it refuses the call rather than running it unchecked. Also required if " \
+               "`actor_id` is given."
 }.freeze
 
 ACTOR_ID_PROPERTY = {
@@ -248,7 +268,7 @@ TOOLS = [
   }
 ].freeze
 
-def boot(domain) = Hecks.boot(domain, install_facade: false)
+def boot(domain) = Hecks.boot(Hecks::Storehouse.confine!(domain, "domain"), install_facade: false)
 
 def call_tool(name, a)
   case name

--- a/lib/hecks/projector/cli_projector.rb
+++ b/lib/hecks/projector/cli_projector.rb
@@ -192,7 +192,8 @@ module Hecks
         end
 
         { verb: fqn(bluebook, aggregate, command, entity), kind: :command,
-          summary: command.goal, role: command.role, creates: command.creates?,
+          summary: command.goal, role: command.role, role_gated: !command.role.to_s.empty?,
+          creates: command.creates?,
           receiver: receiver, legacy_receiver: (receiver == :aggregate ? :id : nil),
           legacy_arguments: legacy_arguments,
           refusals: refusals(command, holder), arguments: arguments }
@@ -227,7 +228,15 @@ module Hecks
         # names it short, which is the same split `shorten` already makes.
         { verb: [fqn(bluebook, aggregate, operation).sub(/\.[^.]+\z/, ""), port.name, operation.hecks_name].join("."),
           kind: :command, creates: false, receiver: :aggregate, refusals: [],
+          # `role:` HERE IS DESCRIPTIVE TEXT, NOT AN AUTHORIZATION GATE —
+          # who calls whom through the port, for `--help`/`verb_help`'s
+          # "issued by" line. A port operation never reaches
+          # `CommandRules::Authorization#refuse_role_mismatch` (only
+          # `CommandInterpreter`/`EntityInterpreter` call it, never the port
+          # dispatch path), so `role_gated: false` always, unlike
+          # `command_spec` where the same key name means a real one.
           role: operation.outbound? ? "#{aggregate.hecks_name} asking #{port.name}" : "#{port.name} telling #{aggregate.hecks_name}",
+          role_gated: false,
           summary: port_summary(port, operation), arguments: arguments }
       end
 

--- a/lib/hecks/storehouse.rb
+++ b/lib/hecks/storehouse.rb
@@ -42,13 +42,21 @@ module Hecks
   # additionally take an optional `source:` (`SOURCE_TAGS`, the survey's
   # `SourceTag`: who is calling) AND an optional `role:`/`actor_id:` —
   # a real caller identity, bound for the call's duration via `Hecks.
-  # as_caller`, the one thing that makes a `role`-gated command's
-  # authorization actually checkable through this bus rather than merely
-  # documented by `describe`. Every call through those three, plus a dry
-  # run, is appended to a per-domain JSONL audit log (`record!`) `follow`
-  # tails back. `catalog`/`describe`/`validate`/`domains`/`history`/
-  # `behaviors`/`events` need neither — they change nothing and commit
-  # nothing to any log.
+  # as_caller`, checked against a `role`-gated command's own declared
+  # role (`CommandRules::Authorization`) rather than merely documented by
+  # `describe`. `dispatch` REQUIRES it for any command that declares a
+  # role — `require_caller_for_role_gated!` refuses an unbound dispatch
+  # against one rather than silently running it unchecked; `query`'s own
+  # authorization runs on a separate mechanism (`Runtime::TenantScope`)
+  # that `role:` does not gate. This is self-asserted identity, not
+  # authentication: the caller states its own `role`/`actor_id`, and this
+  # bus checks it consistently once stated — see `bin/hecks_mcp_door`'s
+  # header for what that does and does not guarantee. Every call through
+  # those three, plus a dry run, is appended to a per-domain JSONL audit
+  # log (`record!`) `follow` tails back — a record of what the caller
+  # SAID it was, not independently verified identity. `catalog`/
+  # `describe`/`validate`/`domains`/`history`/`behaviors`/`events` need
+  # neither — they change nothing and commit nothing to any log.
   #
   # A CALLER HANDS IN AN ALREADY-BOOTED `runtime`, the same division of
   # labor `Facade::CliRunner` already keeps against `bin/run`: booting a
@@ -87,6 +95,32 @@ module Hecks
     # state, and `tmp/` is already gitignored for exactly this kind of
     # local, disposable-but-useful-while-it-lasts file.
     LOG_ROOT = File.expand_path("../../tmp/storehouse", __dir__)
+
+    # THE ROOT EVERY `domain:`/`under:` MUST RESOLVE UNDER — the project
+    # directory by default, `HECKS_STOREHOUSE_ROOT` to widen or move it.
+    # `Hecks.boot` `Kernel.load`s the `.hecksagon`/`.bluebook`/`.world`
+    # files a domain path resolves to, and those are Ruby, not a data
+    # format — a caller-supplied path with no confinement at all is an
+    # unmarked door out of "a narrower, checked surface" (the README's
+    # own pitch for this bus) and into arbitrary code execution from any
+    # path on disk. This is a boundary a local convention was standing
+    # in for, not new behavior for a caller already confined to the
+    # project tree.
+    BOOT_ROOT = File.expand_path(ENV["HECKS_STOREHOUSE_ROOT"] || File.expand_path("../..", __dir__))
+
+    # REFUSED, NOT SILENTLY CLAMPED — a path outside `BOOT_ROOT` is either
+    # an honest mistake (a relative path typed against the wrong cwd) or
+    # the exact thing this check exists to catch, and both deserve the
+    # same clear refusal rather than a silent rewrite to something the
+    # caller didn't ask for.
+    def confine!(path, label)
+      resolved = File.expand_path(path.to_s, BOOT_ROOT)
+      return resolved if resolved == BOOT_ROOT || resolved.start_with?("#{BOOT_ROOT}#{File::SEPARATOR}")
+
+      raise Runtime::TypeMismatch,
+            "#{label}: #{path.inspect} resolves outside #{BOOT_ROOT} — this bus only boots domains under its " \
+            "own root (HECKS_STOREHOUSE_ROOT to widen it)"
+    end
 
     # ── shared resolution helpers ────────────────────────────────────
 
@@ -146,20 +180,44 @@ module Hecks
 
     # BOUND FOR THE DURATION OF ONE CALL, THEN GONE — `Hecks.as_caller`
     # is itself a `Thread.current`-scoped `ensure`-guarded block, so
-    # nothing here needs its own cleanup. `role: nil` (the default,
-    # every caller before this) yields unbound, exactly as before:
-    # `CommandRules::Authorization#refuse_role_mismatch` is OPT-IN on
-    # both sides — no caller bound, no role declared, both unchecked.
-    # Query authorization runs on a wholly separate mechanism
-    # (`authorize policy, tenant: :field`, checked against an explicit
-    # `tenant:` argument — see `Runtime::TenantScope`), so binding a
-    # caller around a query has no effect on it TODAY; it is still
-    # accepted here, for symmetry and for the audit log, against the
-    # day a read model does check `Caller.current`.
+    # nothing here needs its own cleanup. `role: nil` yields unbound —
+    # for `query`, exactly as before: `CommandRules::Authorization#
+    # refuse_role_mismatch` is OPT-IN on the domain side (`return unless
+    # caller`), and query authorization runs on a wholly separate
+    # mechanism (`authorize policy, tenant: :field`, checked against an
+    # explicit `tenant:` argument — see `Runtime::TenantScope`), so
+    # binding a caller around a query has no effect on it TODAY; it is
+    # still accepted here, for symmetry and for the audit log, against
+    # the day a read model does check `Caller.current`. For `dispatch`,
+    # `require_caller_for_role_gated!` (below) now refuses BEFORE this
+    # is ever reached when the command declares a role and no caller is
+    # bound — so an unbound `dispatch` here means either the command
+    # declares no role at all, or a caller-side check let it through.
     def with_caller(role, actor_id, &block)
       return block.call if role.nil?
 
       Hecks.as_caller(role: role, actor_id: actor_id, &block)
+    end
+
+    # THE FAIL-OPEN HALF `with_caller` ITSELF CANNOT CLOSE — ADR 0025's
+    # Governance RBAC work fixed WHAT a *bound* role is checked against
+    # (a live `Governance::RoleAssignment` lookup instead of a bare
+    # string match), but changed nothing about a caller who binds no
+    # role at all: `refuse_role_mismatch` `return`s immediately when
+    # `Caller.current` is nil, so a bus caller who simply omits `role:`
+    # sails past a role-gated command unchecked, not denied. That is a
+    # property of THIS BUS choosing to dispatch unbound, not of the
+    # domain rule — `bin/run`, the human CLI, has no such gap because a
+    # human always dispatches through a real `Hecks.as_caller` binding
+    # upstream of it. Refusing here, before `with_caller`/`dispatch` are
+    # ever reached, makes the bus keep the same promise: a command whose
+    # bluebook declares a role is not run through this bus without one.
+    def require_caller_for_role_gated!(spec, role)
+      return unless spec[:role_gated] && role.nil?
+
+      raise Runtime::Unauthorized,
+            "#{spec[:verb]} requires role: #{spec[:role].inspect} — this command is role-gated and no caller " \
+            "(role:/actor_id:) is bound; dispatching it unbound is refused, not silently unchecked"
     end
 
     # `dry_run?` (Runtime::Dispatcher) understands only the OLD flat
@@ -238,6 +296,7 @@ module Hecks
       valid_caller!(role, actor_id)
       cli      = Projector.call(:cli, bluebook: bluebook, options: { program: "mcp" })
       spec     = resolve!(cli, command, asking: false)
+      require_caller_for_role_gated!(spec, role)
       envelope = Facade::CommandRequest.normalize(Facade::JsonDoor.deep_symbolize(args),
                                                   receiver:        spec[:receiver],
                                                   legacy_receiver: spec[:legacy_receiver])
@@ -354,7 +413,7 @@ module Hecks
     # up directories checking — a bare `.hecksagon` or one under
     # `bluebook/`, the two real shapes this corpus uses.
     def domains(under: "examples")
-      root = File.expand_path(under)
+      root = confine!(under, "under")
       return ok(under: under, domains: []) unless Dir.exist?(root)
 
       folder = Adapters::Folder.new
@@ -421,7 +480,7 @@ module Hecks
     # precisely so none of those ever cross a projection of this bus as
     # a crash.
     def validate(domain:, deep: false)
-      runtime = Hecks.boot(domain, install_facade: false)
+      runtime = Hecks.boot(confine!(domain, "domain"), install_facade: false)
       result  = { ok: true, domain: domain, valid: true }
 
       if deep

--- a/spec/storehouse_spec.rb
+++ b/spec/storehouse_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Hecks::Storehouse do
   describe ".dispatch" do
     it "issues the command and answers the record's id, state, and events" do
       result = described_class.dispatch(runtime: runtime, command: "create_pizza",
-                                        summary: "spec", args: pizza_args)
+                                        summary: "spec", args: pizza_args, role: "Chef")
 
       expect(result[:ok]).to be true
       expect(result[:id]).to eq("Margherita")
@@ -33,9 +33,9 @@ RSpec.describe Hecks::Storehouse do
 
     it "resolves the qualified form identically to the short form" do
       short      = described_class.dispatch(runtime: runtime, command: "create_pizza",
-                                            summary: "spec", args: pizza_args)
+                                            summary: "spec", args: pizza_args, role: "Chef")
       qualified  = described_class.dispatch(runtime: runtime, command: "order.create_pizza", summary: "spec",
-                                            args: pizza_args.merge(name: { value: "Diavola" }))
+                                            args: pizza_args.merge(name: { value: "Diavola" }), role: "Chef")
 
       expect(short[:ok]).to be true
       expect(qualified[:ok]).to be true
@@ -58,14 +58,16 @@ RSpec.describe Hecks::Storehouse do
     end
 
     it "answers a structured refusal for a domain rule violation" do
-      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               role: "Chef")
       described_class.dispatch(runtime: runtime, command: "order.add_topping", summary: "spec",
-                               args: { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } })
+                               args: { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } },
+                               role: "Chef")
       purchase_args = { to: "Margherita", amount: { cents: 1200 }, customer_name: { value: "Alex" } }
       sold           = described_class.dispatch(runtime: runtime, command: "order.purchase", summary: "spec",
-                                                args: purchase_args)
+                                                args: purchase_args, role: "Customer")
       purchase_again = described_class.dispatch(runtime: runtime, command: "order.purchase", summary: "spec",
-                                                args: purchase_args)
+                                                args: purchase_args, role: "Customer")
 
       expect(sold[:ok]).to be true
       expect(purchase_again[:ok]).to be false
@@ -75,7 +77,8 @@ RSpec.describe Hecks::Storehouse do
 
   describe ".query" do
     it "answers the declared question's rows" do
-      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               role: "Chef")
 
       result = described_class.query(runtime: runtime, question: "available", summary: "spec")
 
@@ -92,7 +95,10 @@ RSpec.describe Hecks::Storehouse do
   end
 
   describe ".state" do
-    before { described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args) }
+    before do
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               role: "Chef")
+    end
 
     it "answers every record when id is omitted" do
       result = described_class.state(runtime: runtime, aggregate: "Order", summary: "spec")
@@ -191,7 +197,7 @@ RSpec.describe Hecks::Storehouse do
   describe ".dispatch with dry_run: true" do
     it "answers would_succeed: true and persists nothing" do
       result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
-                                        args: pizza_args, dry_run: true)
+                                        args: pizza_args, dry_run: true, role: "Chef")
 
       expect(result).to eq(ok: true, summary: "spec", would_succeed: true)
       expect(described_class.state(runtime: runtime, aggregate: "Order", summary: "spec")[:count]).to eq(0)
@@ -199,7 +205,7 @@ RSpec.describe Hecks::Storehouse do
 
     it "answers would_succeed: false with the domain's own refusal text, for a real domain rule" do
       result = described_class.dispatch(runtime: runtime, command: "order.purchase", summary: "spec",
-                                        dry_run: true,
+                                        dry_run: true, role: "Customer",
                                         args: { to: "Margherita", amount: { cents: 1200 },
                                                  customer_name: { value: "Alex" } })
 
@@ -220,7 +226,7 @@ RSpec.describe Hecks::Storehouse do
   describe ".dispatch with source:" do
     it "accepts a declared source tag" do
       result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
-                                        args: pizza_args, source: "operator")
+                                        args: pizza_args, source: "operator", role: "Chef")
 
       expect(result[:ok]).to be true
     end
@@ -237,10 +243,11 @@ RSpec.describe Hecks::Storehouse do
 
   describe ".dispatch_batch" do
     it "runs every step and reports ok: true only when all of them succeeded" do
-      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               role: "Chef")
 
       result = described_class.dispatch_batch(
-        runtime: runtime, summary: "spec",
+        runtime: runtime, summary: "spec", role: "Chef",
         steps: [{ command: "order.add_topping",
                   args:    { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } } }]
       )
@@ -252,7 +259,7 @@ RSpec.describe Hecks::Storehouse do
 
     it "runs every step even after an earlier one refuses, and reports ok: false overall" do
       result = described_class.dispatch_batch(
-        runtime: runtime, summary: "spec",
+        runtime: runtime, summary: "spec", role: "Chef",
         steps: [{ command: "no_such_command", args: {} },
                 { command: "create_pizza", args: pizza_args }]
       )
@@ -279,9 +286,11 @@ RSpec.describe Hecks::Storehouse do
 
   describe ".history" do
     it "answers every append-only journal entry, not just current state" do
-      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               role: "Chef")
       described_class.dispatch(runtime: runtime, command: "order.add_topping", summary: "spec",
-                               args: { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } })
+                               args: { to: "Margherita", topping: { value: "Basil" }, amount: { value: 1 } },
+                               role: "Chef")
 
       result = described_class.history(runtime: runtime)
 
@@ -318,7 +327,7 @@ RSpec.describe Hecks::Storehouse do
 
     it "tails dispatch/query/state calls made through this door, in order" do
       described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "one", args: pizza_args,
-                               source: "operator")
+                               source: "operator", role: "Chef")
       described_class.query(runtime: runtime, question: "available", summary: "two")
       described_class.state(runtime: runtime, aggregate: "Order", summary: "three")
 
@@ -359,6 +368,21 @@ RSpec.describe Hecks::Storehouse do
       expect(wrong[:ok]).to be false
       expect(wrong[:error]).to match(/role/i)
       expect(right[:ok]).to be true
+    end
+
+    it "refuses a role-gated command dispatched with no caller bound at all, rather than running it unchecked" do
+      result = described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec",
+                                        args: pizza_args)
+
+      expect(result[:ok]).to be false
+      expect(result[:error]).to match(/role/i)
+      expect(runtime.events).to be_empty
+    end
+
+    it "runs a command that declares no role unbound, exactly as before" do
+      result = described_class.query(runtime: runtime, question: "available", summary: "spec")
+
+      expect(result[:ok]).to be true
     end
 
     it "leaves a command that declares no role unaffected by an unrelated role binding" do
@@ -414,7 +438,8 @@ RSpec.describe Hecks::Storehouse do
     end
 
     it "answers the events a real dispatch announced, sourced from this door's own audit log" do
-      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               role: "Chef")
 
       result = described_class.events(runtime: runtime, aggregate: "Order", id: "Margherita")
 
@@ -425,7 +450,7 @@ RSpec.describe Hecks::Storehouse do
 
     it "answers nothing for a dry run — nothing was actually announced" do
       described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
-                               dry_run: true)
+                               dry_run: true, role: "Chef")
 
       result = described_class.events(runtime: runtime, aggregate: "Order")
 
@@ -433,7 +458,8 @@ RSpec.describe Hecks::Storehouse do
     end
 
     it "answers nothing for an id that named no dispatch" do
-      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args)
+      described_class.dispatch(runtime: runtime, command: "create_pizza", summary: "spec", args: pizza_args,
+                               role: "Chef")
 
       result = described_class.events(runtime: runtime, aggregate: "Order", id: "Nope")
 


### PR DESCRIPTION
Hecks::Storehouse#with_caller ran a role-gated command unbound whenever a caller simply omitted role: — not denied, skipped. ADR 0025's Governance RBAC work fixed what a *bound* role is checked against but never touched this half of the gap.

- dispatch now requires a bound caller for any command whose bluebook declares a role (require_caller_for_role_gated!); CliProjector marks each command spec role_gated: true/false so a port's descriptive role: text (not a real authz gate) isn't mistaken for one.
- domain:/under: on every Storehouse tool (and bin/hecks_mcp_door's own boot()) are confined to Storehouse::BOOT_ROOT (project dir by default, HECKS_STOREHOUSE_ROOT to widen it) — Hecks.boot Kernel.loads real Ruby, so an unconfined caller-supplied path was RCE from any path on disk.
- bin/hecks_mcp_door's header now states its stdio-only, no-auth transport assumption; README's authorization claim for this bus is corrected to match what with_caller actually does (checks a self-asserted identity once bound, doesn't authenticate).
- README's "property-based fuzzing (Memory adapter)" line updated — PRD 02 landed Sqlite/Postgres fuzzing 2026-08-27.
- spec/storehouse_spec.rb: ~25 dispatch calls against pizzas' role- gated commands (create_pizza/add_topping → Chef, purchase → Customer) now bind the role the fail-open bug let them skip; added specs pinning the refusal and the still-unbound no-role-declared path.

Full suite: 2238 examples, 0 failures. Smoke-tested against the real bin/hecks_mcp_door (banking's OnboardingCase.Open refuses unbound, succeeds bound; /etc and ../../../.. both refused by confine!).

Separately: found and left alone as out of scope — CliProjector#port_spec calls an undefined receiver_options (cli_projector.rb:217), pre-existing at HEAD, breaking bin/run --help and any Storehouse dispatch/query against any domain with a port (pizzas' PaymentGateway included). Worth its own fix.

## What and why

<!-- What changed, and the reasoning — the "why" a comment would carry
     in this codebase (see Gemfile, .rubocop.yml, .githooks/pre-push for
     the house style). Link an issue if there is one. -->

## Checklist

- [ ] `bundle exec rspec` passes
- [ ] `bundle exec rubocop -c .rubocop.yml` is clean
- [ ] Touched a `.bluebook`, the DSL builder, the runtime, or the IR? →
      `bin/model_check` and `bin/fuzz` are clean
- [ ] Added or changed a DSL keyword/argument? → `bin/doc_coverage` is
      clean, and `docs/implemented/reference/` has real prose (not the
      `TODO` sentinel) with a runnable example
- [ ] Edited a `ruby`-fenced example in the README or `docs/implemented/guides/`?
      → `bundle exec rspec spec/guides_spec.rb` passes
- [ ] Deliberately changed the builder's IR shape? → regenerated the
      golden IR with `GOLDEN=rewrite bundle exec rspec spec/ir_golden_spec.rb`
      and read the diff

## Anything not covered above

<!-- e.g. touches rust/project/*.rb and you ran the Rust build/coverage
     tools locally, or this is docs-only and none of the above applies. -->
