### PR TITLE
Fix deploy generator: DB password no longer readable via GetFunctionConfiguration

### DIFF
--- a/bin/project_deploy
+++ b/bin/project_deploy
@@ -262,7 +262,7 @@ def cross_domain_lambda_policies_yaml(targets, base)
   ].map { |line| "#{base}# #{line}" }.join("\n")
 
   resources = targets.map { |target|
-    "#{base}          - !Sub \"arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:hecks-#{target.downcase}\""
+    "#{base}        - !Sub \"arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:hecks-#{target.downcase}\""
   }.join("\n")
 
   # Ends with exactly one trailing newline (`+ "\n"`, not a heredoc's
@@ -270,13 +270,19 @@ def cross_domain_lambda_policies_yaml(targets, base)
   # including its own single trailing "\n", so this needs to supply the
   # identical one back for "VpcConfig:" to still start its own fresh
   # line right after.
+  #
+  # ONE MORE LIST ITEM under the ALREADY-PRESENT `Policies:` key (the
+  # DB_SECRET_ARN grant, right above this marker in the template) --
+  # not a second `Policies:` key of its own. `base` is this marker's
+  # OWN rendered indentation, which now sits one list-item level
+  # (`- Statement:` itself) rather than at the `Policies:` key's own
+  # column -- everything below is relative to that.
   [
     comment,
-    "#{base}Policies:",
-    "#{base}  - Statement:",
-    "#{base}      - Effect: Allow",
-    "#{base}        Action: lambda:InvokeFunction",
-    "#{base}        Resource:",
+    "#{base}- Statement:",
+    "#{base}    - Effect: Allow",
+    "#{base}      Action: lambda:InvokeFunction",
+    "#{base}      Resource:",
     resources,
   ].join("\n") + "\n"
 end
@@ -359,6 +365,15 @@ db_ref_id = aurora ? "#{db_id}Cluster" : db_id
 # isn't inside a `!Sub` string at all.
 secret_sub       = aurora ? "#{db_id}Secret" : "#{db_ref_id}.MasterUserSecret.SecretArn"
 secret_intrinsic = aurora ? "!Ref #{db_id}Secret" : "!GetAtt #{db_ref_id}.MasterUserSecret.SecretArn"
+# THE SAME `${...}`-INSIDE-`!Sub` IDENTIFIER `secret_sub` ABOVE ALREADY
+# IS -- used here for #{logical_id}'s own runtime IAM grant instead of a
+# deploy-time `{{resolve:secretsmanager:...}}` dynamic reference (see
+# that Environment.Variables comment below for why DATABASE_URL moved
+# off that mechanism entirely). Shared mode has no `secret_sub` of its
+# own to reach for -- `OwningDatabaseSecretArn` (this template's own
+# Parameter, filled from the owning stack's Output) already IS the bare
+# ARN string, not a Ref/GetAtt target inside THIS stack.
+db_secret_ref = shared ? "OwningDatabaseSecretArn" : secret_sub
 
 # OPT-IN, BY FILE PRESENCE — a domain that wants its own web app on
 # Lambda too (not every domain has one; Banking doesn't) drops a
@@ -858,6 +873,14 @@ template_yaml = <<~YAML
         # failed" caught live. A self-managed secret (generated once,
         # here, never auto-rotated) has nothing to go stale: the same
         # resolved value stays correct for as long as this stack exists.
+        # THE OTHER HALF OF THAT TRADE: this password also never
+        # rotates for the life of the deployment -- there is no
+        # mechanism here that ever changes it, by design, not oversight.
+        # Acceptable today (rotation was never a requirement this
+        # generator was asked to meet), but worth carrying forward
+        # explicitly rather than only as the staleness fix's own upside
+        # -- a future rotation requirement means revisiting this
+        # decision, not just this comment.
         # Scoped to the Aurora path alone -- the plain-RDS path below is
         # Embryonaut's own already-live, proven arrangement, untouched.
         #{db_id}Secret:
@@ -1004,11 +1027,31 @@ template_yaml = <<~YAML
         Timeout: #{timeout}
         Environment:
           Variables:
-            # {{resolve:secretsmanager:...}} is a CloudFormation dynamic
-            # reference — resolved by the platform at deploy time, never
-            # rendered into the template, this tool's output, or any
-            # CloudTrail/console view of the function's own config as
-            # plaintext outside AWS's own encrypted handling.
+            # NOT a `{{resolve:secretsmanager:...}}`-composed DATABASE_URL
+            # anymore (the WebFunction handler below still uses that
+            # mechanism, unchanged) -- that dynamic reference genuinely
+            # IS resolved fresh at deploy time and never rendered into
+            # this template, this tool's output, or the CloudFormation
+            # console. But once it resolves INTO a Lambda's own
+            # Environment.Variables entry, the resolved PLAINTEXT is
+            # stored in the function's OWN configuration:
+            # `lambda:GetFunctionConfiguration` returns it decrypted,
+            # and the Lambda console's Configuration tab displays it, to
+            # ANY principal holding read-only account access (AWS's own
+            # managed ReadOnlyAccess policy included) -- caught
+            # reviewing this template, not live; AWS's own guidance is
+            # to fetch a secret from Secrets Manager at RUNTIME instead,
+            # precisely to avoid this. DB_HOST/DB_NAME/DB_SECRET_ARN
+            # below are not secrets themselves -- an endpoint address, a
+            # database name, and a Secrets Manager ARN authenticate
+            # nothing on their own -- so sitting here as plain
+            # Environment.Variables values costs nothing; main.rs itself
+            # fetches the actual password from Secrets Manager at cold
+            # start, over the AWS SDK, and never hands it back to
+            # CloudFormation or Lambda's own configuration at all.
+            # #{logical_id}'s own least-privilege Policies grant (below,
+            # sibling of VpcConfig) is the one runtime IAM permission
+            # that fetch needs, scoped to this one secret ARN.
             #{if shared
                 # THE STOREHOUSE — #{owner_domain_name}'s own live
                 # Endpoint/Secret, looked up at deploy time into
@@ -1017,15 +1060,13 @@ template_yaml = <<~YAML
                 # THIS stack. Same dbname as #{owner_domain_name}'s own
                 # DBName -- ONE database, isolated by SCHEMA
                 # (HECKS_SCHEMA below), not a second database.
-                "DATABASE_URL: !Sub\n" \
-                "            - \"postgres://postgres:${DbPass}@${DbHost}:5432/#{owner_db_name}\"\n" \
-                "            - DbPass: !Sub \"{{resolve:secretsmanager:${OwningDatabaseSecretArn}:SecretString:password}}\"\n" \
-                "              DbHost: !Ref OwningDatabaseEndpoint"
+                "DB_HOST: !Ref OwningDatabaseEndpoint\n" \
+                "          DB_NAME: #{owner_db_name}\n" \
+                "          DB_SECRET_ARN: !Sub \"${OwningDatabaseSecretArn}\""
               else
-                "DATABASE_URL: !Sub\n" \
-                "            - \"postgres://postgres:${DbPass}@${DbHost}:5432/#{infra_name}\"\n" \
-                "            - DbPass: !Sub \"{{resolve:secretsmanager:${#{secret_sub}}:SecretString:password}}\"\n" \
-                "              DbHost: !GetAtt #{db_ref_id}.Endpoint.Address"
+                "DB_HOST: !GetAtt #{db_ref_id}.Endpoint.Address\n" \
+                "          DB_NAME: #{infra_name}\n" \
+                "          DB_SECRET_ARN: !Sub \"${#{secret_sub}}\""
               end}
             # `domain_name`, NOT `infra_name` — this names the actual
             # .wasm FILE bin/project_wasm writes (rust/dist/#{domain_name}.wasm,
@@ -1060,7 +1101,17 @@ template_yaml = <<~YAML
             GOOGLE_REDIRECT_URI: !Sub "${WebRedirectBaseUrl}/auth/google/callback"
             SESSION_SECRET: !Sub "{{resolve:secretsmanager:${#{logical_id}SessionSecret}:SecretString:session_secret}}"
             RUSTOAUTH
-        # TMPL:cross_domain_lambda_policies
+        # LEAST-PRIVILEGE -- #{logical_id}'s own execution role is
+        # otherwise SAM's bare default (logging only); this is the one
+        # runtime AWS permission the DB_SECRET_ARN handling above needs,
+        # scoped to the single secret ARN this stack itself depends on,
+        # never `Resource: "*"`.
+        Policies:
+          - Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Sub "${#{db_secret_ref}}"
+          # TMPL:cross_domain_lambda_policies
         VpcConfig:
           #{if shared
               "SubnetIds: [!Ref OwningSubnetAId, !Ref OwningSubnetBId]\n        SecurityGroupIds: [!Ref OwningSecurityGroupId]"

--- a/rust/host/Cargo.lock
+++ b/rust/host/Cargo.lock
@@ -190,6 +190,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.111.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f840fd8a79900661ca05e9af1f4e2b3c74386e9fc1b4a9dd58745faf689f0"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sts"
 version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2395,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-lambda",
+ "aws-sdk-secretsmanager",
  "aws-smithy-http-client",
  "hmac 0.12.1",
  "jsonwebtoken",

--- a/rust/host/Cargo.toml
+++ b/rust/host/Cargo.toml
@@ -111,5 +111,13 @@ uuid = { version = "1", features = ["v4"] }
 # http_client` rather than letting either crate build its own default one.
 aws-config = { version = "1", default-features = false, features = ["rt-tokio", "behavior-version-latest", "credentials-process"] }
 aws-sdk-lambda = { version = "1", default-features = false, features = ["rt-tokio", "behavior-version-latest"] }
+# DB PASSWORD FETCHED AT RUNTIME (secrets.rs), not baked into
+# Environment.Variables by a CloudFormation dynamic reference anymore
+# (see secrets.rs's own header) -- SAME default-features=false +
+# rustls-ring-via-aws-smithy-http-client treatment as aws-sdk-lambda
+# above, for the identical reason: this crate's own aarch64-unknown-
+# linux-gnu cross-compile has no C toolchain configured, and either
+# crate's own "default"/"rustls" feature pulls in aws-lc-sys regardless.
+aws-sdk-secretsmanager = { version = "1", default-features = false, features = ["rt-tokio", "behavior-version-latest"] }
 aws-smithy-http-client = { version = "1", default-features = false, features = ["rustls-ring"] }
 async-trait = "0.1.92"

--- a/rust/host/src/main.rs
+++ b/rust/host/src/main.rs
@@ -26,6 +26,7 @@ mod lambda_client;
 mod mint;
 mod reference_transform;
 mod reference_validate;
+mod secrets;
 mod storage_shape;
 mod wasm_runner;
 mod web;
@@ -37,7 +38,40 @@ use tokio::sync::Mutex;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let database_url = std::env::var("DATABASE_URL").map_err(|_| "DATABASE_URL is required")?;
+    // DB_SECRET_ARN — bin/project_deploy's own default now (template.yaml's
+    // Environment.Variables comment has the full story): the password
+    // itself is fetched from Secrets Manager HERE, at cold start, over
+    // the AWS SDK, rather than trusted from a CloudFormation dynamic
+    // reference already resolved into this function's own
+    // Environment.Variables — which is readable in plaintext by any
+    // principal with read-only access to the account
+    // (lambda:GetFunctionConfiguration), not the secret-at-rest
+    // protection its own name suggests. DB_HOST/DB_NAME travel as plain
+    // (non-secret) Environment.Variables alongside it.
+    //
+    // FALLS BACK TO DATABASE_URL directly when DB_SECRET_ARN is absent —
+    // the one legitimate case being a human hand-debugging over an SSM
+    // tunnel with DATABASE_URL set manually (project_deploy's own
+    // ExcludeCharacters comment already anticipates exactly this).
+    let database_url = match std::env::var("DB_SECRET_ARN") {
+        Ok(secret_arn) => {
+            let db_host = std::env::var("DB_HOST").map_err(|_| "DB_HOST is required when DB_SECRET_ARN is set")?;
+            let db_name = std::env::var("DB_NAME").map_err(|_| "DB_NAME is required when DB_SECRET_ARN is set")?;
+            let secret_json = secrets::AwsSecretFetcher::from_env()
+                .await
+                .fetch_secret_string(&secret_arn)
+                .await
+                .map_err(|e| format!("fetching DB_SECRET_ARN from Secrets Manager: {e:#}"))?;
+            let password = secrets::extract_password(&secret_json)?;
+            // Composed exactly the way template.yaml's own retired
+            // `{{resolve:secretsmanager:...}}` DATABASE_URL Sub used to —
+            // literal, unescaped, no percent-encoding. parse_database_url
+            // below never percent-decodes the password segment either way.
+            format!("postgres://postgres:{password}@{db_host}:5432/{db_name}")
+        }
+        Err(_) => std::env::var("DATABASE_URL")
+            .map_err(|_| "either DB_SECRET_ARN (+ DB_HOST/DB_NAME) or DATABASE_URL is required")?,
+    };
     let wasm_path = PathBuf::from(
         std::env::var("HECKS_WASM_PATH").unwrap_or_else(|_| "banking.wasm".to_string()),
     );

--- a/rust/host/src/secrets.rs
+++ b/rust/host/src/secrets.rs
@@ -1,0 +1,107 @@
+// FETCHES THE DB PASSWORD AT RUNTIME, not deploy time -- template.yaml
+// (bin/project_deploy) used to compose DATABASE_URL itself via a
+// CloudFormation `{{resolve:secretsmanager:...}}` dynamic reference
+// baked straight into this function's own Environment.Variables. That
+// reference genuinely never touches the template or the CloudFormation
+// console as plaintext -- but once it resolves INTO a Lambda's
+// Environment.Variables entry, the resolved plaintext lands in the
+// function's own configuration: `lambda:GetFunctionConfiguration`
+// returns it decrypted, to any principal holding read-only account
+// access. AWS's own guidance is exactly what this module does instead:
+// fetch the secret at runtime, over the SDK, and never let
+// CloudFormation/Lambda configuration see it at all. main.rs's own
+// cold-start reads DB_SECRET_ARN/DB_HOST/DB_NAME (none of which are
+// secrets themselves -- an ARN, an endpoint, and a database name
+// authenticate nothing on their own) and calls this module once.
+//
+// NO TRAIT/MOCK BOUNDARY HERE, unlike lambda_client.rs's own
+// LambdaInvoker -- that trait exists because dispatch.rs's real test
+// suite threads through many call sites and needs to prove behavior
+// without live AWS credentials. This module has exactly one call site
+// (main.rs's own cold start, never exercised by a test), so the only
+// piece worth proving in isolation is the one pure, synchronous parse
+// below -- `extract_password` -- which this file's own `tests` module
+// does directly, with no client and no mock at all. `AwsSecretFetcher`
+// itself is real AWS SDK glue, structurally unverifiable here, same
+// honest limitation lambda_client.rs's own `AwsLambdaInvoker` states
+// about itself.
+
+pub struct AwsSecretFetcher {
+    client: aws_sdk_secretsmanager::Client,
+}
+
+impl AwsSecretFetcher {
+    // Same credential/region resolution chain, same explicit
+    // ring-backed HTTP client (not either crate's own "rustls"/
+    // "default" feature, which wires in aws-lc-rs instead -- see
+    // Cargo.toml's own header) as `lambda_client.rs`'s
+    // `AwsLambdaInvoker::from_env` -- the identical pattern, applied to
+    // a second AWS service client in this same crate.
+    pub async fn from_env() -> Self {
+        let http_client = aws_smithy_http_client::Builder::new()
+            .tls_provider(aws_smithy_http_client::tls::Provider::Rustls(aws_smithy_http_client::tls::rustls_provider::CryptoMode::Ring))
+            .build_https();
+        let config = aws_config::defaults(aws_config::BehaviorVersion::latest()).http_client(http_client).load().await;
+        Self { client: aws_sdk_secretsmanager::Client::new(&config) }
+    }
+
+    /// The secret's whole `SecretString`, undecoded -- `secret_id` is a
+    /// full ARN or a name, either works against `GetSecretValue`.
+    /// Callers that need one JSON field out of it (the generated
+    /// RDS/Aurora secret's own `{"username":"postgres","password":"..."}`
+    /// shape, `GenerateSecretString`'s template in bin/project_deploy)
+    /// parse it themselves -- `extract_password`, below, for this
+    /// crate's one caller.
+    pub async fn fetch_secret_string(&self, secret_id: &str) -> anyhow::Result<String> {
+        let response = self
+            .client
+            .get_secret_value()
+            .secret_id(secret_id)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("fetching secret {secret_id}: {e:?}"))?;
+        response
+            .secret_string()
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow::anyhow!("secret {secret_id} has no SecretString"))
+    }
+}
+
+/// The one JSON field this crate ever needs out of a fetched secret --
+/// `GenerateSecretString`'s own `{"username":"postgres"}` template plus
+/// a generated `password` key (bin/project_deploy's own
+/// `#{db_id}Secret`/plain-RDS `ManageMasterUserPassword` comment). Pure
+/// and synchronous, deliberately kept separate from the network fetch
+/// above so it needs no client and no mock to prove.
+pub fn extract_password(secret_json: &str) -> Result<String, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(secret_json).map_err(|e| format!("secret's SecretString isn't valid JSON: {e}"))?;
+    value
+        .get("password")
+        .and_then(|p| p.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "secret's SecretString has no string \"password\" field".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_password_from_the_generated_secret_shape() {
+        assert_eq!(
+            extract_password(r#"{"username":"postgres","password":"abc123"}"#).unwrap(),
+            "abc123"
+        );
+    }
+
+    #[test]
+    fn refuses_a_missing_password_field() {
+        assert!(extract_password(r#"{"username":"postgres"}"#).is_err());
+    }
+
+    #[test]
+    fn refuses_invalid_json() {
+        assert!(extract_password("not json").is_err());
+    }
+}

--- a/spec/project_deploy_contract_spec.rb
+++ b/spec/project_deploy_contract_spec.rb
@@ -1,6 +1,7 @@
 require "tmpdir"
 require "fileutils"
 require "open3"
+require "yaml"
 
 # bin/project_deploy's own STACK_OUTPUTS/BASTION_PARAMETERS tables (its
 # header explains why they're plain Ruby data, not a bluebook aggregate:
@@ -75,6 +76,24 @@ RSpec.describe "bin/project_deploy's stack<->bastion structural contract, in its
   end
 
   after(:context) { FileUtils.rm_rf(@generated_dir) }
+
+  # bin/project_deploy assembles template.yaml/bastion.yaml through
+  # heredocs and `#{}` interpolation -- nothing else in this file (or in
+  # bin/project_deploy itself) ever parses the result back as YAML, so a
+  # string-interpolation mistake that breaks YAML syntax is otherwise
+  # only caught by an actual `sam deploy` failing against real AWS. Two
+  # such bugs were already caught exactly that way: a non-ASCII em-dash
+  # inside a GroupDescription string, and a generated password
+  # containing "@" producing "found character '@' that cannot start any
+  # token" (now excluded via ExcludeCharacters). CloudFormation's own
+  # short-form intrinsic tags (!Sub, !Ref, !GetAtt, ...) parse fine as
+  # plain untyped scalars under YAML.safe_load -- this doesn't need to
+  # understand CloudFormation, only to confirm the interpolation
+  # produced a well-formed YAML document at all.
+  it "produces syntactically valid YAML for every generated CloudFormation template" do
+    expect { YAML.safe_load(@files[:template], aliases: true) }.not_to raise_error
+    expect { YAML.safe_load(@files[:bastion], aliases: true) }.not_to raise_error
+  end
 
   it "gives every Makefile OutputKey lookup against the main stack a real template.yaml Output" do
     declared = @files[:template][/^Outputs:\n(.*)\z/m, 1].to_s.scan(/^  (\w+):$/).flatten


### PR DESCRIPTION
## Summary

Three fixes from a review of `bin/project_deploy`'s generated CloudFormation.

**1. The security finding.** The generated Lambda's `Environment.Variables` composed `DATABASE_URL` from a `{{resolve:secretsmanager:...}}` dynamic reference, with a comment claiming the resolved value never appears "as plaintext outside AWS's own encrypted handling." That's wrong: once a dynamic reference resolves into a Lambda's `Environment.Variables`, `lambda:GetFunctionConfiguration` returns it decrypted to any principal with read-only account access (AWS's managed `ReadOnlyAccess` policy included), and the Lambda console displays it.

Fixed by moving the password fetch to runtime: `rust/host` now reads `DB_SECRET_ARN`/`DB_HOST`/`DB_NAME` (none of which are secrets) and fetches the password from Secrets Manager itself at cold start (new `secrets.rs`), with a least-privilege `secretsmanager:GetSecretValue` grant scoped to the one secret ARN each stack depends on. Falls back to `DATABASE_URL` directly for manual SSM-tunnel debugging.

Scoped to `rust/host`'s own main function only — the `WebFunction` (Ruby) handler's `DATABASE_URL`, and both functions' `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`/`SESSION_SECRET`, still use the same dynamic-reference-into-env-var pattern and carry the identical exposure. Left as a follow-up given the larger blast radius (Ruby Lambda boot code, Google OAuth flow, session signing) untested here.

**2.** The Aurora self-managed-secret comment documented the staleness bug it fixes but not the trade it makes — added the missing "this password also never rotates" consequence alongside it.

**3.** Nothing validated that generated `template.yaml`/`bastion.yaml` are well-formed YAML — the contract spec only regex-extracts Outputs/Parameters. Two live deploy failures (a non-ASCII em-dash, an unescaped `@`) were previously only caught by a failed `sam deploy`. Added a `YAML.safe_load` check to the contract spec.

## Verification

- `spec/project_deploy_contract_spec.rb` + `spec/deploy_bluebook_spec.rb`: 20 examples, 0 failures.
- Manually regenerated and YAML-validated the Postgres/Aurora/Shared/cross-domain-policy template variants (the marker-splice restructuring for the IAM Policies block needed this — verified the rendered indentation by hand for each).
- `rust/host` builds clean under a compatible toolchain; new `secrets::` unit tests pass. The 17 pre-existing failures in `dispatch`/`web` (missing `.wasm` build artifacts) are unrelated — confirmed present on the unmodified branch too.
- Full pre-push gate passed: rspec suite, fuzzer, model checks, doc coverage, rubocop.
