### PR TITLE
docs: drop the "research language" framing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-hecks is a research language. That is not a disclaimer to skip past —
-it sets what a contribution should look like. The interesting bugs here
+hecks is a language whose declarations are meant to be checked, and
+that sets what a contribution should look like. The interesting bugs here
 are rarely "it crashed"; they are "the declaration says one thing and
 the runtime quietly did another." Read
 [Verification](docs/implemented/guides/verification.md) before you

--- a/README.md
+++ b/README.md
@@ -735,9 +735,9 @@ The example domains this README draws from:
 
 ## Contributing
 
-Issues, examples, and runtime/adapter work are all welcome — this is
-still research software, and the gaps in [Project
-status](#project-status) are real starting points, not a formality.
+Issues, examples, and runtime/adapter work are all welcome — the gaps
+in [Project status](#project-status) are real starting points, not a
+formality.
 Before sending a change: `bundle exec rspec`, `bin/model_check`, and
 `bin/fuzz` are what CI runs, and every `ruby`-fenced example in a guide
 or this README is expected to execute exactly as shown

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,6 @@
 # Security
 
-hecks is a research language, not a hardened production dependency —
-that's the honest framing, not a hedge, and it applies here too. It
-still runs real code against real state (the Postgres/Sqlite/Heki
+hecks runs real code against real state (the Postgres/Sqlite/Heki
 adapters, the Lambda dispatcher, the OAuth2/Google-ID-token
 authentication adapter, generated SAM/deploy artifacts) on behalf of
 whatever project embeds it, so a real vulnerability report is welcome
@@ -86,6 +84,6 @@ means more than a bad refusal message:
 
 ## Supported versions
 
-Pre-1.0 (currently 0.3.0 per `lib/hecks/version.rb`): no parallel
-maintenance branches. Fixes land on the latest release; there is no
-commitment yet to backport a security fix to an older tag.
+Currently 1.0.2 per `lib/hecks/version.rb`: no parallel maintenance
+branches. Fixes land on the latest release; there is no commitment yet
+to backport a security fix to an older tag.

--- a/docs/implemented/guides/getting-started.md
+++ b/docs/implemented/guides/getting-started.md
@@ -15,9 +15,9 @@ read can be checked.
 
 ## What you need
 
-This is a research language, published as the `hecks` gem (currently
-0.3.0), but the repository itself is still the primary way to work with
-it — clone it and the repository is the tool:
+hecks is published as the `hecks` gem (currently 1.0.2), but the
+repository itself is still the primary way to work with it — clone it
+and the repository is the tool:
 
 ```sh
 git clone https://github.com/heckslabs/hecks


### PR DESCRIPTION
hecks is at 1.0.2; CONTRIBUTING, SECURITY, README and the getting-started guide still introduced it as "a research language, not a hardened production dependency" / "research software". This removes that framing and fixes the two stale "currently 0.3.0" version references (getting-started guide, SECURITY.md supported-versions section) alongside it.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164GhP9GRMbu1vDSTCgj2oC