### PR TITLE
DX feedback: given diagnostics, .set?/.unset?, translation-audit trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,44 @@ language now treats that as a rule rather than a convention:
   single-attribute value object; the explicit spelling keeps working,
   and multi-field shapes still require their fields spelled out.
 
+**The translation audit's preview now reads through the SAME
+layered-or-full SQL selection a real mint materializes with.**
+`translated_latest` (`bin/translation_audit`'s own preview, and the
+real mint-time gate in `coverage_check.rb#audit!`) used to call
+`chain_sql` unconditionally; `compile_head!`, at actual mint time,
+picks the LAYERED build instead whenever era >= 3 and a prior matview
+exists — most eras of any domain that has minted more than a couple of
+times. The two were asserted equivalent by spec, but only tested for
+an ordinary (non-rekey) edge; a rekey's own `id_column` CASE went
+through the layered path at real mint time and through `chain_sql`
+alone at every preview, two independently-maintained implementations
+with no shared test ever exercising both for the SAME rekey. Pulled
+into one `head_body_sql` picker both call, with a defensive
+`edges.size != era - 1` guard on the layered path (a caller handed a
+shorter edge chain against the same target era — the audit's own
+"before" reading always is — used to index past its own array bounds
+instead of falling back cleanly). A rekey reaching era 3+ now audits
+against the literal SQL a real mint will run, not a second guess at it.
+
+**`.set?`/`.unset?`, a deliberately narrower sibling of `.present?`/
+`.blank?`.** `!receiver.nil?`, full stop — an assigned-but-empty
+`String`/`Array` is `.set?`, unlike `.present?`'s own Rails-standard
+emptiness reading of the identical value. For an optional field whose
+only legitimate unset state IS nil, that conflation was a real trap;
+these ask the narrower question by name instead. Ported to the Rust
+kernel (`Expr::Assignment`, `expression_operators::presence`) alongside
+the Ruby resolver; `rust/host`'s JSON interpreter parses it structurally
+but does not yet evaluate it, the same boundary `.present?`/`.blank?`
+themselves already sit behind there.
+
+**`GivenNotMet#detail`.** A refused `given` whose top-level shape is a
+bare comparison now carries its own resolved operands — "left: X,
+right: Y" — as `#detail`, off `#message` (every corpus spec asserting
+an exact refusal string keeps passing unchanged). Rides on Ruby's own
+`#detailed_message` (3.2+), so it shows up in an irb/console
+unhandled-exception banner without any caller code reading it on
+purpose.
+
 ## [1.0.2] - 2026-08-28
 
 **Gem page cleanup, now that the gem is actually published.** `1.0.0`

--- a/bin/translation_audit
+++ b/bin/translation_audit
@@ -9,6 +9,20 @@
 # compute or rekey rule, the only verification there is. The same
 # layers run inside every era mint; this tool runs them standalone,
 # including over a PENDING edge before anything is minted.
+#
+# EVERY SAMPLE BELOW IS A PLAIN SELECT — this tool never writes to the
+# journal, a matview, or hecks_eras (the one exception, `--approve`,
+# writes to hecks_approvals ALONE, and only after every sample above has
+# already printed); a mint stays refused until a human runs it again.
+# And what it reads is not a second, hand-kept-in-sync guess at what a
+# real mint will materialize: `translated_latest` (head_compiler.rb)
+# reads through `head_body_sql`, the SAME layered-or-full choice
+# `compile_head!` makes at actual mint time. A discrepancy between what
+# this preview shows and what a real mint later produces for the
+# identical edge is a bug in `head_body_sql`'s own callers agreeing to
+# read it, not something this tool can be argued around by hand-running
+# the compiled SQL yourself — if you see one, that is the bug to report,
+# not a nudge to trust the hand-run query over this one.
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 

--- a/docs/implemented/guides/commands.md
+++ b/docs/implemented/guides/commands.md
@@ -254,6 +254,29 @@ Write your givens with the cheapest or most-likely-to-fail check first
 if you want your callers reading the most useful message; the runtime
 will not reorder them for you.
 
+A description tells you WHICH rule refused, not what the record's
+fields actually held when it did — the gap between "the rule is right
+and my data is wrong" and "the rule is subtly wrong." When a `given` is
+a bare comparison (`balance.cents >= amount.cents`, not one side of an
+`&&`/`||`, and not `.include?`/a bare boolean read — those have no
+single honest left/right to show), the raised `GivenNotMet` carries the
+comparison's own resolved operands as `#detail`:
+
+```ruby
+begin
+  account.debit!(amount: { cents: 999_999 }, narrative: { text: "too much" })
+rescue Hecks::Runtime::GivenNotMet => e
+  e.message # => "Debit refused — the balance covers it"
+  e.detail  # => "left: 0, right: 999999"
+end
+```
+
+`#detail` never changes `#message` — every corpus spec asserting an
+exact refusal string keeps passing unchanged. It rides on Ruby's own
+`#detailed_message` (3.2+) instead, so it shows up automatically in an
+`irb`/Rails console's own unhandled-exception banner without any code
+reading `#detail` on purpose.
+
 ## `from:` — lifecycle state as a command guard
 
 `command "Debit", from: "open"` (or, on `CloseAccount`, `from: ["open",

--- a/docs/implemented/guides/running-a-runtime.md
+++ b/docs/implemented/guides/running-a-runtime.md
@@ -529,6 +529,7 @@ and held equal to it by `spec/operator_conformance_spec.rb`:
 | `.any?`, `.none?`, `.all?`, `.find` | enumeration | 2 | `list.any? { \|x\| predicate }` — the block's parameter is bound for the predicate (a whole boolean expression, blocks nest freely); `.find { }` may carry a dotted path, `list.find { \|x\| … }.a.b`, and is nil when nothing matches. Braces only, never `do…end` |
 | `.match?` | pattern_match | 2 | `receiver.match?(/pattern/flags)` — a real Ruby-Regexp source between the slashes; `i`/`m`/`x` flags supported |
 | `.present?`, `.blank?` | presence | 1 | Rails-standard semantics: `nil`/`false` are blank, `String`/`Array` are blank when empty, everything else is present |
+| `.set?`, `.unset?` | presence | 1 | narrower than `.present?`/`.blank?` on purpose: `!receiver.nil?`, full stop — an assigned-but-empty `String`/`Array` is `.set?`, unlike `.present?`'s own reading of the identical value |
 | `.split` | text | 2 | `receiver.split("SEP")` — produces an `Array`, literal separator only |
 | `.start_with?`, `.end_with?` | text | 2 | `String` receiver only |
 | `.first`, `.last` | positional | 1 | over an array-typed receiver (an `ArrayLiteral`, a `.split` result, or a list-typed field of scalar elements) — `nil` on an empty list |
@@ -572,8 +573,8 @@ Hecks::Bluebook::Expression::Evaluator.parse("old.balance.cents == balance.cents
 Below `Compare`, the left and right sides are `Resolver` leaves — a
 smaller grammar for the non-boolean part: integer/float/string/bool/nil/
 array literals, `+` addition, `.modulo`, a sign test, `.empty?`/`.size`,
-`.to_s`, `.match?`, `.present?`/`.blank?`, `.split`, `.start_with?`/
-`.end_with?`, `.first`/`.last`, the block-taking enumeration operators
+`.to_s`, `.match?`, `.present?`/`.blank?`, `.set?`/`.unset?`, `.split`,
+`.start_with?`/`.end_with?`, `.first`/`.last`, the block-taking enumeration operators
 (`.any?`/`.none?`/`.all?`/`.find { |x| … }`, whose body is a whole
 boolean expression parsed by `Evaluator` again), and the true leaf,
 `Lookup` — a bare or dotted name resolved

--- a/lib/hecks/bluebook/expression/ast_json.rb
+++ b/lib/hecks/bluebook/expression/ast_json.rb
@@ -42,8 +42,8 @@ module Hecks
       # `expr_emitter.rb`'s own `emit_bool`/`emit_resolver` already hold
       # to — even though, as of this writing, no real corpus VALUE OBJECT
       # invariant exercises `Include`/`Modulo`/`BlockPredicate`/`Find`/
-      # `Array`/`MatchesRegex`/`Presence`/`Split`/`StartsWith`/`EndsWith`/
-      # `First`/`Last` (only `given`/`ensures` clauses do, elsewhere in
+      # `Array`/`MatchesRegex`/`Presence`/`Assignment`/`Split`/`StartsWith`/
+      # `EndsWith`/`First`/`Last` (only `given`/`ensures` clauses do, elsewhere in
       # the corpus — a different consumer of this same grammar).
       # `rust/host/src/expr_json.rs`'s own header names exactly which of
       # these its interpreter evaluates for real today versus refuses
@@ -131,6 +131,8 @@ module Hecks
             { "op" => "matches_regex", "receiver" => emit_resolver(node.receiver), "pattern" => node.pattern, "flags" => node.flags }
           when Resolver::Presence
             { "op" => "presence", "receiver" => emit_resolver(node.receiver), "negated" => node.negated }
+          when Resolver::Assignment
+            { "op" => "assignment", "receiver" => emit_resolver(node.receiver), "negated" => node.negated }
           when Resolver::Split
             { "op" => "split", "receiver" => emit_resolver(node.receiver), "separator" => node.separator }
           when Resolver::StartsWith

--- a/lib/hecks/bluebook/expression/evaluator.rb
+++ b/lib/hecks/bluebook/expression/evaluator.rb
@@ -58,6 +58,32 @@ module Hecks
           interpret(ast_cache[expr] ||= parse(expr), state, attrs)
         end
 
+        # A refused `given`/`ensures`/`invariant` names its own DESCRIPTION
+        # ("not already superseded") but, on its own, not what the block
+        # actually evaluated to — the difference between "the rule is right
+        # and my data is wrong" and "the rule is subtly wrong" is often just
+        # seeing the two operands. Scoped to the single shape that has one
+        # honest answer: `expr`'s own TOP-LEVEL node is a bare `Compare` —
+        # not `Or`/`And`/`Not` (which of several sub-comparisons would even
+        # be "the" one at fault is genuinely ambiguous), `Include` (no
+        # left/right to show), or `Resolve` (a bare boolean read, nothing to
+        # compare against). Values are rendered with `Rendering.describe`,
+        # the same house style every other refusal already prints a value
+        # through. Returns `nil` — not raised — on anything else, INCLUDING
+        # an operand that itself fails to resolve (`EvaluationError`): a
+        # missing diagnostic is a worse debugging experience than none, a
+        # crash while building one is worse still.
+        def comparison_detail(expr, state, attrs = {})
+          node = ast_cache[expr] ||= parse(expr)
+          return nil unless node.is_a?(Compare)
+
+          lhs = Resolver.interpret(node.left, state, attrs)
+          rhs = Resolver.interpret(node.right, state, attrs)
+          "left: #{Resolver.describe(lhs)}, right: #{Resolver.describe(rhs)}"
+        rescue EvaluationError
+          nil
+        end
+
         def parse(expr)
           expr = strip_parens(expr.to_s.strip)
 

--- a/lib/hecks/bluebook/expression/projection.json
+++ b/lib/hecks/bluebook/expression/projection.json
@@ -197,6 +197,18 @@
       "category": "positional",
       "precedence": 7,
       "arity": 1
+    },
+    {
+      "symbol": ".set?",
+      "category": "presence",
+      "precedence": 7,
+      "arity": 1
+    },
+    {
+      "symbol": ".unset?",
+      "category": "presence",
+      "precedence": 7,
+      "arity": 1
     }
   ],
   "normalisations": [

--- a/lib/hecks/bluebook/expression/resolver.rb
+++ b/lib/hecks/bluebook/expression/resolver.rb
@@ -109,6 +109,24 @@ module Hecks
         # field that could legitimately be "" rather than absent.
         Presence       = Struct.new(:receiver, :negated, keyword_init: true)
 
+        # `.set?`/`.unset?` -- sibling of `.present?`/`.blank?` immediately
+        # above, added for a DELIBERATELY narrower question, spelled out in
+        # the name so choosing between the two pairs is a choice, not a
+        # trap: `.present?` means "not EMPTY" (Rails-standard -- nil/false,
+        # and an EMPTY String/Array/Hash, are blank; nothing else is),
+        # which quietly answers "was this ever assigned" and "does the
+        # assigned value happen to be empty" as the SAME question. For an
+        # optional field whose only legitimate unset state IS nil, that
+        # conflation is a real trap -- confirmed live: a corpus author
+        # reaching for `superseded_by.blank?` to guard an optional
+        # reference burned real time before landing on "just don't guard
+        # it," because `.blank?` cannot be asked to mean ONLY "was this
+        # never assigned." `.set?`/`.unset?` ask exactly that, and nothing
+        # else: `!receiver.nil?`, full stop -- an assigned-but-empty
+        # String/Array/Hash (or a VO wrapping one) is `.set?`, not
+        # `.unset?`, unlike `.blank?`'s own reading of the identical value.
+        Assignment     = Struct.new(:receiver, :negated, keyword_init: true)
+
         # `receiver.split("SEP")` -- vendored addition, not (yet) upstream
         # hecks (migration plan task 9): confirmed the single
         # highest-value new finding of the real-dispatch smoke sweep --
@@ -224,6 +242,9 @@ module Hecks
           return Presence.new(receiver: parse(Regexp.last_match(1)), negated: false) if expr =~ /\A(.+)\.present\?\z/
           return Presence.new(receiver: parse(Regexp.last_match(1)), negated: true)  if expr =~ /\A(.+)\.blank\?\z/
 
+          return Assignment.new(receiver: parse(Regexp.last_match(1)), negated: false) if expr =~ /\A(.+)\.set\?\z/
+          return Assignment.new(receiver: parse(Regexp.last_match(1)), negated: true)  if expr =~ /\A(.+)\.unset\?\z/
+
           if expr =~ /\A(.+)\.split\("([^"]*)"\)\z/
             return Split.new(receiver: parse(Regexp.last_match(1)), separator: Regexp.last_match(2))
           end
@@ -274,6 +295,9 @@ module Hecks
           when Presence
             present = !blank?(interpret(node.receiver, state, attrs))
             node.negated ? !present : present
+          when Assignment
+            set = !interpret(node.receiver, state, attrs).nil?
+            node.negated ? !set : set
           when Split
             split_value(interpret(node.receiver, state, attrs), node.separator)
           when Last

--- a/lib/hecks/grammar/expression_operators.json
+++ b/lib/hecks/grammar/expression_operators.json
@@ -1643,6 +1643,130 @@
           "value": "length_to_size"
         }
       }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".set?"
+        },
+        "category": {
+          "value": "presence"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 1
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "suffix_match"
+        },
+        "position": {
+          "value": 21
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".set?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.set?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".set?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.set? -> !nil?(a)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".set?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Propose",
+      "args": {
+        "symbol": {
+          "value": ".unset?"
+        },
+        "category": {
+          "value": "presence"
+        },
+        "precedence": {
+          "value": 7
+        },
+        "arity": {
+          "value": 1
+        },
+        "grammar": {
+          "value": "inner"
+        },
+        "strategy": {
+          "value": "suffix_match"
+        },
+        "position": {
+          "value": 22
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".unset?"
+        },
+        "target": {
+          "value": "ruby"
+        },
+        "form": {
+          "value": "a.unset?"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Render",
+      "args": {
+        "symbol": {
+          "value": ".unset?"
+        },
+        "target": {
+          "value": "rust"
+        },
+        "form": {
+          "value": "a.unset? -> nil?(a)"
+        }
+      }
+    },
+    {
+      "verb": "Expression::Operator.Admit",
+      "args": {
+        "symbol": {
+          "value": ".unset?"
+        }
+      }
     }
   ]
 }

--- a/lib/hecks/ports/persistence/plugins/era/postgres_era/lineage/head_compiler.rb
+++ b/lib/hecks/ports/persistence/plugins/era/postgres_era/lineage/head_compiler.rb
@@ -252,8 +252,20 @@ module Hecks
           # written under — so the final edge applies uniformly, with no
           # per-era CASE. That equality is asserted, not argued: the spec
           # builds a third era both ways and diffs them.
+          # `edges.size != era - 1` — added alongside `head_body_sql`
+          # below, not merely a pre-existing guard: `names_by_era(aggregate,
+          # edges)` sizes `names[:storage]` to `edges.size + 1`, and the
+          # union above indexes it at `names[:storage][era - 2]` — CORRECT
+          # only when `edges` is the FULL chain reaching `era` (mint's own
+          # call, and the audit's own "after" reading, both are). A caller
+          # handed a SHORTER chain against the SAME `era` — exactly what
+          # the audit's own "before" reading is, `chain[0..-2]` against the
+          # unchanged target era — would index `names[:storage]` out of
+          # its real bounds instead of falling back to `chain_sql` the way
+          # every other mismatch here already does. Guarded structurally,
+          # not by trusting every future caller to know this invariant.
           def layered_chain_sql(aggregate, era, edges)
-            return nil if era < 3 || edges.size < 2
+            return nil if era < 3 || edges.size < 2 || edges.size != era - 1
 
             held = eras
             prior = held.find { |candidate| candidate[:ordinal] == era - 1 }
@@ -305,9 +317,19 @@ module Hecks
 
           # The translated tail as it would stand in era `era`, latest
           # entry per id, saves only — what the audit holds up against the
-          # bluebook and the edge.
+          # bluebook and the edge. Reads through `head_body_sql`, the SAME
+          # layered-or-full choice `compile_head!` makes at real mint time
+          # (that method's own comment has the full reasoning) — so this
+          # is provably what the real mint will materialize, not a second
+          # implementation that could silently drift from it. Safe for
+          # BOTH real callers: the "after" reading (`edges` is the full
+          # chain reaching `era`) and the "before" reading (`edges` one
+          # shorter, same `era` — `audit.rb`'s own `samples_for`/`check`
+          # callers) — `layered_chain_sql`'s own `edges.size != era - 1`
+          # guard falls back to `chain_sql` exactly when the shorter
+          # chain can't honestly answer the layered question.
           def translated_latest(aggregate, era, edges)
-            latest_of(chain_sql(aggregate, era, edges))
+            latest_of(head_body_sql(aggregate, era, edges))
           end
 
           # The UNtranslated ancestor tail, latest entry per id — the
@@ -363,15 +385,30 @@ module Hecks
           # write count; the ancestor side was already bounded that way
           # (the matview only ever holds the reduced tail, never raw
           # history — see latest_per_id's own comment).
+          # THE ONE PLACE THAT PICKS layered VS full — pulled out so the
+          # audit's own preview (`translated_latest`, below: both
+          # `bin/translation_audit`'s standalone run and the real
+          # mint-time gate in coverage_check.rb#audit!) reads through the
+          # IDENTICAL branch selection a real mint's own `compile_head!`
+          # will use, rather than a second, hand-kept-in-sync copy of this
+          # same "layered when eligible, else full" choice. Before this,
+          # `translated_latest` called `chain_sql` unconditionally — for
+          # any era >= 3, the real mint (this method, `full: false` by
+          # default) could materialize via the LAYERED path while the
+          # preview that approved it never exercised that branch at all.
+          # `full:` mirrors `compile_head!`'s own default; tail_merge's
+          # `full: true` rebuild is the one caller that ever needs the
+          # non-layered branch unconditionally.
+          def head_body_sql(aggregate, era, edges, full: false)
+            return chain_sql(aggregate, era, edges) if full
+
+            layered_chain_sql(aggregate, era, edges) || chain_sql(aggregate, era, edges)
+          end
+
           def compile_head!(aggregate, era, label, edges, full: false)
             storage_name = aggregate.storage_name
             view = matview(storage_name, era, label)
-            body =
-              if !full && (layered = layered_chain_sql(aggregate, era, edges))
-                layered
-              else
-                chain_sql(aggregate, era, edges)
-              end
+            body = head_body_sql(aggregate, era, edges, full: full)
             @db.exec(<<~SQL)
               CREATE MATERIALIZED VIEW #{quote(view)} AS
               #{body}

--- a/lib/hecks/runtime/command_rules/admissibility.rb
+++ b/lib/hecks/runtime/command_rules/admissibility.rb
@@ -145,7 +145,10 @@ module Hecks
           command.givens.each do |given|
             next if Bluebook::Expression::Evaluator.call(given.canonical, state, attrs)
 
-            raise GivenNotMet, "#{command.hecks_name} refused — #{given.description}"
+            raise GivenNotMet.new(
+              "#{command.hecks_name} refused — #{given.description}",
+              detail: Bluebook::Expression::Evaluator.comparison_detail(given.canonical, state, attrs)
+            )
           end
 
           enforce_lifecycle_guard(declaring, command, subject) if declaring

--- a/lib/hecks/runtime/errors.rb
+++ b/lib/hecks/runtime/errors.rb
@@ -5,7 +5,31 @@ module Hecks
   module Runtime
     class UnknownVerb < StandardError; end
     class EnsuresNotMet < StandardError; end
-    class GivenNotMet < StandardError; end
+    # `detail` — the failing comparison's own resolved operands, "left: X,
+    # right: Y" — set only when the given's TOP-LEVEL shape is a bare
+    # comparison (`Evaluator.comparison_detail`'s own comment has the full
+    # scoping); nil otherwise. Deliberately NOT folded into `#message`:
+    # that string is pinned byte-for-byte across this corpus's own specs
+    # (`raise_error(GivenNotMet, "...")`, command_rules_spec.rb and every
+    # domain that vendors this gem) as CONTRACT, so changing its shape by
+    # default would be a breaking change for every one of them. Riding on
+    # `#detailed_message` instead (Ruby 3.2+, what irb/a Rails console's
+    # own unhandled-exception banner already calls to show more than
+    # `#message`) means the detail actually reaches a human staring at a
+    # live refusal, without moving the string anything else asserts on.
+    class GivenNotMet < StandardError
+      attr_reader :detail
+
+      def initialize(message = nil, detail: nil)
+        super(message)
+        @detail = detail
+      end
+
+      def detailed_message(highlight: false, **opts)
+        base = super
+        detail ? "#{base} (#{detail})" : base
+      end
+    end
     class NotFound    < StandardError; end
     class LifecycleRefused < StandardError; end
     class TypeMismatch < StandardError; end

--- a/lib/hecks/runtime/errors.rb
+++ b/lib/hecks/runtime/errors.rb
@@ -5,6 +5,7 @@ module Hecks
   module Runtime
     class UnknownVerb < StandardError; end
     class EnsuresNotMet < StandardError; end
+
     # `detail` — the failing comparison's own resolved operands, "left: X,
     # right: Y" — set only when the given's TOP-LEVEL shape is a bare
     # comparison (`Evaluator.comparison_detail`'s own comment has the full
@@ -30,7 +31,8 @@ module Hecks
         detail ? "#{base} (#{detail})" : base
       end
     end
-    class NotFound    < StandardError; end
+
+    class NotFound < StandardError; end
     class LifecycleRefused < StandardError; end
     class TypeMismatch < StandardError; end
     # An argument the command does not declare. Sibling of TypeMismatch : that one

--- a/rust/host/src/expr_json.rs
+++ b/rust/host/src/expr_json.rs
@@ -17,7 +17,7 @@
 // STRUCTURALLY COMPLETE, NARROWLY INTERPRETED — a real, deliberate split,
 // not an oversight:
 //
-// - `parse`, below, accepts EVERY node the real grammar admits (all 27
+// - `parse`, below, accepts EVERY node the real grammar admits (all 28
 //   `rust::kernel::expr::Expr` variants), because `AstJson` on the Ruby
 //   side emits ALL of them for ANY value-object invariant an author
 //   writes — refusing to even PARSE an unfamiliar shape would turn
@@ -33,12 +33,12 @@
 //   by reading those files directly rather than re-derived from
 //   scratch, since this crate cannot import them. Every OTHER variant
 //   (`Include`, `Add`, `Modulo`, `BlockPredicate`, `Find`, `Array`,
-//   `MatchesRegex`, `Presence`, `Split`, `StartsWith`, `EndsWith`,
-//   `First`, `Last`) is a REAL, deliberate boundary, not a silent gap:
-//   `interpret` refuses them by name, cleanly, the same "unresolved,
-//   never guessed" discipline `reference_validate.rs`'s own unrecognized-
-//   type-name handling already holds to — an author who writes a value-
-//   object invariant using one of these gets a clear, loud audit
+//   `MatchesRegex`, `Presence`, `Assignment`, `Split`, `StartsWith`,
+//   `EndsWith`, `First`, `Last`) is a REAL, deliberate boundary, not a
+//   silent gap: `interpret` refuses them by name, cleanly, the same
+//   "unresolved, never guessed" discipline `reference_validate.rs`'s
+//   own unrecognized-type-name handling already holds to — an author
+//   who writes a value-object invariant using one of these gets a clear, loud audit
 //   failure naming exactly which operator isn't checked yet, never a
 //   silently-skipped or silently-wrong evaluation. Porting the full
 //   11-file operator surface (enumeration's own block-predicate
@@ -95,6 +95,7 @@ pub enum Expr {
     Array { elements: Vec<Expr> },
     MatchesRegex { receiver: Box<Expr>, pattern: String, flags: String },
     Presence { receiver: Box<Expr>, negated: bool },
+    Assignment { receiver: Box<Expr>, negated: bool },
     Split { receiver: Box<Expr>, separator: String },
     StartsWith { receiver: Box<Expr>, substring: String },
     EndsWith { receiver: Box<Expr>, substring: String },
@@ -176,6 +177,10 @@ pub fn parse(json: &Json) -> Result<Expr, String> {
         "presence" => Expr::Presence {
             receiver: Box::new(expr("receiver")?),
             negated: field("negated")?.as_bool().ok_or_else(|| format!("presence's negated isn't a boolean: {json}"))?,
+        },
+        "assignment" => Expr::Assignment {
+            receiver: Box::new(expr("receiver")?),
+            negated: field("negated")?.as_bool().ok_or_else(|| format!("assignment's negated isn't a boolean: {json}"))?,
         },
         "split" => Expr::Split { receiver: Box::new(expr("receiver")?), separator: str_field("separator")? },
         "starts_with" => Expr::StartsWith { receiver: Box::new(expr("receiver")?), substring: str_field("substring")? },
@@ -345,6 +350,7 @@ pub fn interpret(expr: &Expr, instance: &Json) -> Result<Value, String> {
         | Expr::Array { .. }
         | Expr::MatchesRegex { .. }
         | Expr::Presence { .. }
+        | Expr::Assignment { .. }
         | Expr::Split { .. }
         | Expr::StartsWith { .. }
         | Expr::EndsWith { .. }
@@ -444,6 +450,15 @@ mod tests {
         let expr = parse(&ast).expect("valid Expr JSON");
 
         let err = interpret(&expr, &field("value", serde_json::json!("x"))).unwrap_err();
+        assert!(err.contains("not yet supported"), "{err}");
+    }
+
+    #[test]
+    fn assignment_parses_structurally_the_same_as_presence_and_is_not_yet_interpreted_either() {
+        let ast = serde_json::json!({"op":"assignment","receiver":{"op":"lookup","path":"value"},"negated":true});
+        let expr = parse(&ast).expect("valid Expr JSON");
+
+        let err = interpret(&expr, &field("value", serde_json::json!(null))).unwrap_err();
         assert!(err.contains("not yet supported"), "{err}");
     }
 

--- a/rust/project/expr_emitter.rb
+++ b/rust/project/expr_emitter.rb
@@ -122,6 +122,8 @@ module RustProjection
         "Expr::MatchesRegex { receiver: Box::new(#{emit_resolver(node.receiver)}), pattern: #{node.pattern.inspect}.to_string(), flags: #{node.flags.inspect}.to_string() }"
       when r::Presence
         "Expr::Presence { receiver: Box::new(#{emit_resolver(node.receiver)}), negated: #{node.negated} }"
+      when r::Assignment
+        "Expr::Assignment { receiver: Box::new(#{emit_resolver(node.receiver)}), negated: #{node.negated} }"
       when r::Split
         "Expr::Split { receiver: Box::new(#{emit_resolver(node.receiver)}), separator: #{node.separator.inspect}.to_string() }"
       when r::StartsWith

--- a/rust/src/kernel/expr.rs
+++ b/rust/src/kernel/expr.rs
@@ -325,6 +325,15 @@ pub enum Expr {
     /// (`.blank?` is `.present?` negated) exactly the way `SignTest`
     /// above is one node for three symbols.
     Presence { receiver: Box<Expr>, negated: bool },
+    /// `receiver.set?` / `receiver.unset?` — `Resolver::Assignment`, the
+    /// same one-node-per-symbol-pair shape as `Presence` immediately
+    /// above, for a DELIBERATELY narrower question: `!receiver.is_nil()`,
+    /// full stop — not `Presence`'s own Rails-standard emptiness (nil/
+    /// false, or an EMPTY String/Array, are blank). An assigned-but-empty
+    /// value is `.set?`, not `.unset?`, unlike `.present?`'s own reading
+    /// of the identical value — see `expression_operators::presence`'s
+    /// own header for the full reasoning.
+    Assignment { receiver: Box<Expr>, negated: bool },
     /// `receiver.split("SEP")` — `Resolver::Split`. Produces a real
     /// `Value::Array`, not `Value::List` — see that variant's own header.
     Split { receiver: Box<Expr>, separator: String },
@@ -385,7 +394,7 @@ fn category_of(expr: &Expr) -> OperatorCategory {
         ToS(..) => OperatorCategory::ToString,
         BlockPredicate { .. } | Find { .. } => OperatorCategory::Enumeration,
         MatchesRegex { .. } => OperatorCategory::PatternMatch,
-        Presence { .. } => OperatorCategory::Presence,
+        Presence { .. } | Assignment { .. } => OperatorCategory::Presence,
         Split { .. } | StartsWith { .. } | EndsWith { .. } => OperatorCategory::Text,
         First(..) | Last(..) => OperatorCategory::Positional,
         Int(..) | Float(..) | Str(..) | Bool(..) | Nil | Lookup(..) | Array(..) => {
@@ -421,7 +430,11 @@ fn dispatch_operator(category: OperatorCategory, expr: &Expr, ctx: &EvalContext)
         OperatorCategory::ToString => to_string::interpret(expr, ctx),
         OperatorCategory::Enumeration => enumeration::interpret(expr, ctx),
         OperatorCategory::PatternMatch => pattern_match::interpret(expr, ctx),
-        OperatorCategory::Presence => presence::interpret(expr, ctx),
+        OperatorCategory::Presence => match expr {
+            Expr::Presence { .. } => presence::interpret(expr, ctx),
+            Expr::Assignment { .. } => presence::interpret_assignment(expr, ctx),
+            _ => Err(Refusal::TypeMismatch(format!("dispatch_operator(Presence, ..) called with {expr:?} — a router bug"))),
+        },
         OperatorCategory::Text => text::interpret(expr, ctx),
         OperatorCategory::Positional => positional::interpret(expr, ctx),
     }

--- a/rust/src/kernel/expression_operators/presence.rs
+++ b/rust/src/kernel/expression_operators/presence.rs
@@ -1,15 +1,26 @@
 // Implements the Ruby grammar's "presence" expression-operator category
-// (projection.json: `.present?`, `.blank?` — two symbols, one interpreter
-// node sharing a `negated` flag, the exact `SignTest`-style precedent
-// `sign_test.rs`'s own header already documents for a symbol pair sugar
-// over one primitive) — `Resolver::Presence` (resolver.rb's `blank?`),
-// read directly: Rails-standard semantics, not just `!nil?` — `nil`/
-// `false` are blank, and a `Str`/`List`/`Array` is blank when EMPTY, not
-// merely falsy.
+// (projection.json: `.present?`, `.blank?`, `.set?`, `.unset?` — two
+// symbol pairs, one interpreter FUNCTION each, sharing a `negated` flag
+// the exact `SignTest`-style precedent `sign_test.rs`'s own header
+// already documents for a symbol pair sugar over one primitive) —
+// `Resolver::Presence` (resolver.rb's `blank?`), read directly:
+// Rails-standard semantics, not just `!nil?` — `nil`/`false` are blank,
+// and a `Str`/`List`/`Array` is blank when EMPTY, not merely falsy.
 //
-// `expr.rs`'s `category_of` guarantees `interpret` below is only ever
-// called with `Presence` — see `logical.rs`'s header for why the
-// trailing arm is a router-bug guard, not a real refusal path.
+// `.set?`/`.unset?` (`Resolver::Assignment`, `interpret_assignment`
+// below) ask a DELIBERATELY narrower question instead: `!receiver.
+// is_nil()`, full stop — an assigned-but-empty `Str`/`Array` is `.set?`,
+// unlike `.present?`'s own reading of the identical value. Both symbol
+// pairs share this one file because both share `OperatorCategory::
+// Presence` (`expr.rs`'s own `category_of`) — the same "one category,
+// several `Expr` variants, one function each" shape `arithmetic.rs`
+// already uses for `Add`/`Modulo`.
+//
+// `expr.rs`'s `category_of` maps BOTH `Presence` and `Assignment` to
+// `OperatorCategory::Presence`; `dispatch_operator` sub-matches on the
+// `Expr` variant itself to pick `interpret` vs `interpret_assignment` —
+// see `logical.rs`'s header for why each function's own trailing arm is
+// a router-bug guard, not a real refusal path.
 
 use crate::kernel::expr::{interpret as eval, EvalContext, Expr, Value};
 use crate::kernel::Refusal;
@@ -22,6 +33,25 @@ pub fn interpret(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
     let v = eval(receiver, ctx)?;
     let present = !blank(&v);
     Ok(Value::Bool(if *negated { !present } else { present }))
+}
+
+/// `receiver.set?` / `receiver.unset?` — `Expr::Assignment`, the sibling
+/// question to `interpret` above: `!receiver.is_nil()`, full stop. NOT
+/// `blank()` — an assigned-but-empty `Str`/`Array` is `.set?`, unlike
+/// `Presence`'s own reading of the identical value (`blank()`'s own
+/// header has the full contrast). Kept in this file rather than a
+/// sibling one: both share `OperatorCategory::Presence` (`expr.rs`'s own
+/// `category_of`), the same "one category, several `Expr` variants"
+/// precedent `arithmetic.rs`/`sized.rs` already set for `Add`/`Modulo`
+/// and `Empty`/`Size`.
+pub fn interpret_assignment(expr: &Expr, ctx: &EvalContext) -> Result<Value, Refusal> {
+    let Expr::Assignment { receiver, negated } = expr else {
+        return Err(Refusal::TypeMismatch(format!("presence::interpret_assignment called with a non-assignment node {expr:?} — a router bug")));
+    };
+
+    let v = eval(receiver, ctx)?;
+    let set = !matches!(v, Value::Nil);
+    Ok(Value::Bool(if *negated { !set } else { set }))
 }
 
 /// `Resolver#blank?`, read directly: `nil`/`false` are blank outright;
@@ -78,5 +108,29 @@ mod tests {
     fn an_empty_array_literal_is_blank() {
         assert_eq!(present(Expr::Array(vec![]), false), Value::Bool(false));
         assert_eq!(present(Expr::Array(vec![Expr::Int(1)]), false), Value::Bool(true));
+    }
+
+    fn set(receiver: Expr, negated: bool) -> Value {
+        let expr = Expr::Assignment { receiver: Box::new(receiver), negated };
+        let ctx = EvalContext { args: &NoFields, instance: &NoFields };
+        eval(&expr, &ctx).expect("evaluates")
+    }
+
+    #[test]
+    fn only_nil_is_unset() {
+        assert_eq!(set(Expr::Nil, false), Value::Bool(false));
+        assert_eq!(set(Expr::Bool(false), false), Value::Bool(true));
+    }
+
+    #[test]
+    fn an_empty_string_or_array_is_set_unlike_present_s_own_reading() {
+        assert_eq!(set(Expr::Str(String::new()), false), Value::Bool(true));
+        assert_eq!(set(Expr::Array(vec![]), false), Value::Bool(true));
+    }
+
+    #[test]
+    fn unset_negates_set() {
+        assert_eq!(set(Expr::Nil, true), Value::Bool(true));
+        assert_eq!(set(Expr::Str("x".to_string()), true), Value::Bool(false));
     }
 }

--- a/spec/adapters/driven/postgres_era/lineage_spec.rb
+++ b/spec/adapters/driven/postgres_era/lineage_spec.rb
@@ -110,6 +110,54 @@ RSpec.describe "lineage in the PostgresEra adapter",
     RUBY
   end
 
+  # A REKEYED sibling of V3_SOURCE, identical fields, identity moved from
+  # `kind` to a new `ref` attribute — the layered/full equivalence test
+  # below exists because `layered_chain_sql`'s own `id_column` CASE
+  # (Translation::RuleCompiler.id_case) is exactly the piece the ordinary
+  # V3_SOURCE edge above (a bare `rename`) never exercises: identity
+  # NEVER changes across it, so `aggregate_id` passes through unmodified
+  # either way, layered or full, whether or not the CASE's own guard is
+  # right.
+  V3_REKEYED_SOURCE = <<~BLUEBOOK.freeze
+    Hecks.bluebook "Ledger" do
+      aggregate "Account" do
+        identified_by :ref
+
+        attribute :amount, Money
+        attribute :kind, Kind
+        attribute :denomination, Denomination
+        attribute :ref, Ref
+
+        value_object "Money" do
+          attribute :cents, Integer
+        end
+
+        value_object "Kind" do
+          attribute :label, String
+        end
+
+        value_object "Denomination" do
+          attribute :code, String
+        end
+
+        value_object "Ref" do
+          attribute :value, String
+        end
+      end
+    end
+  BLUEBOOK
+
+  def edge_source_v3_rekey(from:, to:)
+    <<~RUBY
+      Hecks.data_translation("Ledger", from: #{from.inspect}, to: #{to.inspect}) do
+        aggregate("Account") do
+          rekey sql: "'ref-' || ((__s -> 'kind') ->> 'label')"
+          backfill :ref, default: "unknown"
+        end
+      end
+    RUBY
+  end
+
   before(:all) do
     skip "no reachable Postgres — start one to run this spec" unless PostgresProbe.available?
 
@@ -1416,6 +1464,91 @@ RSpec.describe "lineage in the PostgresEra adapter",
 
     expect(layered).to eq(full)
     expect(layered).not_to be_empty
+  end
+
+  # THE SAME EQUIVALENCE, FOR A REKEY SPECIFICALLY — `layered_chain_sql`'s
+  # own `id_column` CASE (Translation::RuleCompiler.id_case) is dead code
+  # the test above never exercises: `edge_source_v3`'s edge never changes
+  # identity, so `aggregate_id` passes through unmodified whether the
+  # CASE's own guard is right or not. This is also what closes the real
+  # gap `translated_latest`'s own header now documents: before
+  # `head_body_sql` existed, the audit's preview (`translated_latest`)
+  # NEVER read this branch at all — a rekey reaching era 3 could show one
+  # answer at audit time and a DIFFERENT one once actually minted, with
+  # nothing here to catch it either way.
+  it "produces the identical id under a REKEY too — the layered build's id_column CASE agrees with the full one" do
+    write_v1_record
+    l1 = label_of(V1_SOURCE)
+    l2 = label_of(V2_SOURCE)
+    l3 = label_of(V3_REKEYED_SOURCE)
+    check!(V2_SOURCE, translation_source: edge_source(from: l1, to: l2))
+
+    # more era-2 traffic, so the layer has both a matview AND live rows
+    # of its own to fold in — same reason the ordinary-edge test above
+    # writes a second record before minting era 3
+    # kind "personal", deliberately DIFFERENT from the v1 record's own
+    # "biz" -> "business" — a rekey collapses onto `kind.label`, and
+    # reusing "business" here would collide the two rows onto the SAME
+    # new id, tripping the audit's own count-preservation gate for a
+    # reason that has nothing to do with what this test checks.
+    registry = load_registry(V2_SOURCE)
+    account = registry.bluebooks.values.first.aggregate("Account")
+    adapter = Hecks::Adapters::PostgresEra.new(aggregate: account, settings: { database: LINEAGE_DB, domain: "Ledger" })
+    adapter.save(Hecks::Runtime::Instance.new(
+                   aggregate: account, id: "personal",
+                   state: { amount: { "cents" => 250 }, kind: { "label" => "personal" },
+                            denomination: { "code" => "USD" } }
+                 ))
+
+    rekey_edge = edge_source_v3_rekey(from: l2, to: l3)
+    edges = "#{edge_source(from: l1, to: l2)}\n#{rekey_edge}"
+    drifted = load_registry(V3_REKEYED_SOURCE, translation_source: edges)
+
+    # a rekey's only verification is the audit's human-approved sample —
+    # the mint refuses non-interactively without it, same as every other
+    # compute/rekey edge in this file
+    expect do
+      Hecks::Adapters::PostgresEra::LineageManager.check!(
+        registry: drifted, bluebook: drifted.bluebooks.values.first,
+        current_text: V3_REKEYED_SOURCE, settings: { database: LINEAGE_DB }
+      )
+    end.to raise_error(Hecks::Runtime::WiringError, /this edge carries a compute or rekey rule/)
+
+    db = PG.connect(dbname: LINEAGE_DB)
+    ledger_lineage = Hecks::Adapters::PostgresEra::Lineage.new(db, "Ledger")
+    ledger_lineage.record_approval!(
+      from: l2, to: l3,
+      edge_digest: Hecks::Translation::Audit.edge_digest(drifted.translations.find { |t| t.from == l2 && t.to == l3 })
+    )
+    db.close
+
+    Hecks::Adapters::PostgresEra::LineageManager.check!(
+      registry: drifted, bluebook: drifted.bluebooks.values.first,
+      current_text: V3_REKEYED_SOURCE, settings: { database: LINEAGE_DB }
+    )
+
+    db = PG.connect(dbname: LINEAGE_DB)
+    layered = db.exec("SELECT aggregate_id, operation, state FROM #{PG::Connection.quote_ident("account_lineage_3_#{l3}")} ORDER BY aggregate_id").values
+
+    # the definition actually used era 2's matview rather than the journal
+    definition = db.exec_params("SELECT definition FROM pg_matviews WHERE matviewname = $1",
+                                ["account_lineage_3_#{l3}"])[0]["definition"]
+    expect(definition).to include("account_lineage_2_#{l2}")
+
+    # ...and it agrees with the from-scratch build, row for row — ids
+    # included, the one dimension the ordinary-edge test above cannot see
+    lineage = Hecks::Adapters::PostgresEra::Lineage.new(db, "Ledger")
+    chain = Hecks::Adapters::PostgresEra::LineageManager.edge_chain(
+      load_registry(V3_REKEYED_SOURCE, translation_source: edges), load_registry(V3_REKEYED_SOURCE).bluebooks.values.first,
+      lineage.eras[0..-2], l3
+    )
+    full = db.exec("SELECT aggregate_id, operation, state FROM (#{lineage.chain_sql(account, 3,
+                                                                                    chain)}) full_build ORDER BY aggregate_id").values
+    db.close
+
+    expect(layered).to eq(full)
+    expect(layered).not_to be_empty
+    expect(layered.map(&:first)).to include("ref-business")
   end
 
   it "the layered build still honours the cut — an era-2 checkout writing after era 3 was minted never reaches era 3's head" do

--- a/spec/expression_spec.rb
+++ b/spec/expression_spec.rb
@@ -488,6 +488,26 @@ RSpec.describe "the expression sublanguage" do
     end
   end
 
+  describe "set?/unset? -- deliberately narrower than present?/blank?" do
+    it "asks only whether the receiver is nil, never whether it is empty" do
+      expect(evaluate("value.set?", value: nil)).to be(false)
+      expect(evaluate("value.unset?", value: nil)).to be(true)
+
+      # THE POINT OF THE PAIR: an assigned-but-empty value is SET, unlike
+      # `.present?`'s own reading of the identical value (see the block
+      # above -- `"".present?` is false).
+      expect(evaluate("value.set?", value: "")).to be(true)
+      expect(evaluate("value.unset?", value: "")).to be(false)
+      expect(evaluate("value.set?", value: [])).to be(true)
+    end
+
+    it "reads an optional field's nil the same way whether it was never assigned or explicitly cleared" do
+      expect(evaluate("superseded_by.unset?", superseded_by: nil)).to be(true)
+      expect(evaluate("superseded_by.set?", superseded_by: nil)).to be(false)
+      expect(evaluate("superseded_by.unset?", superseded_by: "evt-1")).to be(false)
+    end
+  end
+
   describe "comparison_detail" do
     def detail(expression, state = {}, args = {})
       Hecks::Bluebook::Expression::Evaluator.comparison_detail(expression, state, args)

--- a/spec/expression_spec.rb
+++ b/spec/expression_spec.rb
@@ -488,6 +488,33 @@ RSpec.describe "the expression sublanguage" do
     end
   end
 
+  describe "comparison_detail" do
+    def detail(expression, state = {}, args = {})
+      Hecks::Bluebook::Expression::Evaluator.comparison_detail(expression, state, args)
+    end
+
+    it "reports the resolved operands of a bare comparison" do
+      expect(detail("status == \"open\"", status: "closed")).to eq('left: "closed", right: "open"')
+      expect(detail("balance.cents >= 0", balance: { cents: -5 })).to eq("left: -5, right: 0")
+    end
+
+    it "renders a nil operand the same way every other refusal does" do
+      expect(detail("superseded_by == nil", superseded_by: nil)).to eq("left: nil, right: nil")
+    end
+
+    it "is nil for shapes with no single honest left/right — Or/And/Not/Include/Resolve" do
+      expect(detail("a == 1 || b == 2", a: 0, b: 0)).to be_nil
+      expect(detail("a == 1 && b == 2", a: 0, b: 0)).to be_nil
+      expect(detail("!(a == 1)", a: 1)).to be_nil
+      expect(detail("names.include?(\"x\")", names: [])).to be_nil
+      expect(detail("flag", flag: false)).to be_nil
+    end
+
+    it "is nil, not raised, when an operand itself fails to resolve" do
+      expect(detail("totally_unknown == 1")).to be_nil
+    end
+  end
+
   describe "agreeing with Ruby itself" do
     def agrees?(expression, bindings)
       mine = begin

--- a/spec/operator_conformance_spec.rb
+++ b/spec/operator_conformance_spec.rb
@@ -135,14 +135,14 @@ RSpec.describe "the operator domain" do
   it "orders the inner grammar exactly the way grammar.md documents it" do
     # rule 1 (.length), 2-5 (literals), and 12 (dotted lookup) are
     # terminal productions, not operators — same exclusion. This is rules
-    # 6-11, in order, followed by the eight vendored operators
+    # 6-11, in order, followed by the ten vendored operators
     # (`.match?`/`.present?`/`.blank?`/`.split`/`.start_with?`/
-    # `.end_with?`/`.first`/`.last`) admitted after grammar.md was
-    # written — see this file's own header update for the finding that
-    # sent them through the ledger for the first time.
+    # `.end_with?`/`.first`/`.last`/`.set?`/`.unset?`) admitted after
+    # grammar.md was written — see this file's own header update for the
+    # finding that sent them through the ledger for the first time.
     expect(symbols(by_grammar("inner"))).to eq(
       ["+", ".positive?", ".negative?", ".zero?", ".empty?", ".to_s", ".modulo", ".size", ".any?", ".none?", ".all?", ".find",
-       ".match?", ".present?", ".blank?", ".split", ".start_with?", ".end_with?", ".first", ".last"]
+       ".match?", ".present?", ".blank?", ".split", ".start_with?", ".end_with?", ".first", ".last", ".set?", ".unset?"]
     )
   end
 
@@ -186,7 +186,9 @@ RSpec.describe "the operator domain" do
     ".start_with?" => -> { Resolver.parse('a.start_with?("x")').is_a?(Resolver::StartsWith) },
     ".end_with?"   => -> { Resolver.parse('a.end_with?("x")').is_a?(Resolver::EndsWith) },
     ".first"       => -> { Resolver.parse("a.first").is_a?(Resolver::First) },
-    ".last"        => -> { Resolver.parse("a.last").is_a?(Resolver::Last) }
+    ".last"        => -> { Resolver.parse("a.last").is_a?(Resolver::Last) },
+    ".set?"        => -> { Resolver.parse("a.set?").is_a?(Resolver::Assignment) && !Resolver.parse("a.set?").negated },
+    ".unset?"      => -> { Resolver.parse("a.unset?").is_a?(Resolver::Assignment) && Resolver.parse("a.unset?").negated }
   }.freeze
 
   it "implements every admitted structural operator, and no other" do
@@ -234,7 +236,8 @@ RSpec.describe "the operator domain" do
     ".find" => Resolver::Find,
     ".match?" => Resolver::MatchesRegex, ".present?" => Resolver::Presence, ".blank?" => Resolver::Presence,
     ".split" => Resolver::Split, ".start_with?" => Resolver::StartsWith, ".end_with?" => Resolver::EndsWith,
-    ".first" => Resolver::First, ".last" => Resolver::Last
+    ".first" => Resolver::First, ".last" => Resolver::Last,
+    ".set?" => Resolver::Assignment, ".unset?" => Resolver::Assignment
   }.freeze
 
   # Every real Class either module defines DIRECTLY (`false` — no

--- a/spec/runtime/command_rules_spec.rb
+++ b/spec/runtime/command_rules_spec.rb
@@ -146,6 +146,22 @@ narrative: { text: "Opening" })
       end.to raise_error(Hecks::Runtime::GivenNotMet,
                          "Amend refused — an amendment leaves a non-negative amount")
     end
+
+    it "carries the failing comparison's own operands as #detail, off #message" do
+      runtime = funded_account(boot_banking)
+
+      error = nil
+      begin
+        runtime.dispatch("Banking::Account.LedgerEntry.Amend",
+                         number: { value: "a1" }, sequence: { value: 1 }, adjustment: { cents: -10_001, currency: "USD" }, narrative: narrative)
+      rescue Hecks::Runtime::GivenNotMet => e
+        error = e
+      end
+
+      expect(error.message).to eq("Amend refused — an amendment leaves a non-negative amount")
+      expect(error.detail).to eq("left: -1, right: 0")
+      expect(error.detailed_message).to include(error.message).and include(error.detail)
+    end
   end
 
   describe "the state machine" do


### PR DESCRIPTION
Responds to three pieces of DX feedback in one place — each is an independent commit, easy to split or cherry-pick if you'd rather review/merge them separately.

## 1. `given` refusals now carry their comparison's own operands

A refused `given` names its own description ("not already superseded") but not what the block actually evaluated to. When a given's top-level shape is a bare comparison, `GivenNotMet` now carries `"left: X, right: Y"` as `#detail` — off `#message`, so every corpus spec asserting an exact refusal string keeps passing unchanged. Rides on Ruby's own `#detailed_message` (3.2+), so it shows up in an irb/console unhandled-exception banner without any caller code reading it on purpose.

## 2. `.set?` / `.unset?` — deliberately narrower than `.present?` / `.blank?`

`.present?`/`.blank?` are Rails-standard emptiness — which quietly conflates "was this ever assigned" with "does the assigned value happen to be empty." For an optional field whose only legitimate unset state is nil, that's a real trap. `.set?`/`.unset?` ask exactly one question: `!receiver.nil?`, full stop.

Admitted through the real grammar ledger (not vendored around it), and ported to the Rust kernel (`Expr::Assignment`, sharing `OperatorCategory::Presence`) and to `rust/host`'s JSON AST (parseable there for structural completeness, not yet interpreted — the same documented boundary `.present?`/`.blank?` themselves already sit behind in that crate).

## 3. Translation audit's preview now provably matches what a real mint materializes

`translated_latest` (the audit's own preview, in both `bin/translation_audit` and the real mint-time gate) called `chain_sql` unconditionally. `compile_head!`, at actual mint time, picks the LAYERED build instead whenever era >= 3 and a prior matview exists — most eras of any domain that has minted more than a couple of times. The two were asserted equivalent by spec, but only for an ordinary (non-rekey) edge; a rekey's own `id_column` CASE went through the layered path at real mint time and through `chain_sql` alone at every preview, with no test ever exercising both for the same rekey.

Pulled the layered-or-full choice into one `head_body_sql` picker both `compile_head!` and `translated_latest` now call, so the preview is provably what a real mint will materialize — closing the whole class of "hand-run SQL disagrees with the tool's own preview" risk. Added a defensive `edges.size != era - 1` guard to `layered_chain_sql` (a caller handed a shorter edge chain against the same target era — the audit's own "before" reading always is — used to index past its own array bounds instead of falling back cleanly). New spec coverage: a rekey-reaching-era-3 sibling of the existing layered/full equivalence test, exercising the exact CASE expression the pre-existing ordinary-edge version can never reach.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
