### PR TITLE
Context Mapping: check Shared Kernel / Customer-Supplier relationships

### DIFF
--- a/bin/model_check
+++ b/bin/model_check
@@ -58,14 +58,22 @@ def boot(source)
                 end
     Kernel.load(hecksagon) if hecksagon && File.exist?(hecksagon)
   end
-  registry.bluebooks.values
+  registry
 end
 
-def examine(name, source)
+# `known_domains:` — every bluebook/hecksagon name booted ANYWHERE across
+# this run, not just this one target — see `boot_all`'s own comment for
+# how it's built. `nil` for the single-target CLI form (`bin/model_check
+# some/domain`), where only that one target's own boot is ever seen —
+# a real, accepted reduction in the cross-domain check's own reach for
+# that narrower form, not a bug.
+def examine(name, registry, known_domains: nil)
   puts "── #{name}"
 
-  chapters = boot(source)
-  findings = chapters.flat_map { |chapter| Hecks::Bluebook::ModelCheck.call(chapter) }
+  chapters = registry.bluebooks.values
+  findings = chapters.flat_map do |chapter|
+    Hecks::Bluebook::ModelCheck.call(chapter, hecksagon: registry.hecksagon(chapter.name), known_domains: known_domains)
+  end
 
   allowed = Hecks::Bluebook::ModelCheck::ALLOWED_FINDINGS.fetch(name, [])
   matched, findings = findings.partition { |f| allowed.include?([f.kind, f.subject]) }
@@ -127,13 +135,26 @@ grammar_chapters = Dir.glob("#{ROOT}/lib/hecks/grammar/*.bluebook").sort
 framework_members = Dir.glob("#{ROOT}/lib/hecks/framework/bluebook/*.bluebook").sort
 
 if domain_arg
-  ok = examine(File.basename(domain_arg.chomp("/")), bluebook_in(domain_arg.chomp("/")) || domain_arg)
+  registry = boot(bluebook_in(domain_arg.chomp("/")) || domain_arg)
+  ok = examine(File.basename(domain_arg.chomp("/")), registry)
 else
   targets = example_domains.map { |d| [File.basename(d), bluebook_in(d)] }.reject { |_, s| s.nil? } +
             grammar_chapters.map { |c| [File.basename(c, ".bluebook"), c] } +
             framework_members.map { |m| [File.basename(m, ".bluebook"), m] }
 
-  ok = targets.reduce(true) { |all_ok, (name, source)| examine(name, source) && all_ok }
+  # TWO PASSES OVER THE SAME BOOTS, not two boots — PASS 1 boots every
+  # target once (booting is the expensive part) and accumulates every
+  # bluebook/hecksagon name any of them declares into ONE corpus-wide
+  # set; PASS 2 re-examines each already-booted registry against that
+  # NOW-COMPLETE set, so a cross-domain check on the FIRST target
+  # examined still sees the LAST target's own domain names too — the
+  # exact reason a single boot's own registry (Compliance never loaded
+  # in the same registry as Banking, by design) cannot answer "does
+  # this target domain exist anywhere in the corpus" on its own.
+  booted = targets.map { |name, source| [name, boot(source)] }
+  known_domains = booted.flat_map { |_, registry| registry.bluebooks.keys + registry.hecksagons.keys }.to_set
+
+  ok = booted.reduce(true) { |all_ok, (name, registry)| examine(name, registry, known_domains: known_domains) && all_ok }
   ok = examine_language && ok
 end
 

--- a/docs/implemented/reference/hecksagon.md
+++ b/docs/implemented/reference/hecksagon.md
@@ -68,6 +68,41 @@ nothing at all:
 runtime.registry.bluebook("Banking").policies.map(&:event_name).include?("AccountFreezeReviewOpened")  # => false
 ```
 
+**Checked, not routed.** `subscribe` still dispatches nothing at
+runtime — the example just above proves that, and it stays true. What
+changed is that it is now checked at model-check time: a cross-domain
+`policy ... across: "X"` with nothing acknowledging `X` (neither
+`subscribe "X.*"` nor `uses_framework "X"`) is a real, static finding
+(`:unacknowledged_relationship`, `Hecks::Bluebook::ModelCheck`). Banking's
+own `subscribe "Compliance.AccountFreezeReviewOpened"` line, above, is
+exactly what makes its `across "Compliance"` policy clean:
+
+```ruby
+require "hecks/bluebook/model_check"
+banking      = runtime.registry.bluebook("Banking")
+hecksagon    = runtime.registry.hecksagon("Banking")
+compliance_policy = banking.policies.find { |p| p.target_domain == "Compliance" }
+Hecks::Bluebook::ModelCheck.call(banking, hecksagon: hecksagon).map(&:subject).include?(compliance_policy.name)  # => false
+```
+
+Remove the acknowledgment and the SAME policy is flagged — this is what
+finally gives `subscribe` real teeth, without giving it real dispatch
+behavior:
+
+```ruby
+# A PLAIN Hecksagon, built directly rather than through Hecks.hecksagon
+# (which only runs inside a boot) — no subscribe, no uses_framework, so
+# Compliance goes unacknowledged.
+unacknowledging = Hecks::Bluebook::Hecksagon.new(domain: "Banking")
+findings = Hecks::Bluebook::ModelCheck.call(banking, hecksagon: unacknowledging)
+findings.find { |f| f.subject == compliance_policy.name }.kind  # => :unacknowledged_relationship
+```
+
+See `docs/implemented/reference/policy.md`'s own `## across` section for
+the other half — `uses_framework` and `across` on the SAME target
+(`:contradictory_relationship`) — and the model-checker's own file for
+why this needs no new keyword at all.
+
 ## uses_framework
 
 <!-- generated:begin word=uses_framework -->

--- a/docs/implemented/reference/policy.md
+++ b/docs/implemented/reference/policy.md
@@ -101,6 +101,7 @@ Kernel.load(File.join(InMemoryDomain::ROOT, "examples/compliance/bluebook/compli
 
 Hecks.hecksagon("Banking") do
   uses_framework "Governance"
+  subscribe "Compliance.AccountFreezeReviewOpened"
   Banking::Customer.persisted_by("Memory")
   Banking::Account.persisted_by("Memory")
 end
@@ -234,6 +235,22 @@ the fully-qualified command the runtime actually dispatched:
 
 ```ruby
 runtime.registry.reaction_log.first[:trigger]  # => "Compliance::AccountFreezeReview.Open"
+```
+
+`across` is a real relationship declaration now, not just a routing
+detail — `Hecks::Bluebook::ModelCheck` checks it against the sibling
+hecksagon's own `subscribe`/`uses_framework` lines (see
+`docs/implemented/reference/hecksagon.md`'s own "Checked, not routed"
+section for the other half). Banking's real corpus is clean here — its
+own `subscribe "Compliance.AccountFreezeReviewOpened"` is exactly what
+acknowledges `ReviewOnFreeze`'s `across "Compliance"`:
+
+```ruby
+require "hecks/bluebook/model_check"
+banking  = runtime.registry.bluebook("Banking")
+review_on_freeze = banking.policies.find { |p| p.target_domain == "Compliance" }
+findings = Hecks::Bluebook::ModelCheck.call(banking, hecksagon: runtime.registry.hecksagon("Banking"))
+findings.any? { |f| f.subject == review_on_freeze.name }  # => false
 ```
 
 ## where

--- a/lib/hecks/bluebook/model_check.rb
+++ b/lib/hecks/bluebook/model_check.rb
@@ -46,18 +46,51 @@ module Hecks
       # states), so a state nothing ever transitions into or out of no
       # longer exists to be unreachable — the finding this allowlisted
       # cannot occur any more, by construction.
-      ALLOWED_FINDINGS = {}.freeze
+      #
+      # "banking"/NotifyOnClosure, FlagKeyReturn — real, confirmed
+      # findings, not bugs to fix. `across "Notifications"` names a
+      # domain that does not exist anywhere in this repo — no
+      # Notifications bluebook, no hecksagon, nothing to `uses_framework`
+      # or `subscribe` to. This is deliberate: `spec/runtime/policy_spec.
+      # rb` (a test literally named "records a reaction it cannot
+      # deliver rather than swallowing it") and `lib/hecks/runtime/
+      # errors.rb`'s own `UnknownVerb` comment both treat "target domain
+      # not loaded" as the EXPECTED outcome for it — Notifications is
+      # used on purpose to exercise the undelivered-reaction runtime
+      # path, not left half-built. There is no real `subscribe` line to
+      # add (no event of Notifications' own to name) and no real domain
+      # to point `uses_framework` at.
+      ALLOWED_FINDINGS = {
+        "banking" => [
+          [:unacknowledged_relationship, "NotifyOnClosure"],
+          [:unknown_target_domain, "NotifyOnClosure"],
+          [:unacknowledged_relationship, "FlagKeyReturn"],
+          [:unknown_target_domain, "FlagKeyReturn"]
+        ]
+      }.freeze
 
       module_function
 
-      def call(bluebook)
+      # `hecksagon:`/`known_domains:` — both optional, both `nil`-safe
+      # (every existing caller with no sibling hecksagon, or checking one
+      # domain in isolation, behaves exactly as before). `hecksagon` is
+      # THIS bluebook's own sibling wiring file, if the caller loaded one
+      # (see `emitted_events`'s own comment on why a caller that didn't
+      # simply finds none, correctly). `known_domains` is the caller's
+      # OWN corpus-wide view — every bluebook/hecksagon name it has
+      # booted anywhere, across every domain it has looked at, not just
+      # this one — used only to catch a typo'd `across`/`uses_framework`
+      # target; see `cross_domain_policy_findings`'s own comment for why
+      # this can only ever be a corpus-scoped heuristic, never a general
+      # correctness guarantee.
+      def call(bluebook, hecksagon: nil, known_domains: nil)
         findings = []
         bluebook.aggregates.each do |aggregate|
           findings.concat(lifecycle_findings(aggregate, aggregate))
           aggregate.entities.each { |entity| findings.concat(lifecycle_findings(aggregate, entity)) }
         end
         bluebook.process_managers.each { |pm| findings.concat(saga_findings(bluebook, pm)) }
-        bluebook.policies.each { |policy| findings.concat(policy_findings(bluebook, policy)) }
+        bluebook.policies.each { |policy| findings.concat(policy_findings(bluebook, policy, hecksagon, known_domains)) }
         findings
       end
 
@@ -240,8 +273,8 @@ module Hecks
 
       # ── policies ───────────────────────────────────────────────────────
 
-      def policy_findings(bluebook, policy)
-        return [] if policy.target_domain # cross-domain: CommandRules skips it too; so does this checker.
+      def policy_findings(bluebook, policy, hecksagon, known_domains)
+        return cross_domain_policy_findings(policy, hecksagon, known_domains) if policy.target_domain
 
         emitted = emitted_events(bluebook)
         findings = []
@@ -271,6 +304,83 @@ module Hecks
           findings << Finding.new(kind: :unknown_trigger, severity: :error, subject: policy.name,
                                   message: "trigger #{policy.trigger_command.inspect} resolves to no command " \
                                            "this domain declares")
+        end
+
+        findings
+      end
+
+      # ── cross-domain policies (Context Mapping) ───────────────────────
+      #
+      # `uses_framework "X"` already IS a Shared Kernel relationship — it
+      # merges X's own bluebook into THIS registry, no boundary. A cross-
+      # domain `policy ... across: "X"` already IS a Customer/Supplier
+      # relationship — it dispatches into X over real cross-Lambda RPC in
+      # the Rust host (`rust/host/src/lambda_client.rs`). Neither is a new
+      # word; this makes the CHOICE between them checked instead of a
+      # prose comment nobody enforces (`examples/banking/bluebook/
+      # banking.hecksagon`'s own hand-written note explaining why
+      # Compliance is reached via `across`, never `uses_framework`).
+      #
+      # NO NEW KEYWORD ANYWHERE — ADR 0025 principle 1 ("one idea, one
+      # spelling") refuses a `relationship:`/`as:` argument that would
+      # just restate, as a string, the fact the chosen keyword (
+      # `uses_framework` vs `across`) already states completely. The
+      # DDD vocabulary (Shared Kernel, Customer/Supplier) lives here, in
+      # the finding's own name and this comment, and in prose docs — not
+      # in the grammar.
+      def cross_domain_policy_findings(policy, hecksagon, known_domains)
+        return [] unless hecksagon # no sibling hecksagon loaded — nothing to check a relationship against.
+
+        target = policy.target_domain
+        findings = []
+
+        if hecksagon.framework_members.include?(target)
+          # SHARED KERNEL AND CUSTOMER/SUPPLIER ARE MUTUALLY EXCLUSIVE
+          # CLAIMS about the SAME target — `uses_framework` means "X is
+          # loaded in-process, right here"; `across` means "X is a
+          # separate deployment, reached only by RPC." Declaring both is
+          # either a pointless RPC to a domain already local, or a
+          # `uses_framework` that isn't really doing what its name says.
+          findings << Finding.new(kind: :contradictory_relationship, severity: :error, subject: policy.name,
+                                  message: "across #{target.inspect} dispatches over RPC (Customer/Supplier), " \
+                                           "but this hecksagon also uses_framework #{target.inspect} (Shared " \
+                                           "Kernel) — #{target} is already loaded in-process here, so the two " \
+                                           "relationship declarations contradict each other for the same " \
+                                           "target domain")
+        elsif hecksagon.subscriptions.none? { |subscribed| Naming.qualifier(subscribed) == target }
+          # THIS IS WHAT FINALLY GIVES `subscribe` REAL TEETH — checked
+          # here, at model-check time, still never routed at runtime
+          # (nothing dispatches off a `subscribe` line; see hecksagon.md's
+          # own "checked, not routed" section). ADR 0025 names `subscribe`
+          # by number as failing the corpus-use bar; this is the real use.
+          findings << Finding.new(kind: :unacknowledged_relationship, severity: :error, subject: policy.name,
+                                  message: "across #{target.inspect} declares a Customer/Supplier " \
+                                           "relationship, but nothing in this hecksagon records the " \
+                                           "expectation — add subscribe \"#{target}.SomeEvent\" for what " \
+                                           "you expect back from it, or uses_framework #{target.inspect} to " \
+                                           "attach it in-process instead")
+        end
+
+        # TYPO DETECTION, DELIBERATELY WEAKER — `known_domains` can only
+        # ever be a MONOREPO-SCOPED heuristic: a real external hecks
+        # consumer's own domain (this repo's own embryonaut/lifeadelics-
+        # shaped case) lives in a genuinely separate repository this
+        # corpus scan can never see, so a target this check cannot find
+        # is "unknown to THIS corpus," never proof of a typo. Two real,
+        # legitimate reasons a target is unresolvable — genuinely
+        # undefined by design (the corpus's own "Notifications," used
+        # deliberately to exercise the undelivered-reaction runtime path)
+        # and real-but-external (a separate repository) — both go in
+        # `ALLOWED_FINDINGS`, the same judged-exception mechanism this
+        # file already uses for ExternalSettlement, rather than a new
+        # keyword invented to declare "this one's fine."
+        if known_domains && !known_domains.include?(target)
+          findings << Finding.new(kind: :unknown_target_domain, severity: :error, subject: policy.name,
+                                  message: "across #{target.inspect} names a domain nowhere in the corpus " \
+                                           "this check has booted — a typo, or a real domain intentionally " \
+                                           "outside this corpus (undefined by design, or living in a " \
+                                           "separate repository) belongs in ALLOWED_FINDINGS, named and " \
+                                           "explained, not silently assumed correct")
         end
 
         findings

--- a/spec/fixtures/model_check/relationship_findings.bluebook
+++ b/spec/fixtures/model_check/relationship_findings.bluebook
@@ -1,0 +1,46 @@
+Hecks.bluebook "RelationshipFindings" do
+  vision "Three cross-domain policies — unacknowledged, contradictory, and clean."
+  core
+
+  aggregate "Thing" do
+    identified_by :number
+
+    attribute :number, Number
+
+    value_object "Number" do
+      attribute :value, String
+    end
+
+    command "Do" do
+      role "Tester"
+      goal "A real local command, so trigger has something true to resolve"
+      emits "ThingDone"
+    end
+  end
+
+  # UNACKNOWLEDGED: across "Elsewhere" with nothing in the sibling
+  # hecksagon recording the expectation (no uses_framework, no subscribe).
+  policy "OnElsewhere" do
+    on      "ThingDone"
+    trigger Elsewhere::SomeCommand
+    across  "Elsewhere"
+  end
+
+  # CONTRADICTORY: across "Governance" while the sibling hecksagon ALSO
+  # uses_framework "Governance" — mutually exclusive relationship claims
+  # about the same target (Shared Kernel AND Customer/Supplier at once).
+  policy "OnGovernance" do
+    on      "ThingDone"
+    trigger Governance::SomeCommand
+    across  "Governance"
+  end
+
+  # CLEAN: across "Known" with a matching subscribe "Known.*" in the
+  # sibling hecksagon — the well-formed case, proving the checker does
+  # not false-positive it.
+  policy "OnKnown" do
+    on      "ThingDone"
+    trigger Known::SomeCommand
+    across  "Known"
+  end
+end

--- a/spec/fixtures/model_check/relationship_findings.hecksagon
+++ b/spec/fixtures/model_check/relationship_findings.hecksagon
@@ -1,0 +1,6 @@
+Hecks.hecksagon "RelationshipFindings" do
+  uses_framework "Governance"
+  subscribe "Known.SomethingHappened"
+
+  RelationshipFindings::Thing.persisted_by("Memory")
+end

--- a/spec/model_check_spec.rb
+++ b/spec/model_check_spec.rb
@@ -29,12 +29,20 @@ RSpec.describe "the model checker" do
                   end
       Kernel.load(hecksagon) if hecksagon && File.exist?(hecksagon)
     end
-    registry.bluebooks.values.first
+    registry
+  end
+
+  # `boot` now returns the REGISTRY, not the bluebook directly — every
+  # caller needs `registry.hecksagon(bluebook.name)` too, to exercise the
+  # cross-domain relationship findings.
+  def call_model_check(registry, known_domains: nil)
+    bluebook = registry.bluebooks.values.first
+    Hecks::Bluebook::ModelCheck.call(bluebook, hecksagon: registry.hecksagon(bluebook.name), known_domains: known_domains)
   end
 
   def findings_for(name)
     path = File.join(ROOT_DIR, "spec/fixtures/model_check/#{name}.bluebook")
-    Hecks::Bluebook::ModelCheck.call(boot(path))
+    call_model_check(boot(path))
   end
 
   def has?(findings, kind, subject)
@@ -129,6 +137,40 @@ RSpec.describe "the model checker" do
     end
   end
 
+  describe "relationship findings (Context Mapping)" do
+    let(:findings) { findings_for("relationship_findings") }
+
+    it "finds an across: with nothing in the sibling hecksagon acknowledging it" do
+      finding = findings.find { |f| f.kind == :unacknowledged_relationship && f.subject == "OnElsewhere" }
+      expect(finding.message).to include('across "Elsewhere"')
+    end
+
+    it "finds a domain both uses_framework'd (Shared Kernel) AND reached via across (Customer/Supplier)" do
+      finding = findings.find { |f| f.kind == :contradictory_relationship && f.subject == "OnGovernance" }
+      expect(finding.message).to include('across "Governance"').and include('uses_framework "Governance"')
+    end
+
+    it "does not flag a well-formed across: matched by a subscribe — OnKnown is clean" do
+      expect(findings.map(&:subject)).not_to include("OnKnown")
+    end
+
+    it "raises no finding kind outside the ones this fixture deliberately triggers" do
+      expect(findings.map(&:kind).uniq.sort).to eq(%i[contradictory_relationship unacknowledged_relationship].sort)
+    end
+
+    it "checked, not routed — no sibling hecksagon at all means no cross-domain finding either way" do
+      # `findings_for` loads the fixture's OWN sibling `.hecksagon`
+      # (`boot`'s own comment) — this proves the inverse directly: a
+      # bluebook with a cross-domain policy but genuinely NO sibling
+      # hecksagon (every other model_check fixture's own shape) raises
+      # neither new finding, the same `return [] unless hecksagon` guard
+      # `policy_findings.bluebook`'s own OnArchive/OnWrite already prove
+      # for the pre-existing same-domain checks.
+      no_hecksagon_findings = call_model_check(boot(File.join(ROOT_DIR, "spec/fixtures/model_check/policy_findings.bluebook")))
+      expect(no_hecksagon_findings.map(&:kind)).not_to include(:contradictory_relationship, :unacknowledged_relationship)
+    end
+  end
+
   # THE COVERAGE GATE. `bin/model_check` runs this same walk over every
   # example domain, every grammar chapter, and the language itself — the
   # spec keeps that corpus finding-free by holding it to bin/model_check's
@@ -161,9 +203,34 @@ RSpec.describe "the model checker" do
     # The SAME constant bin/model_check reads — one table, not a copy.
     MODEL_CHECK_ALLOWED = Hecks::Bluebook::ModelCheck::ALLOWED_FINDINGS
 
+    # TWO PASSES OVER THE SAME BOOTS — the identical structure
+    # bin/model_check's own main loop takes, own comment there. Every
+    # corpus member's own bluebook/hecksagon name has to be known before
+    # ANY member's own cross-domain check can trust "this target isn't
+    # anywhere in the corpus" — a single member's own boot (Compliance
+    # never loaded in the same registry as Banking, by design) cannot
+    # answer that alone. Computed lazily, once, on first use (not at
+    # class-body/file-load time) and memoized — every corpus member gets
+    # re-booted once more per `it` below regardless (each test needs its
+    # own fresh registry the same way it always did), so this only adds
+    # ONE extra full boot pass, not one per example.
+    def self.known_domains
+      @known_domains ||= MODEL_CHECK_CORPUS.flat_map do |_, source|
+        registry = Hecks::Runtime::Registry.new
+        Hecks.with_registry(registry) do
+          Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+          Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+          Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+          Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+          InMemoryDomain.load_bluebook_files(source)
+        end
+        registry.bluebooks.keys + registry.hecksagons.keys
+      end.to_set.freeze
+    end
+
     MODEL_CHECK_CORPUS.each do |name, source|
       it "#{name} has no error bin/model_check does not already name" do
-        findings = Hecks::Bluebook::ModelCheck.call(boot(source))
+        findings = call_model_check(boot(source), known_domains: self.class.known_domains)
         errors   = findings.select { |f| f.severity == :error }
         allowed  = MODEL_CHECK_ALLOWED.fetch(name, [])
 
@@ -175,7 +242,7 @@ RSpec.describe "the model checker" do
     it "names nothing in the allowlist that the checker no longer finds" do
       MODEL_CHECK_ALLOWED.each do |name, entries|
         source = MODEL_CHECK_CORPUS.to_h.fetch(name) { next }
-        findings = Hecks::Bluebook::ModelCheck.call(boot(source))
+        findings = call_model_check(boot(source), known_domains: self.class.known_domains)
         found = findings.select { |f| f.severity == :error }.map { |f| [f.kind, f.subject] }
 
         stale = entries - found


### PR DESCRIPTION
Adds a DDD Context Mapping check on top of two mechanisms that already exist: `uses_framework` already IS a Shared Kernel relationship, cross-domain `policy { across: }` already IS a Customer/Supplier relationship — but the choice between them (e.g. Compliance reached only via `across`, never `uses_framework`) lived only in a prose comment, unchecked by anything. `subscribe` existed as pure documentation with zero enforcement.

Zero new keywords. The whole feature lives in the static model-checker (`lib/hecks/bluebook/model_check.rb`) — no Rust/parser/codegen changes (confirmed: `parser_table_spec.rb` passes unchanged).

Two new advisory findings:
- `:contradictory_relationship` — a policy dispatches `across "X"` while the hecksagon also `uses_framework "X"` for the same target.
- `:unacknowledged_relationship` — a policy dispatches `across "X"` and nothing acknowledges `X` via `uses_framework`/`subscribe`. This gives `subscribe` real teeth — checked at model-check time, still never routed at runtime.

Resolvability needed a real fix, not a shortcut: `bin/model_check` is now two-pass — pass 1 boots every corpus member and accumulates a `known_domains` set, pass 2 re-examines every hecksagon's `across`/`uses_framework` targets against it. A target outside that set is a separate `:unknown_target_domain` finding. Two real, pre-existing corpus cases needed `ALLOWED_FINDINGS` exemptions: `Notifications` (genuinely undefined, intentional test target per `spec/runtime/policy_spec.rb`) and Embryonaut/lifeadelics-style domains (real, but confirmed to live in a separate repo, outside this corpus scan's reach).

Verified: `spec/model_check_spec.rb`, `bin/model_check` clean against the full corpus (zero un-allowlisted findings), `spec/parser_table_spec.rb` unchanged, `spec/reference_doctest_spec.rb`, full suite green.