### PR TITLE
Wire TenantCheck into ProjectRegister#register, close the cross-tenant boot-isolation gap

### DIFF
--- a/docs/1.0-readiness.md
+++ b/docs/1.0-readiness.md
@@ -126,6 +126,38 @@ says "not yet, and here is the whole list," not just the DSL-syntax part:
 None of these blocked ADR 0025 work from starting, and all five are now
 resolved — nothing on this list blocks the tag any longer.
 
+## Known gaps at 1.0
+
+Passing the ADR 0025 gate is not the same claim as "no gaps exist." Three
+are known, named here on purpose rather than left for someone else to
+find later — see "Why this doc exists" below for why that matters more
+here than in most projects:
+
+1. ~~**Cross-tenant boot isolation was unwired at the 1.0.0 tag
+   itself.**~~ **Resolved, post-tag.** `Runtime::TenantCheck
+   .refuse_unless_tenant_capable!` existed and was directly tested
+   (`spec/tenant_isolation_spec.rb`), but nothing called it — a second
+   `Hecks.boot` of the same directory for a second tenant, bound to a
+   non-`tenant_capable?` adapter (plain Postgres, no schema story), was
+   not refused; both boots shared tables. Closed by wiring the check
+   into `Bluebook::ProjectRegister#register`, the actual point where
+   more than one tenant boot of a directory converges into one shared
+   route table: a directory's SECOND registration is refused — its
+   first never is, so an ordinary single-tenant deploy on a plain
+   adapter is unaffected — before that second boot's routes ever merge
+   in, so a leaking tenant's requests are never reachable through
+   `Router#resolve` at all.
+2. **Read models have no cross-engine agreement gate.**
+   `ReadModelInterpreter#project` still silently forks between native
+   SQL pushdown and an in-process Ruby loop, switched by declaration
+   details (e.g. `group_by`) rather than checked for agreement. This is
+   the layer that produces dashboard/query numbers; a divergence here
+   doesn't refuse or crash, it just renders a wrong number.
+3. **ADR 0037 Findings 3–5 are still `pending:`**, including a
+   dangling-reference gap where `SafeDepositBox.Rent` refuses in Ruby
+   but succeeds in Rust — a silent data-integrity divergence between
+   the two runtimes a projection to WASM/Lambda would carry forward.
+
 ## Why this doc exists
 
 Because the pattern that produced it — a status doc calling something fixed

--- a/lib/hecks/bluebook/project_register.rb
+++ b/lib/hecks/bluebook/project_register.rb
@@ -16,6 +16,7 @@ module Hecks
 
       def initialize
         @entries = {}
+        @tenant_directories = Hash.new { |hash, key| hash[key] = [] }
       end
 
       def fetch(address) = entries.fetch(address.to_s)
@@ -25,6 +26,7 @@ module Hecks
 
       def register(bluebooks, registry, dispatcher, directory)
         bluebooks.each do |bluebook|
+          refuse_unless_safe_for_second_tenant!(bluebook, registry, directory)
           world = registry.world(bluebook.name)
           realm = world&.realm
           raise MissingRealm, "#{bluebook.name} in #{directory} has no world realm" if realm.to_s.empty?
@@ -61,6 +63,29 @@ module Hecks
       end
 
       private
+
+      # THE ACTUAL "more than one tenant" MOMENT — Runtime::TenantCheck's
+      # own header names this table as the one place real multitenancy
+      # happens: the SAME on-disk directory (one domain, one
+      # `persisted_by` binding) registering a SECOND time, under a
+      # different realm, into this SAME shared route table. A directory's
+      # FIRST registration is never refused here — nothing shares its
+      # data yet, so a plain single-tenant deployment on an ordinary
+      # adapter (Postgres, no schema story) still boots exactly as
+      # before. Only the SECOND (and any later) registration of that
+      # same directory is refused, and refused before this call adds its
+      # routes to the table — so a leaking tenant's requests never
+      # become reachable through `Router#resolve` in the first place.
+      #
+      # Keyed on `directory` + `bluebook.name` only, not realm or
+      # `dispatcher` — two tenants share the identical on-disk domain,
+      # differing only by which realm/environment overlay booted it.
+      def refuse_unless_safe_for_second_tenant!(bluebook, registry, directory)
+        key = [directory, bluebook.name]
+        seen_before = @tenant_directories.key?(key) && @tenant_directories[key].any?
+        Runtime::TenantCheck.refuse_unless_tenant_capable!(registry, bluebook.name) if seen_before
+        @tenant_directories[key] << registry
+      end
 
       def current?(bluebook, world)
         bluebook.version.nil? || world.latest == bluebook.version

--- a/spec/tenant_isolation_spec.rb
+++ b/spec/tenant_isolation_spec.rb
@@ -162,6 +162,61 @@ RSpec.describe "multitenancy: one boot per tenant, one shared route table" do
     end
   end
 
+  # THE WIRING ITSELF, NOT JUST THE PREDICATE — every example above
+  # calls `TenantCheck.refuse_unless_tenant_capable!` BY HAND, which
+  # proves the gate works but not that anything actually reaches it.
+  # This one instead drives the real integration point:
+  # `ProjectRegister#register`, called twice for the SAME on-disk
+  # directory the way a real multi-tenant host would (`register_tenant`
+  # above, the same helper the Memory/PostgresEra examples use).
+  #
+  # A domain's FIRST registration for a directory is never refused —
+  # nothing shares its data yet, so an ordinary single-tenant deploy on
+  # a plain, non-tenant_capable? adapter still boots exactly as before
+  # this gate existed. Only the SECOND registration of that same
+  # directory is refused — and refused before ITS routes are merged
+  # into the shared table, so a leaking tenant's requests never even
+  # become reachable through `Router#resolve`.
+  def load_bare_registry(dir, realm)
+    registry = Hecks::Runtime::Registry.new(root: dir)
+    Hecks.with_registry(registry) do
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.load(File.join(dir, "tenanted.bluebook"))
+      Kernel.load(File.join(dir, "tenanted.hecksagon"))
+      Kernel.load(File.join(dir, "tenanted.world"))
+      Kernel.load(File.join(dir, "environments/#{realm.downcase}.world"))
+    end
+    registry
+  end
+
+  it "refuses a domain's SECOND registration into a shared route table when its bound adapter " \
+     "is not tenant_capable?, but never touches its first" do
+    Dir.mktmpdir do |dir|
+      # `Postgres` (no era, no schema story) never declares
+      # tenant_capable? — same non-capable adapter the direct-call
+      # example above uses, and for the same reason: this never boots
+      # through `Hecks.boot`, so it never tries to actually connect.
+      write_tenant_domain(dir, adapter: "Postgres", tenant_settings: { "acme" => {}, "bloom" => {} })
+
+      acme_registry  = load_bare_registry(dir, "Acme")
+      bloom_registry = load_bare_registry(dir, "Bloom")
+
+      register = Hecks::Bluebook::ProjectRegister.new
+      acme_dispatcher  = Hecks::Runtime::Dispatcher.new(acme_registry)
+      bloom_dispatcher = Hecks::Runtime::Dispatcher.new(bloom_registry)
+
+      expect { register.register([acme_registry.bluebook("Tenanted")], acme_registry, acme_dispatcher, dir) }
+        .not_to raise_error
+
+      expect { register.register([bloom_registry.bluebook("Tenanted")], bloom_registry, bloom_dispatcher, dir) }
+        .to raise_error(Hecks::Runtime::WiringError, /not tenant_capable\?/)
+
+      expect(register.include?("Acme::Tenanted::Widget.Make")).to be true
+      expect(register.include?("Bloom::Tenanted::Widget.Make")).to be false
+    end
+  end
+
   it "keeps two tenants' data completely apart on real PostgresEra, in genuinely separate schemas", io: true do
     skip "no local Postgres reachable" unless PostgresProbe.available?
 


### PR DESCRIPTION
Wire TenantCheck into ProjectRegister#register, close the cross-tenant boot-isolation gap

Runtime::TenantCheck.refuse_unless_tenant_capable! existed and was
directly spec'd (spec/tenant_isolation_spec.rb) but nothing called it
outside its own spec — run_boot_gates! never referenced it, so a second
Hecks.boot of the same directory for a second tenant, bound to a
non-tenant_capable? adapter (plain Postgres, no schema story), was not
refused. Both boots shared tables. Shipped, unwired, in the 1.0.0 tag.

Wiring it into every boot unconditionally would have refused ordinary
single-tenant deploys on a plain adapter, which is not the actual bug —
the module's own doc says this gates a domain being "safe to boot for
MORE THAN ONE TENANT." The real convergence point is
Bluebook::ProjectRegister#register: the one place multiple tenant boots
of the same directory merge into one shared route table. A directory's
first registration is never refused (nothing shares its data yet); its
second (and any later) one is, before that boot's routes are merged in,
so a leaking tenant's requests never become reachable through
Router#resolve at all.

Adds an integration spec exercising the real wiring path (ProjectRegister
directly, not TenantCheck by hand) to prove the gate is actually reached.
Full default rspec (2305 examples), the io-tagged tenant/deploy-tenant
specs against real Postgres, model_check, doc_coverage, and rubocop all
pass. Updates docs/1.0-readiness.md with a "Known gaps at 1.0" section
naming this (now resolved) plus the two other open gaps from the same
post-tag review: no read-model cross-engine agreement gate, and ADR 0037
Findings 3-5 still pending.
