### PR TITLE
Automate gem push via 1Password (Touch ID-gated)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,3 +151,14 @@ first PR here goes sideways.
 
 If you're not sure whether an idea fits before writing any code, open
 an issue first — see the templates under `.github/ISSUE_TEMPLATE/`.
+
+## Releasing
+
+1. Bump `VERSION` in `lib/hecks/version.rb` and add a `CHANGELOG.md`
+   entry, on a branch, as its own PR.
+2. Once that PR merges to `main`, tag the merge commit
+   (`git tag -a vX.Y.Z <sha>`) and push the tag.
+3. Run `bin/release_gem` to build and push to rubygems.org. It pulls
+   the push API key from 1Password (`op run`, Touch ID-gated) rather
+   than a credentials file on disk — see the script's header comment
+   for one-time setup.

--- a/bin/release_gem
+++ b/bin/release_gem
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Builds the hecks gem and pushes it to rubygems.org, pulling the
+# push-scoped API key from 1Password (vault: Hecks, item: "RubyGems API
+# Key") instead of ~/.gem/credentials on disk. `op run` resolves the
+# op:// reference in release/gem_push.env into GEM_HOST_API_KEY for gem
+# push's one subprocess only — gated by Touch ID, never written to disk
+# or shell history, and gone once that process exits.
+#
+# One-time setup, both outside this script:
+#   - 1Password app: Settings > Developer > "Integrate with 1Password CLI"
+#   - a "RubyGems API Key" item (API Credential category, field:
+#     credential) in the Hecks vault, holding a rubygems.org key scoped
+#     to push-only, restricted to this gem
+#
+# Usage: bin/release_gem   (pushes the version lib/hecks/version.rb declares)
+
+require "fileutils"
+
+ROOT_DIR = File.expand_path("..", __dir__)
+Dir.chdir(ROOT_DIR)
+
+unless system("command -v op > /dev/null 2>&1")
+  warn "1Password CLI (op) not found. Install: brew install 1password-cli"
+  exit 1
+end
+
+require_relative "../lib/hecks/version"
+
+gem_file = "hecks-#{Hecks::VERSION}.gem"
+
+puts "Building #{gem_file}..."
+system("gem", "build", "hecks.gemspec", exception: true)
+
+begin
+  puts "Pushing #{gem_file} to rubygems.org (1Password will prompt for Touch ID)..."
+  system(
+    "op", "run", "--env-file=release/gem_push.env", "--",
+    "gem", "push", gem_file,
+    exception: true
+  )
+ensure
+  FileUtils.rm_f(gem_file)
+end
+
+puts "Released hecks #{Hecks::VERSION}."

--- a/release/gem_push.env
+++ b/release/gem_push.env
@@ -1,0 +1,6 @@
+# Read by `op run --env-file` (see bin/release_gem). This holds an
+# op:// REFERENCE, not a secret — safe to commit. `op run` resolves it
+# against the "RubyGems API Key" item in the Hecks vault at run time,
+# unlocked by Touch ID, and injects it as GEM_HOST_API_KEY into gem
+# push's one subprocess only.
+GEM_HOST_API_KEY="op://Hecks/RubyGems API Key/credential"


### PR DESCRIPTION
Adds `bin/release_gem`: builds the gem and pushes it via `op run`, pulling `GEM_HOST_API_KEY` from a 1Password vault (`Hecks`) rather than a credentials file on disk. RubyGems already honors `GEM_HOST_API_KEY` as its highest-priority credential source (`rubygems/gemcutter_utilities.rb`), so no gem-side change was needed — this is purely local tooling.

`release/gem_push.env` holds only an `op://` reference (the secret's *location*, not the secret itself) — safe to commit.

Documents the release process end-to-end in CONTRIBUTING.md, since it wasn't written down anywhere before.

**One-time setup needed outside this repo** (not part of this PR):
- 1Password app: Settings > Developer > "Integrate with 1Password CLI", Touch ID unlock enabled
- A "RubyGems API Key" item (API Credential category, field: `credential`) in a "Hecks" vault, holding a rubygems.org key scoped to push-only for this gem

🤖 Generated with [Claude Code](https://claude.com/claude-code)