### PR TITLE
Gem page cleanup: Install section, changelog/documentation_uri (1.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Entries below are grouped by theme, not itemized commit-by-commit; see
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-28
+
+**Gem page cleanup, now that the gem is actually published.** `1.0.0`
+shipped before `gem install hecks` was live on RubyGems, so the README's
+Quickstart still said "There is no published gem" and had no Install
+section — the first thing a visitor reads contradicted reality. Fixed:
+an `## Install` section now sits right after the intro, and Quickstart
+points at `git clone` for the examples/docs rather than implying it's
+the only way in. Gemspec also gained `changelog_uri` and
+`documentation_uri` metadata, which render as links on the RubyGems page;
+`homepage`/`source_code_uri` were already correct (`heckslabs/hecks`,
+not the `chrisyoung/hecks` fork/redirect). Metadata is baked into the
+published gem version, so this needed its own release rather than
+riding along on `1.0.1`.
+
 ## [1.0.1] - 2026-08-28
 
 **Cross-tenant boot-isolation gap closed.** `refuse_unless_tenant_capable!`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ harness.
 **Status:** `1.0.0`. See [Project status](#project-status) for what the
 1.0 stability promise covers and what it explicitly doesn't yet.
 
+## Install
+
+```sh
+gem install hecks
+```
+
+Or in a Gemfile: `gem "hecks"`. See [Quickstart](#quickstart) below to
+go from a bare install to a running domain.
+
 ## Why
 
 Take one real rule — "a pizza may carry at most 10 toppings." In a
@@ -624,8 +633,9 @@ before assuming a capability exists that isn't demonstrated above.
 
 ## Quickstart
 
-There is no published gem. You clone the repository, and the
-repository is the tool:
+`gem install hecks` gets you the runtime, but the examples and docs
+below live in the repository, so cloning it is still the fastest way
+to try the whole thing:
 
 ```sh
 git clone https://github.com/heckslabs/hecks

--- a/hecks.gemspec
+++ b/hecks.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["source_code_uri"]   = spec.homepage
+  spec.metadata["changelog_uri"]     = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/hecks"
 
   # UNLIKE Postgres/Sqlite (ADAPTERS, reached only if a domain's
   # .hecksagon wires one — declaring them here would force a database

--- a/lib/hecks/version.rb
+++ b/lib/hecks/version.rb
@@ -12,5 +12,5 @@ module Hecks
   # it there, or even in the consuming Gemfile, never closed the gap,
   # because gemspec evaluation happens before anything Bundler
   # resolves is actually loadable yet.
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
1.0.1 is live on RubyGems, but README still said "There is no published gem" with no Install section, and the gemspec had no changelog_uri/documentation_uri metadata.

- README: new `## Install` section (`gem install hecks`) near the top; Quickstart's intro no longer implies clone is the only way in.
- gemspec: added `changelog_uri`, `documentation_uri`. `homepage`/`source_code_uri` were already correct — `chrisyoung/hecks` just redirects to `heckslabs/hecks`.
- Bumped to 1.0.2 since gemspec metadata is baked into the published gem and 1.0.1 is already tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)