### PR TITLE
Add LocalStorage: a persisted_by adapter for browser-hosted domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,8 +624,10 @@ before assuming a capability exists that isn't demonstrated above.
 
 ## Quickstart
 
-There is no published gem. You clone the repository, and the
-repository is the tool:
+hecks is [published on RubyGems](https://rubygems.org/gems/hecks), but
+the quickstart below clones the repository instead, since the example
+domains it runs (`examples/banking`, `examples/pizzas`) live in the
+repo, not in the gem:
 
 ```sh
 git clone https://github.com/heckslabs/hecks

--- a/lib/hecks/adapters/driven.rb
+++ b/lib/hecks/adapters/driven.rb
@@ -32,6 +32,7 @@ require_relative "driven/postgres"
 Hecks::Adapters.autoload(:PostgresEra, "hecks/ports/persistence/plugins/era")
 require_relative "driven/lambda"
 require_relative "driven/heki"
+require_relative "driven/local_storage"
 require_relative "driven/prism"
 require_relative "driven/folder"
 require_relative "driven/d1"

--- a/lib/hecks/adapters/driven/local_storage.adapter
+++ b/lib/hecks/adapters/driven/local_storage.adapter
@@ -1,0 +1,3 @@
+Hecks.adapter "LocalStorage" do
+  port "persistence"
+end

--- a/lib/hecks/adapters/driven/local_storage.rb
+++ b/lib/hecks/adapters/driven/local_storage.rb
@@ -1,0 +1,120 @@
+require_relative "../../ports/persistence/append_only"
+require_relative "../../ports/query/in_memory"
+require_relative "in_memory_ordering"
+require_relative "../../runtime/instance"
+
+module Hecks
+  module Adapters
+    # A BROWSER-HOSTED DOMAIN'S OWN DECLARED INTENT — not a second Memory
+    # wearing a different name. Ruby has no way to reach a real browser's
+    # `window.localStorage` at all (it is per-tab, per-origin, JS-only,
+    # unreachable over any network the way D1's own REST API is) — so
+    # this Ruby-side adapter is honestly a stand-in: in-process, ephemeral,
+    # mechanically identical to Memory. What earns it a name of its own
+    # is what it DECLARES, not what it happens to do in Ruby: `persisted_by
+    # "LocalStorage"` says "this domain expects real, durable, single-
+    # device storage the moment it's actually running where it's meant to
+    # run" — the same distinction Heki (real local durability) already
+    # draws against Memory (deliberately ephemeral, test/example-only),
+    # one adapter over. `bin/console`, the fuzzer, `spec/`, `bin/
+    # model_check` all get a domain that boots and behaves correctly
+    # against this adapter; only a real browser gets the real durability.
+    #
+    # THE REAL BROWSER HALF lives outside this file entirely: `rust/web`'s
+    # `dispatch(json)` (docs/implemented/decisions/0015) takes an optional
+    # `"seed"` (the exact `"instances"` shape it also answers with) plus
+    # `"steps"` — a host rehydrates from a prior snapshot and replays only
+    # the new command(s), rather than the whole history every call. A
+    # page bound to this adapter is expected to hold that snapshot in
+    # `window.localStorage` itself (get on load, set after every
+    # `dispatch`) — the seed/instances round trip IS the adapter, once
+    # you're in the one runtime that can actually reach the storage this
+    # name promises.
+    class LocalStorage
+      # TENANT-CAPABLE TRIVIALLY, same reasoning as Memory's own — a
+      # browser tab is exactly one origin, exactly one user; there is no
+      # second tenant this in-process Hash could ever confuse a first
+      # one with.
+      def self.tenant_capable? = true
+      def persistence_capabilities = [:atomic_put]
+
+      attr_reader :aggregate, :events
+
+      def initialize(aggregate:, settings: {}, root: nil)
+        @aggregate = aggregate
+        @records   = {}
+        @events    = []
+        @entries   = []
+      end
+
+      def find(id) = @records[id.to_s]
+      def count    = @records.size
+
+      def all(order_by: nil, direction: :asc)
+        InMemoryOrdering.ordered(@records.values, aggregate: @aggregate, order_by: order_by, direction: direction)
+      end
+
+      # THE DECISION THE GUIDE ASKS FOR, MADE EXPLICITLY: no compiled
+      # dialect of its own, same as Heki/Memory — a personal-scale local
+      # store answering by walking `all` is correct on day one, and
+      # nothing about a browser tab's own data volume asks for pushdown.
+      def query(specification, args = {}, context: {})
+        Ports::Query::InMemory.execute(all, specification, args, registry: context[:registry])
+      end
+
+      def append(entry)
+        @entries << entry
+        entry
+      end
+
+      def project(entry)
+        if entry.save?
+          @records[entry.id] = Runtime::Instance.new(aggregate: @aggregate, id: entry.id, state: entry.state.dup)
+        else
+          @records.delete(entry.id)
+        end
+      end
+
+      def save(instance)
+        entry = Ports::Persistence::Entry.new(operation: "save", id: instance.id.to_s, state: instance.state.dup)
+        append(entry)
+        project(entry)
+      end
+
+      def atomic_put(entry, insert_only: false)
+        exists = @records.key?(entry.id.to_s)
+        return :conflicted if insert_only && exists
+
+        status = exists ? :replaced : :inserted
+        append(entry)
+        project(entry)
+        status
+      end
+
+      def delete(id)
+        entry = Ports::Persistence::Entry.new(operation: "delete", id: id.to_s, state: nil)
+        append(entry)
+        project(entry)
+      end
+
+      def record_event(event) = @events << event
+
+      def entries = @entries.dup
+
+      def reset!
+        @records = {}
+        @events  = []
+        @entries = []
+        self
+      end
+
+      # NOT lineage_capable? — deliberately absent, the same trade Heki
+      # makes and states plainly (writing-an-adapter.md's own section on
+      # it): a domain bound here has no edge for its own shape to travel
+      # across if it ever changes; that must be hand-migrated, or the
+      # shape must not change. A browser-local personal store is exactly
+      # the small-adapter case that guide names as a fine place to make
+      # that trade.
+    end
+  end
+end

--- a/spec/adapters/driven/local_storage_spec.rb
+++ b/spec/adapters/driven/local_storage_spec.rb
@@ -1,0 +1,100 @@
+require "hecks"
+
+# Mechanically identical to Memory (spec/adapters/driven/memory_spec.rb)
+# on purpose — see local_storage.rb's own header for why a Ruby-side
+# stand-in for a browser's `window.localStorage` can only ever be that,
+# and why the name still earns its own adapter rather than being an
+# alias for Memory.
+RSpec.describe Hecks::Adapters::LocalStorage do
+  def boot_pizzas_on_local_storage
+    registry = Hecks::Runtime::Registry.new
+
+    Hecks.with_registry(registry) do
+      Kernel.load(InMemoryDomain::PERSISTENCE_PORT)
+      Kernel.load(InMemoryDomain::EXTRACTION_PORT)
+      Kernel.load(InMemoryDomain::MEMORY_ADAPTER)
+      Kernel.load(InMemoryDomain::LOCAL_STORAGE_ADAPTER)
+      Kernel.load(InMemoryDomain::PRISM_ADAPTER)
+      Kernel.load(InMemoryDomain::PIZZAS_BLUEBOOK)
+
+      Hecks.hecksagon("Pizzas") do
+        uses_framework "Governance"
+        ::Pizzas::Order.persisted_by("LocalStorage")
+      end
+      Hecks.hecksagon("Governance") do
+        ::Governance::RoleAssignment.persisted_by("Memory")
+        ::Governance::RoleTransition.persisted_by("Memory")
+      end
+    end
+
+    registry.verify!
+    Hecks::Runtime::Loader.bind_runtime(Hecks::Runtime::Dispatcher.new(registry))
+  end
+
+  let(:runtime) { boot_pizzas_on_local_storage }
+
+  def repository
+    runtime.registry.repository("Pizzas", runtime.registry.bluebook("Pizzas").aggregate("Order"))
+  end
+
+  def create(name: "Margherita")
+    runtime.dispatch("Pizzas::Order.CreatePizza",
+                     name: { value: name }, pizza: { price_cents: { cents: 1200 }, size: { value: "large" } })
+  end
+
+  it "boots and dispatches a real domain against it, same as any other persistence adapter" do
+    order = create(name: "Margherita")
+
+    expect(order.instance.status).to eq("available")
+    expect(repository.find(order.instance.id)).not_to be_nil
+    expect(repository.count).to eq(1)
+  end
+
+  it "answers a declared query correctly through the InMemory fallback" do
+    create(name: "Margherita")
+    create(name: "Diavola")
+
+    available = runtime.query("Pizzas::Order.Available")
+    expect(available.map { |row| row[:name].value }.sort).to eq(%w[Diavola Margherita])
+  end
+
+  it "clears saved records, the append log, and recorded events back to empty" do
+    create(name: "Margherita")
+    create(name: "Diavola")
+
+    expect(repository.count).to eq(2)
+    expect(repository.entries).not_to be_empty
+
+    repository.reset!
+
+    expect(repository.count).to eq(0)
+    expect(repository.all).to eq([])
+    expect(repository.entries).to eq([])
+    expect(repository.events).to eq([])
+  end
+
+  it "leaves the adapter fully usable afterward — not just empty, but able to save and find again" do
+    create(name: "Margherita")
+    repository.reset!
+    pizza = create(name: "Diavola")
+
+    expect(repository.count).to eq(1)
+    expect(repository.find(pizza.id)).not_to be_nil
+  end
+
+  it "responds to reset! on the raw adapter, not only through AppendOnly's wrapper" do
+    local_storage = described_class.new(aggregate: runtime.registry.bluebook("Pizzas").aggregate("Order"))
+    local_storage.save(Struct.new(:id, :state).new("1", { name: { value: "Margherita" } }))
+
+    expect(local_storage.reset!).to equal(local_storage)
+    expect(local_storage.count).to eq(0)
+  end
+
+  it "is trivially tenant-capable, the same guarantee Memory carries" do
+    expect(described_class.tenant_capable?).to be(true)
+  end
+
+  it "does not claim lineage capability — no era story for a small local adapter" do
+    expect(described_class.respond_to?(:lineage_capable?)).to be(false)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ module InMemoryDomain
   PERSISTENCE_PORT = File.join(ROOT, "lib/hecks/ports/persistence.port")
   EXTRACTION_PORT  = File.join(ROOT, "lib/hecks/ports/extraction.port")
   MEMORY_ADAPTER   = File.join(ROOT, "lib/hecks/adapters/driven/memory.adapter")
+  LOCAL_STORAGE_ADAPTER = File.join(ROOT, "lib/hecks/adapters/driven/local_storage.adapter")
   PRISM_ADAPTER    = File.join(ROOT, "lib/hecks/adapters/driven/prism.adapter")
   POSTGRES_ADAPTER = File.join(ROOT, "lib/hecks/adapters/driven/postgres.adapter")
   POSTGRES_ERA_ADAPTER = File.join(ROOT, "lib/hecks/adapters/driven/postgres_era.adapter")


### PR DESCRIPTION
## What

A real driven adapter, following `writing-an-adapter.md`'s own two-file pattern (`local_storage.adapter` + `local_storage.rb`) — not app-level plumbing bolted on outside the language.

`persisted_by "LocalStorage"` declares real intent: this domain expects durable, single-device, browser-side storage the moment it's actually running where it's meant to run. Ruby has no way to reach a real browser's `window.localStorage` at all — no network API, nothing — so the Ruby-side implementation is honestly a stand-in, mechanically identical to `Memory`. What earns it a name of its own is the declaration, the same distinction `Heki` (real local durability) already draws against `Memory` (deliberately ephemeral, test/example-only) one adapter over.

The real browser half already exists: `rust/web`'s `dispatch(json)` (decision 0015) takes an optional `"seed"` (the same `"instances"` shape it answers with) alongside `"steps"` — a host rehydrates from a prior snapshot and replays only new commands, instead of the whole history every call. A page bound to `LocalStorage` is expected to hold that snapshot in `window.localStorage` itself (read on load, write after every `dispatch`) — the seed/instances round trip *is* the adapter, once you're in the one runtime that can actually reach the storage this name promises.

## Decisions made explicitly (per the guide's own checklist)

- **`query`**: not compiled — falls back to `Ports::Query::InMemory`, the same trade Heki and Memory both take. Correct on day one for a personal-scale local store.
- **`lineage_capable?`**: not implemented — no era story. A bound domain's shape has no edge to travel across if it changes; that needs a hand migration, the same trade Heki states plainly.
- **`tenant_capable?`**: `true`, trivially — a browser tab is exactly one origin, exactly one user.

## Verification

- `spec/adapters/driven/local_storage_spec.rb` — boots and dispatches Pizzas for real, a declared query answers correctly through the InMemory fallback, `reset!` round-trips, tenant/lineage capability answers correct. 7/7.
- Full suite: 2336 examples, 0 failures. `bin/model_check` clean. `bin/doc_coverage` clean. `bin/check_engine_agreement` clean. rubocop clean (661 files). Fuzzing green (88 examples). All via the local pre-push gate, not just claimed.

## Not done here

No changes to `rust/web`/`rust/host` — the seed/instances contract this adapter's real half relies on already existed (decision 0015); this PR only gives it a name in the Ruby DSL. Generating the actual browser JS glue for a specific domain (reading/writing `window.localStorage` against that contract) is application-level code, not this adapter's job.