### PR TITLE
1.0.1: version bump for the cross-tenant boot-isolation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Entries below are grouped by theme, not itemized commit-by-commit; see
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-28
+
+**Cross-tenant boot-isolation gap closed.** `refuse_unless_tenant_capable!`
+existed and was directly tested (ADR 0025's gate), but nothing in the boot
+path actually called it — a second tenant booting the same directory on a
+tenant-incapable adapter went unrefused. Wired into
+`ProjectRegister#register` rather than `run_boot_gates!`: boot gates run
+per-boot and have no way to see a prior boot, while `ProjectRegister` is the
+shared route table where two tenant boots of one directory actually
+converge, keyed on `[directory, bluebook.name]`. The first registration of a
+directory is never refused, so a plain single-tenant deployment boots
+unchanged; a second, incompatible tenant is refused before its routes are
+added to the table, so a leaking tenant is never reachable through
+`Router#resolve`. `1.0.0` shipped with this gate unwired; anyone who pinned
+that version should move to `1.0.1`. See `docs/1.0-readiness.md`'s "Known
+gaps at 1.0" section for what's still open (read-model cross-engine
+agreement, ADR 0037 findings 3-5).
+
 ## [1.0.0] - 2026-08-28
 
 **ADR 0025 lands: the DSL redesign this whole cycle was blocked on.** All 15

--- a/docs/1.0-readiness.md
+++ b/docs/1.0-readiness.md
@@ -140,7 +140,7 @@ find later — see "Why this doc exists" below for why that matters more
 here than in most projects:
 
 1. ~~**Cross-tenant boot isolation was unwired at the 1.0.0 tag
-   itself.**~~ **Resolved, post-tag.** `Runtime::TenantCheck
+   itself.**~~ **Resolved in 1.0.1.** `Runtime::TenantCheck
    .refuse_unless_tenant_capable!` existed and was directly tested
    (`spec/tenant_isolation_spec.rb`), but nothing called it — a second
    `Hecks.boot` of the same directory for a second tenant, bound to a

--- a/lib/hecks/version.rb
+++ b/lib/hecks/version.rb
@@ -12,5 +12,5 @@ module Hecks
   # it there, or even in the consuming Gemfile, never closed the gap,
   # because gemspec evaluation happens before anything Bundler
   # resolves is actually loadable yet.
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Bumps `VERSION` to `1.0.1` and adds a CHANGELOG entry, since #446 (wiring `refuse_unless_tenant_capable!` into `ProjectRegister#register`) landed after the `1.0.0` tag was already cut — anyone who pinned `1.0.0` has the unwired gate. Also updates `docs/1.0-readiness.md` item 1 from "Resolved, post-tag" to "Resolved in 1.0.1" so a reader doesn't have to work out which tags are on which side of it.

No behavior change beyond the version string and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)