### PR TITLE
Remove hardcoded prod DB credential/endpoint from test fixture

### DIFF
--- a/rust/host/src/main.rs
+++ b/rust/host/src/main.rs
@@ -537,7 +537,7 @@ mod tests {
     #[test]
     fn parses_a_password_with_uri_reserved_characters() {
         let config = parse_database_url(
-            "postgres://postgres:EiP$wT3S9Gi?#rIAjSDii*>GHKPX@hecks-pizzas-pizzasdbcluster-pfblqfmbmpf2.cluster-cmvsoy8c6td2.us-east-1.rds.amazonaws.com:5432/pizzas",
+            "postgres://postgres:T3st$Pa?#ss*>Word@db.example.com:5432/pizzas",
         )
         .expect("should parse despite ?/# in the password");
         assert_eq!(config.get_hosts().len(), 1);


### PR DESCRIPTION
The `parses_a_password_with_uri_reserved_characters` test in `rust/host/src/main.rs` embedded a real-looking Aurora cluster endpoint and Secrets-Manager-shaped password for the pizzas DB. Replaced with a synthetic value that preserves the same reserved characters (`$ ? # * >`) the test exists to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)