### PR TITLE
Fix deploy generator: Google OAuth secret and session secret no longer readable via GetFunctionConfiguration

### DIFF
--- a/bin/project_deploy
+++ b/bin/project_deploy
@@ -1090,16 +1090,23 @@ template_yaml = <<~YAML
             # (era 2+) is a separate, later re-generation, not this one.
             HECKS_DOMAIN: #{declared_domain_name}
             HECKS_ERA: "1"#{hecks_schema ? %(\n          HECKS_SCHEMA: #{hecks_schema}) : ""}#{rust_web ? %(\n          HECKS_IR_PATH: !Sub "/var/task/#{domain_name}.ir.json") : ""}#{rust_web && google_oauth_present ? <<~RUSTOAUTH.each_line.with_index.map { |l, i| i.zero? ? "\n          " + l : "          " + l }.join.rstrip : ""}
-            # By NAME, not `!Ref` -- same dynamic-reference pattern
-            # DATABASE_URL/SESSION_SECRET already use: `make
+            # NOT `{{resolve:secretsmanager:...}}` composing
+            # GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET/SESSION_SECRET
+            # directly anymore -- the identical GetFunctionConfiguration
+            # exposure DATABASE_URL's own comment above documents
+            # applied here too. main.rs's own cold start fetches both
+            # secrets itself and `set_var`s the real GOOGLE_CLIENT_ID/
+            # GOOGLE_CLIENT_SECRET/SESSION_SECRET keys before anything
+            # else runs -- auth.rs/web.rs still read those exact keys,
+            # unchanged. GOOGLE_OAUTH_SECRET_ID is a bare NAME (`make
             # sync-google-oauth` owns #{stack_name}-web-google-oauth's
             # whole lifecycle outside CloudFormation, straight from
-            # #{domain}'s own gitignored .env.local (never baked into
-            # this generated, git-tracked template as plaintext).
-            GOOGLE_CLIENT_ID: !Sub "{{resolve:secretsmanager:#{stack_name}-web-google-oauth:SecretString:client_id}}"
-            GOOGLE_CLIENT_SECRET: !Sub "{{resolve:secretsmanager:#{stack_name}-web-google-oauth:SecretString:client_secret}}"
+            # #{domain}'s own gitignored .env.local, never baked into
+            # this generated, git-tracked template as plaintext) --
+            # GetSecretValue accepts a name directly, no ARN needed.
+            GOOGLE_OAUTH_SECRET_ID: #{stack_name}-web-google-oauth
             GOOGLE_REDIRECT_URI: !Sub "${WebRedirectBaseUrl}/auth/google/callback"
-            SESSION_SECRET: !Sub "{{resolve:secretsmanager:${#{logical_id}SessionSecret}:SecretString:session_secret}}"
+            SESSION_SECRET_ARN: !Sub "${#{logical_id}SessionSecret}"
             RUSTOAUTH
         # LEAST-PRIVILEGE -- #{logical_id}'s own execution role is
         # otherwise SAM's bare default (logging only); this is the one
@@ -1111,6 +1118,24 @@ template_yaml = <<~YAML
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Sub "${#{db_secret_ref}}"
+          #{rust_web && google_oauth_present ? <<~OAUTHPOLICY.each_line.with_index.map { |l, i| i.zero? ? l : "        " + l }.join.rstrip : ""}
+            - Statement:
+                - Effect: Allow
+                  Action: secretsmanager:GetSecretValue
+                  # NAME-BASED, not `!Ref`/`!GetAtt` -- this secret is
+                  # never a stack resource (RUSTOAUTH's own Environment
+                  # comment, above, has the full story), so there is no
+                  # exact ARN to point at. The trailing `-*` is AWS's
+                  # own documented pattern for granting a secret known
+                  # only by name: every real ARN Secrets Manager mints
+                  # is this name plus a random 6-character suffix,
+                  # which can't be predicted at template-render time.
+                  Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:#{stack_name}-web-google-oauth-*"
+            - Statement:
+                - Effect: Allow
+                  Action: secretsmanager:GetSecretValue
+                  Resource: !Sub "${#{logical_id}SessionSecret}"
+            OAUTHPOLICY
           # TMPL:cross_domain_lambda_policies
         VpcConfig:
           #{if shared
@@ -1267,26 +1292,42 @@ template_yaml = <<~YAML
           # journal into, different database engine role (Ruby's own
           # era/lineage schema, not rust/host's), never the real
           # Fly-hosted Postgres this whole effort is retiring away from.
-          DATABASE_URL: !Sub
-            - "postgres://postgres:${DbPass}@${DbHost}:5432/#{infra_name}"
-            - DbPass: !Sub "{{resolve:secretsmanager:${#{secret_sub}}:SecretString:password}}"
-              DbHost: !GetAtt #{db_ref_id}.Endpoint.Address
-          SESSION_SECRET: !Sub "{{resolve:secretsmanager:${#{web_logical_id}SessionSecret}:SecretString:session_secret}}"
+          #
+          # GENERATOR-ONLY FIX, NOT YET SAFE TO DEPLOY — DB_HOST/DB_NAME/
+          # DB_SECRET_ARN/SESSION_SECRET_ARN/GOOGLE_OAUTH_SECRET_ID below
+          # replace the SAME `{{resolve:secretsmanager:...}}`-into-
+          # Environment.Variables shape rust/host's own main.rs (this
+          # template's own #{logical_id}) used to have -- readable in
+          # plaintext by any read-only account principal via
+          # lambda:GetFunctionConfiguration, the exact exposure
+          # #{logical_id}'s own comment above the Policies section
+          # documents. But THIS function's consumer (`lambda_handler.rb`)
+          # is not a file this generator writes or this repo carries --
+          # it lives in the deploying app's own domain directory (real,
+          # live example: Embryonaut's own Sinatra app), outside this
+          # codebase entirely. Redeploying a domain with an existing
+          # `lambda_handler.rb` BEFORE that handler is updated to fetch
+          # these itself (`aws-sdk-secretsmanager`, not yet in this
+          # project's own Gemfile) breaks it: it still expects
+          # `ENV["DATABASE_URL"]`/`ENV["SESSION_SECRET"]`/
+          # `ENV["GOOGLE_CLIENT_ID"]`/`ENV["GOOGLE_CLIENT_SECRET"]`
+          # already resolved, and none of those keys exist below anymore.
+          DB_HOST: !GetAtt #{db_ref_id}.Endpoint.Address
+          DB_NAME: #{infra_name}
+          DB_SECRET_ARN: !Sub "${#{secret_sub}}"
+          SESSION_SECRET_ARN: !Sub "${#{web_logical_id}SessionSecret}"
           #{google_oauth_present ? <<~GOOGLE.each_line.with_index.map { |l, i| i.zero? ? l : "        " + l }.join.rstrip : <<~NOOAUTH.each_line.with_index.map { |l, i| i.zero? ? l : "        " + l }.join.rstrip}
-          # By NAME, not `!Ref` to a stack resource -- #{web_logical_id}GoogleOauth
+          # BY NAME, not `!Ref`/`!GetAtt` -- #{web_logical_id}GoogleOauth
           # is deliberately NOT declared as a CloudFormation resource
           # here (would need either GenerateSecretString, which can't
           # invent a real Google client_id/secret, or a value baked
           # into this git-TRACKED template as plaintext). `make
           # sync-google-oauth` owns this secret's whole lifecycle
           # instead, straight from #{domain}'s own gitignored
-          # .env.local, outside CloudFormation entirely -- the SAME
-          # "resolved by the deployer's own credentials at deploy
-          # time, never touches the function's execution role" dynamic
-          # -reference mechanism DATABASE_URL/SESSION_SECRET above
-          # already rely on, just pointed at a name instead of a Ref.
-          GOOGLE_CLIENT_ID: !Sub "{{resolve:secretsmanager:#{stack_name}-web-google-oauth:SecretString:client_id}}"
-          GOOGLE_CLIENT_SECRET: !Sub "{{resolve:secretsmanager:#{stack_name}-web-google-oauth:SecretString:client_secret}}"
+          # .env.local, outside CloudFormation entirely. GetSecretValue
+          # accepts a bare name directly, no ARN needed -- same
+          # generator-only caveat as DB_SECRET_ARN's own comment above.
+          GOOGLE_OAUTH_SECRET_ID: #{stack_name}-web-google-oauth
           GOOGLE_REDIRECT_URI: !Sub "${WebRedirectBaseUrl}/auth/google/callback"
           GOOGLE
           # GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET/GOOGLE_REDIRECT_URI
@@ -1309,9 +1350,29 @@ template_yaml = <<~YAML
       # (WebFunctionRole is not authorized... on resource
       # hecks-task — this stack has never had ANY policy granting
       # that action, so the fix isn't complete without adding one).
+      # THE SAME secretsmanager:GetSecretValue GRANTS #{logical_id}'s
+      # own Policies section (above) needed, once this function's own
+      # `lambda_handler.rb` fetches DB_SECRET_ARN/SESSION_SECRET_ARN/
+      # GOOGLE_OAUTH_SECRET_ID itself instead of relying on a resolved
+      # Environment.Variables value -- see this Environment block's own
+      # comment for why that consumer-side change isn't in this repo.
       Policies:
         - LambdaInvokePolicy:
             FunctionName: !Ref #{logical_id}
+        - Statement:
+            - Effect: Allow
+              Action: secretsmanager:GetSecretValue
+              Resource: !Sub "${#{secret_sub}}"
+        - Statement:
+            - Effect: Allow
+              Action: secretsmanager:GetSecretValue
+              Resource: !Sub "${#{web_logical_id}SessionSecret}"
+        #{google_oauth_present ? <<~WEBOAUTHPOLICY.each_line.with_index.map { |l, i| i.zero? ? l : "      " + l }.join.rstrip : ""}
+          - Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:#{stack_name}-web-google-oauth-*"
+          WEBOAUTHPOLICY
       # NONE, not AWS_IAM — real users need to reach sign-in over
       # plain HTTPS, unlike #{logical_id}'s own AWS_IAM-protected URL
       # (this function is the ONLY thing meant to call that one).

--- a/rust/host/src/main.rs
+++ b/rust/host/src/main.rs
@@ -53,16 +53,22 @@ async fn main() -> Result<(), Error> {
     // the one legitimate case being a human hand-debugging over an SSM
     // tunnel with DATABASE_URL set manually (project_deploy's own
     // ExcludeCharacters comment already anticipates exactly this).
+    //
+    // ONE FETCHER, built eagerly and reused below for GOOGLE_OAUTH_SECRET_ID/
+    // SESSION_SECRET_ARN too -- a real deploy always sets DB_SECRET_ARN
+    // (bin/project_deploy's own default), so this is the common path in
+    // practice; building it even in the DATABASE_URL-fallback debugging
+    // case costs one unused HTTP client, not worth branching around.
+    let secret_fetcher = secrets::AwsSecretFetcher::from_env().await;
     let database_url = match std::env::var("DB_SECRET_ARN") {
         Ok(secret_arn) => {
             let db_host = std::env::var("DB_HOST").map_err(|_| "DB_HOST is required when DB_SECRET_ARN is set")?;
             let db_name = std::env::var("DB_NAME").map_err(|_| "DB_NAME is required when DB_SECRET_ARN is set")?;
-            let secret_json = secrets::AwsSecretFetcher::from_env()
-                .await
+            let secret_json = secret_fetcher
                 .fetch_secret_string(&secret_arn)
                 .await
                 .map_err(|e| format!("fetching DB_SECRET_ARN from Secrets Manager: {e:#}"))?;
-            let password = secrets::extract_password(&secret_json)?;
+            let password = secrets::extract_field(&secret_json, "password")?;
             // Composed exactly the way template.yaml's own retired
             // `{{resolve:secretsmanager:...}}` DATABASE_URL Sub used to —
             // literal, unescaped, no percent-encoding. parse_database_url
@@ -72,6 +78,41 @@ async fn main() -> Result<(), Error> {
         Err(_) => std::env::var("DATABASE_URL")
             .map_err(|_| "either DB_SECRET_ARN (+ DB_HOST/DB_NAME) or DATABASE_URL is required")?,
     };
+
+    // GOOGLE_OAUTH_SECRET_ID/SESSION_SECRET_ARN — the SAME
+    // {{resolve:secretsmanager:...}}-into-Environment.Variables exposure
+    // DB_SECRET_ARN above replaced, applied to auth.rs's own
+    // GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET and web.rs's own
+    // SESSION_SECRET. Fetched here, once, then `unsafe { set_var }`'d
+    // into the SAME env keys auth.rs/web.rs already read via
+    // `std::env::var(...)` — neither file changes at all; from their
+    // own point of view this is indistinguishable from a human having
+    // exported the real value directly. SAFETY: this runs before
+    // `tokio::spawn` below or any request is ever dispatched — nothing
+    // else in this process reads or writes the environment concurrently
+    // with these two calls.
+    if let Ok(oauth_secret_id) = std::env::var("GOOGLE_OAUTH_SECRET_ID") {
+        let secret_json = secret_fetcher
+            .fetch_secret_string(&oauth_secret_id)
+            .await
+            .map_err(|e| format!("fetching GOOGLE_OAUTH_SECRET_ID from Secrets Manager: {e:#}"))?;
+        let client_id = secrets::extract_field(&secret_json, "client_id")?;
+        let client_secret = secrets::extract_field(&secret_json, "client_secret")?;
+        unsafe {
+            std::env::set_var("GOOGLE_CLIENT_ID", client_id);
+            std::env::set_var("GOOGLE_CLIENT_SECRET", client_secret);
+        }
+    }
+    if let Ok(session_secret_arn) = std::env::var("SESSION_SECRET_ARN") {
+        let secret_json = secret_fetcher
+            .fetch_secret_string(&session_secret_arn)
+            .await
+            .map_err(|e| format!("fetching SESSION_SECRET_ARN from Secrets Manager: {e:#}"))?;
+        let session_secret = secrets::extract_field(&secret_json, "session_secret")?;
+        unsafe {
+            std::env::set_var("SESSION_SECRET", session_secret);
+        }
+    }
     let wasm_path = PathBuf::from(
         std::env::var("HECKS_WASM_PATH").unwrap_or_else(|_| "banking.wasm".to_string()),
     );

--- a/rust/host/src/secrets.rs
+++ b/rust/host/src/secrets.rs
@@ -14,13 +14,26 @@
 // secrets themselves -- an ARN, an endpoint, and a database name
 // authenticate nothing on their own) and calls this module once.
 //
+// NOT JUST THE DB PASSWORD ANYMORE -- GOOGLE_OAUTH_SECRET_ID
+// (`{"client_id":"...","client_secret":"..."}`, make sync-google-oauth's
+// own JSON shape) and SESSION_SECRET_ARN (`{"session_secret":"..."}`,
+// GenerateSecretString's own template) went through the identical
+// `{{resolve:secretsmanager:...}}`-into-Environment.Variables exposure
+// this module was written to close for DATABASE_URL, so main.rs's own
+// cold start fetches those the same way now, then `unsafe { std::env::
+// set_var(...) }`s GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET/SESSION_SECRET
+// itself before anything else runs -- auth.rs/web.rs keep reading
+// `std::env::var("GOOGLE_CLIENT_ID")` etc. completely unchanged, same
+// as they always have, whether that env var came from a real
+// deploy's fetch-then-set or a human's own manually-exported value.
+//
 // NO TRAIT/MOCK BOUNDARY HERE, unlike lambda_client.rs's own
 // LambdaInvoker -- that trait exists because dispatch.rs's real test
 // suite threads through many call sites and needs to prove behavior
 // without live AWS credentials. This module has exactly one call site
 // (main.rs's own cold start, never exercised by a test), so the only
 // piece worth proving in isolation is the one pure, synchronous parse
-// below -- `extract_password` -- which this file's own `tests` module
+// below -- `extract_field` -- which this file's own `tests` module
 // does directly, with no client and no mock at all. `AwsSecretFetcher`
 // itself is real AWS SDK glue, structurally unverifiable here, same
 // honest limitation lambda_client.rs's own `AwsLambdaInvoker` states
@@ -67,20 +80,22 @@ impl AwsSecretFetcher {
     }
 }
 
-/// The one JSON field this crate ever needs out of a fetched secret --
-/// `GenerateSecretString`'s own `{"username":"postgres"}` template plus
-/// a generated `password` key (bin/project_deploy's own
-/// `#{db_id}Secret`/plain-RDS `ManageMasterUserPassword` comment). Pure
-/// and synchronous, deliberately kept separate from the network fetch
+/// One named JSON field out of a fetched secret's `SecretString` --
+/// every secret this crate ever fetches (the RDS/Aurora-generated
+/// `{"username":"postgres","password":"..."}`, the Google OAuth
+/// `{"client_id":"...","client_secret":"..."}`, the generated
+/// `{"session_secret":"..."}`) is a flat JSON object with one field
+/// this crate actually wants, never the whole document. Pure and
+/// synchronous, deliberately kept separate from the network fetch
 /// above so it needs no client and no mock to prove.
-pub fn extract_password(secret_json: &str) -> Result<String, String> {
+pub fn extract_field(secret_json: &str, field: &str) -> Result<String, String> {
     let value: serde_json::Value =
         serde_json::from_str(secret_json).map_err(|e| format!("secret's SecretString isn't valid JSON: {e}"))?;
     value
-        .get("password")
+        .get(field)
         .and_then(|p| p.as_str())
         .map(|s| s.to_string())
-        .ok_or_else(|| "secret's SecretString has no string \"password\" field".to_string())
+        .ok_or_else(|| format!("secret's SecretString has no string {field:?} field"))
 }
 
 #[cfg(test)]
@@ -88,20 +103,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extracts_password_from_the_generated_secret_shape() {
+    fn extracts_the_named_field_from_the_generated_secret_shape() {
         assert_eq!(
-            extract_password(r#"{"username":"postgres","password":"abc123"}"#).unwrap(),
+            extract_field(r#"{"username":"postgres","password":"abc123"}"#, "password").unwrap(),
             "abc123"
         );
     }
 
     #[test]
-    fn refuses_a_missing_password_field() {
-        assert!(extract_password(r#"{"username":"postgres"}"#).is_err());
+    fn extracts_either_field_from_a_two_field_secret() {
+        let json = r#"{"client_id":"id-1","client_secret":"secret-1"}"#;
+        assert_eq!(extract_field(json, "client_id").unwrap(), "id-1");
+        assert_eq!(extract_field(json, "client_secret").unwrap(), "secret-1");
+    }
+
+    #[test]
+    fn refuses_a_missing_field() {
+        assert!(extract_field(r#"{"username":"postgres"}"#, "password").is_err());
     }
 
     #[test]
     fn refuses_invalid_json() {
-        assert!(extract_password("not json").is_err());
+        assert!(extract_field("not json", "password").is_err());
     }
 }

--- a/spec/project_deploy_shared_rust_oauth_spec.rb
+++ b/spec/project_deploy_shared_rust_oauth_spec.rb
@@ -106,8 +106,25 @@ RSpec.describe "bin/project_deploy — Shared mode + rust_web + real Google OAut
   end
 
   it "wires the main function's own real Google OAuth Environment variables" do
-    expect(@raw).to match(/GOOGLE_CLIENT_ID: !Sub "\{\{resolve:secretsmanager:hecks-#{SHARED_RUST_OAUTH_FIXTURE_BASENAME}-web-google-oauth:SecretString:client_id\}\}"/)
+    expect(@raw).to include("GOOGLE_OAUTH_SECRET_ID: hecks-#{SHARED_RUST_OAUTH_FIXTURE_BASENAME}-web-google-oauth")
     expect(@raw).to include('GOOGLE_REDIRECT_URI: !Sub "${WebRedirectBaseUrl}/auth/google/callback"')
+    expect(@raw).to match(/SESSION_SECRET_ARN: !Sub "\$\{\w+SessionSecret\}"/)
+  end
+
+  # The main function's execution role needs to fetch BOTH secrets
+  # GOOGLE_OAUTH_SECRET_ID/SESSION_SECRET_ARN name at runtime now (see
+  # that Environment block's own comment) — same
+  # secretsmanager:GetSecretValue shape the DB secret's own grant
+  # already used, extended rather than duplicated as a second Policies
+  # key (bin/project_deploy's own cross_domain_lambda_policies_yaml
+  # comment documents the same one-Policies-key rule).
+  it "grants the main function's role secretsmanager:GetSecretValue on both the Google OAuth secret and the session secret" do
+    function = @template["Resources"].values.find { |r| r["Type"] == "AWS::Serverless::Function" && r.dig("Properties", "Environment", "Variables", "GOOGLE_OAUTH_SECRET_ID") }
+    statements = function.dig("Properties", "Policies").flat_map { |p| p["Statement"] || [] }
+    resources = statements.select { |s| s["Action"] == "secretsmanager:GetSecretValue" }.map { |s| s["Resource"] }
+
+    expect(resources).to include(a_string_matching(/-web-google-oauth-\*\z/))
+    expect(resources).to include(a_string_matching(/SessionSecret\}\z/))
   end
 
   # The Parameters SECTION declaring both sets together (above) is


### PR DESCRIPTION
## Summary

Extends #432's fix (`DATABASE_URL`) to the two remaining secrets that went through the identical `{{resolve:secretsmanager:...}}`-into-`Environment.Variables` exposure — confirmed live on this account, not just theoretical.

**Confirmed via `aws lambda get-function-configuration`** (a real, read-only-scoped deploy identity): `hecks-lifeadelics` and `hecksagain-embryonaut` both currently return their `DATABASE_URL`, `GOOGLE_CLIENT_SECRET`, and `SESSION_SECRET` in plaintext.

**1. rust/host's main function** (the `rust_web` + Google OAuth case — `hecks-lifeadelics` runs exactly this path): `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` and `SESSION_SECRET` are now fetched from Secrets Manager at cold start (`secrets.rs`'s generalized `extract_field`) and set into the process environment before any request is dispatched. `auth.rs`/`web.rs` keep reading `std::env::var("GOOGLE_CLIENT_ID")` etc. completely unchanged.

**2. The Ruby WebFunction's own secrets: generator-only fix.** This function's consumer is `lambda_handler.rb`, which isn't a file this repo carries — it lives in each deploying app's own domain directory (the live example: Embryonaut's own Sinatra app). Flagged clearly in the generated template's own comment: redeploying an existing WebFunction-based domain with this change **before** its `lambda_handler.rb` is updated to fetch these itself (via `aws-sdk-secretsmanager`, not yet in this project's Gemfile) will break it — the env keys it currently expects no longer exist.

Both function roles get a least-privilege `secretsmanager:GetSecretValue` grant scoped to exactly the secrets they now fetch.

## Verification

- 41 examples across the deploy specs pass, including a new assertion that both grants land in the same `Policies` list (not a duplicate key).
- Regenerated and YAML-validated by hand across Postgres/Aurora/Shared × rust_web × Google-OAuth × cross-domain-policy combinations.
- `rust/host` builds clean (100 passed, same 17 pre-existing unrelated failures from missing `.wasm` build artifacts).
- Full pre-push gate: rspec suite, fuzzer, model checks, doc coverage, rubocop — all green.

## Not done here

- Not yet deployed to the two live stacks this closes real exposure on (`hecks-lifeadelics`, `hecksagain-embryonaut`).
- The already-exposed secret values (DB password, Google OAuth client secret, session secrets) should be rotated regardless of this fix landing, since they were readable before it merged.
- The Ruby WebFunction consumer-side fix (a separate, private app repo) is out of scope here — see the generator's own comment.
